### PR TITLE
use Net(bindIp="localhost", ...) to avoid windows firewall popup

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/MongoCRUD.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/MongoCRUD.java
@@ -53,7 +53,7 @@ public class MongoCRUD {
   public static final String        JSON_PROP_ENTITY        = "entity";
   public static final String        JSON_PROP_SORT          = "sort";
   public static final String        JSON_PROP_CLASS         = "clazz";
-  public static final MongodStarter MONGODB                 = getMongodStarter();
+  public static final MongodStarter MONGODB                 = MongodStarter.getDefaultInstance();
   public static final String        DEFAULT_SCHEMA          = "folio_shared";
   private static MongodProcess      mongoProcess;
   private static ObjectMapper       mapper                  = new ObjectMapper();
@@ -123,29 +123,6 @@ public class MongoCRUD {
       }
     }
     return connectionPool.get(tenantId);
-  }
-
-  /**
-   * Return a MongodStarter with UserTempNaming() to avoid windows firewall dialog popups.
-   *
-   * Code taken from
-   * https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/blob/d67667f/README.md#usage---custom-mongod-filename
-   *
-   * @return the MongodStarter
-   */
-  private static final MongodStarter getMongodStarter() {
-    Command command = Command.MongoD;
-
-    IRuntimeConfig runtimeConfig = new RuntimeConfigBuilder()
-      .defaults(command)
-      .artifactStore(new ExtractedArtifactStoreBuilder()
-        .defaults(command)
-        .download(new DownloadConfigBuilder()
-          .defaultsForCommand(command).build())
-        .executableNaming(new UserTempNaming()))
-      .build();
-
-    return MongodStarter.getInstance(runtimeConfig);
   }
 
   private MongoClient init(Vertx vertx, String tenantId) throws Exception {
@@ -894,7 +871,9 @@ public class MongoCRUD {
   public void startEmbeddedMongo() throws Exception {
 
     if(mongoProcess == null || !mongoProcess.isProcessRunning()){
-      IMongodConfig mongodConfig = new MongodConfigBuilder().version(Version.Main.PRODUCTION).net(new Net(mongoPort, Network.localhostIsIPv6()))
+      IMongodConfig mongodConfig = new MongodConfigBuilder()
+          .version(Version.Main.PRODUCTION)
+          .net(new Net("localhost", mongoPort, Network.localhostIsIPv6()))
           .build();
       mongoProcess = MONGODB.prepare(mongodConfig).start();
     }

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -77,6 +77,7 @@ public class DemoRamlRestTest {
    */
   @After
   public void tearDown(TestContext context) {
+    MongoCRUD.stopEmbeddedMongo();
     deleteTempFilesCreated();
     vertx.close(context.asyncAssertSuccess());
   }


### PR DESCRIPTION
The current code binds the embedded mongo to all IP addresses. This triggers windows firewall popups.
To have the popup only one time UserTempNaming() has been used.

The better solution is to restrict bindIp to localhost.