### PR TITLE
Exclude classes from jaxb-xjc already in com.sun.codemodel:codemodel

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -401,7 +401,16 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
-              <artifactSet />
+              <artifactSet/>
+              <filters>
+                <filter>
+                  <!-- exclude classes from jaxb-xjc that already exist in com.sun.codemodel:codemodel -->
+                  <artifact>com.sun.xml.bind:jaxb-xjc</artifact>
+                  <excludes>
+                    <exclude>com/sun/codemodel/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>
           </execution>


### PR DESCRIPTION
With this commit we no longer have warnings from the shade plugin about overlapping classes. See DMOD-28