### PR TITLE
use codestyles.xml of current branch, not from master

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -256,7 +256,7 @@
           <failsOnError>false</failsOnError>
           <failOnViolation>false</failOnViolation>
           <logViolationsToConsole>true</logViolationsToConsole>
-          <configLocation>https://raw.githubusercontent.com/folio-org/raml-module-builder/master/codestyles.xml</configLocation>
+          <configLocation>../codestyles.xml</configLocation>
           <cacheFile>${basedir}/target/cachefile</cacheFile>
         </configuration>
       </plugin>


### PR DESCRIPTION
This has the additional benefit that `mvn install` works without internet connection (if branch dmod-75 also gets applied).