### PR TITLE
completely update pom versions to 2.2.2-SNAPSHOT

### DIFF
--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -58,12 +58,12 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-aspects</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-interface-extensions</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.raml</groupId>

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-aspects</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -78,12 +78,12 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-interfaces</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-api-aspects</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>rules</artifactId>
-      <version>2.2.1-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.2.2-SNAPSHOT</version>
     <!-- <relativePath>../domain-models-poc</relativePath> -->
   </parent>
   <artifactId>rules</artifactId>


### PR DESCRIPTION
Build fails with `[FATAL] Non-resolvable parent POM for org.folio:rules:[unknown-version]: Could not find artifact org.folio:raml-module-builder:pom:2.2.1-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 3, column 11` after .m2 directory is removed.

