### PR TITLE
fix .properties files

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -266,6 +266,52 @@
         <version>3.0.1</version>
         <executions>
           <execution>
+            <!-- Turn off default resource copying -->
+            <id>default-resources</id>
+            <phase />
+          </execution>
+          <execution>
+            <!-- Copy .properties files using ISO-8859-1 encoding. -->
+            <id>filter-properties-files</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <encoding>ISO-8859-1</encoding>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                  <includes>
+                    <include>**/*.properties</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Copy files that are not .property files. -->
+            <id>copy-other-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>false</filtering>
+                  <excludes>
+                    <exclude>**/*.properties</exclude>
+                  </excludes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
             <id>copy-resources</id>
             <phase>prepare-package</phase>
             <goals>

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/messages/Messages.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/messages/Messages.java
@@ -94,18 +94,25 @@ public class Messages {
     }
   }
 
-  // assume api messages are in English for now!!!
   private void loadMessages(Path messagePath) throws IOException {
 
     Stream<Path> walk = Files.walk(messagePath, 1);
     for (Iterator<Path> it = walk.iterator(); it.hasNext();) {
       Path file = it.next();
       String name = file.getFileName().toString();
+      // APIMessages_de.properties or
+      // de_APIMessages.prop
       int sep = name.indexOf('_');
       if (sep == -1) {
         continue;
       }
-      String lang = name.substring(0, sep);
+      int dot = name.indexOf('.', sep);
+      if (dot == -1) {
+        continue;
+      }
+      String chunk1 = name.substring(0, sep);
+      String chunk2 = name.substring(sep + 1, dot);
+      String lang = chunk1.length() < chunk2.length() ? chunk1 : chunk2;
       String resource = "/" + messagePath.getFileName().toString() + "/" + name;
       log.info("Loading messages from " + resource + " ................................");
       InputStream stream = getClass().getResourceAsStream(resource);

--- a/domain-models-runtime/src/main/resources/infra-messages/APIMessages_de.properties
+++ b/domain-models-runtime/src/main/resources/infra-messages/APIMessages_de.properties
@@ -1,0 +1,17 @@
+#General
+10000=Beim Verticle-Deployen hat die Initialisierung fehlgeschlagen, deshalb Abbruch ....... {0}
+10001=Interner Serverfehler, bitte kontaktieren Sie einen Systemadministrator oder probieren Sie es nochmals.
+10002=Operation wird nicht unterstützt
+10003=Die Anfrage kann nicht bearbeitet werden
+10004=Ungültige Parameter:
+10005=Die API-Ressource unterstützt diese HTTP-Methode nicht
+10006=Content-type Header muss {0} sein, aber er ist "{1}"
+10007=Accept-Header muss {0} für diese Anfrage sein, aber er ist "{1}", und kann nicht mit */* antworten
+10008=Objekt existiert nicht
+10009=Der Import schlug fehl, Grund: {0}
+10010=Anfrage mit ungültigem URL-Pfad {0}
+10011=Hochloaden der Datei schlug fehl: {0}
+10012=Keine Datensätze entsprechen der Anfrage, keine Datensätze geändert
+10013=Zeit für: {0} brauchte {1}
+10014=Anzahl der gelöschten Exemplare ist inkorrekt. {0} gelöschte Datensätze erwartet, aber es waren {1}.
+10015=Beim Dateihochladen muss file_name angegeben werden.

--- a/domain-models-runtime/src/main/resources/infra-messages/APIMessages_en.properties
+++ b/domain-models-runtime/src/main/resources/infra-messages/APIMessages_en.properties
@@ -1,6 +1,3 @@
-#error_code , error_message
-#should be in a DB not in file - maybe initial copy in file
-
 #General
 10000=During verticle deployment, init failed, exiting....... {0}
 10001=Internal Server Error, Please contact System Administrator or try again

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/MessagesTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/MessagesTest.java
@@ -1,15 +1,26 @@
 package org.folio.rest.tools;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 import org.folio.rest.tools.messages.*;
 import org.junit.Test;
 
 public class MessagesTest {
+  private static String __(String language, MessageEnum consts, Object... messageArguments) {
+    return Messages.getInstance().getMessage(language, consts, messageArguments);
+  }
+
   @Test
   public void getMessage() {
-    Messages m = Messages.getInstance();
-    assertEquals("Content-type header must be a but it is \"b\"", m.getMessage("en", "10006", "a", "b"));
-    assertEquals("Content-type header must be a but it is \"b\"", m.getMessage("__", "10006", "a", "b"));
-    assertEquals("Content-type header must be a but it is \"b\"", m.getMessage(null, "10006", "a", "b"));
+    MessageConsts c = MessageConsts.ContentTypeError;
+    assertEquals("Content-type header must be a but it is \"b\"",      __("en", c, "a", "b"));
+    assertEquals("Content-type header must be a but it is \"b\"",      __("__", c, "a", "b"));
+    assertEquals("Content-type header must be a but it is \"b\"",      __(null, c, "a", "b"));
+    assertEquals("Content-type Header muss a sein, aber er ist \"b\"", __("de", c, "a", "b"));
+  }
+
+  @Test
+  public void umlaut() {
+    assertEquals("Operation wird nicht unterstützt", __("de", MessageConsts.OperationNotSupported));
   }
 }


### PR DESCRIPTION
maven: copy .properties using ISO-8859-1
use standard file name schema (APIMessages_en.properties) to help translation toolchain and trigger IDEs to encode them correctly
accept old file name schema during transition time
add German translation