### PR TITLE
Add a flag to the 'get' method to determine whether or not to overrid…

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -158,8 +158,10 @@ public class PostgresClient {
       }
     }
     else{
+      log.info("Using database: " + tenantId);
       postgreSQLClientConfig.put("database", tenantId);
     }
+    log.info("Creating client with configuration:" + postgreSQLClientConfig.encode());
     client = io.vertx.ext.asyncsql.PostgreSQLClient.createNonShared(vertx, postgreSQLClientConfig);
   }
 
@@ -606,6 +608,20 @@ public class PostgresClient {
    * @throws Exception
    */
   public void get(String table, Class<?> clazz, Criterion filter, boolean returnCount, Handler<AsyncResult<Object[]>> replyHandler)
+    throws Exception {
+    get(table, clazz, filter, returnCount, true, replyHandler);
+  }
+  /**
+   * select query
+   * @param table - table to query
+   * @param clazz - class of objects to be returned
+   * @param filter - see Criterion class
+   * @param returnCount - whether to return the amount of records matching the query
+   * @param setId - whether to automatically set the "id" field of the returned object
+   * @param replyHandler
+   * @throws Exception
+   */
+  public void get(String table, Class<?> clazz, Criterion filter, boolean returnCount, boolean setId, Handler<AsyncResult<Object[]>> replyHandler)
       throws Exception {
     client.getConnection(res -> {
       if (res.succeeded()) {
@@ -628,7 +644,7 @@ public class PostgresClient {
             if (query.failed()) {
               replyHandler.handle(io.vertx.core.Future.failedFuture(query.cause().getMessage()));
             } else {
-              replyHandler.handle(io.vertx.core.Future.succeededFuture(processResult(query.result(), clazz, returnCount)));
+              replyHandler.handle(io.vertx.core.Future.succeededFuture(processResult(query.result(), clazz, returnCount, setId)));
             }
           });
         } catch (Exception e) {
@@ -646,6 +662,10 @@ public class PostgresClient {
   }
 
   private Object[] processResult(io.vertx.ext.sql.ResultSet rs, Class<?> clazz, boolean count) {
+    return processResult(rs, clazz, count, true);
+  }
+  
+  private Object[] processResult(io.vertx.ext.sql.ResultSet rs, Class<?> clazz, boolean count, boolean setId) {
     Object[] ret = new Object[2];
     List<Object> list = new ArrayList<>();
     List<JsonObject> tempList = rs.getRows();
@@ -658,7 +678,9 @@ public class PostgresClient {
         Object jo = tempList.get(i).getValue(DEFAULT_JSONB_FIELD_NAME);
         Object id = tempList.get(i).getValue(ID_FIELD);
         Object o = mapper.readValue(jo.toString(), clazz);
-        o.getClass().getMethod("setId", new Class[] { String.class }).invoke(o, new String[] { id.toString() });
+        if(setId) {
+          o.getClass().getMethod("setId", new Class[] { String.class }).invoke(o, new String[] { id.toString() });
+        }
         list.add(o);
       } catch (Exception e) {
         log.error(e);


### PR DESCRIPTION
…e the 'id' value

This is a crack at solving the issue with the objects returned from the get method always blowing away any existing 'id' values.