### PR TITLE
DMOD-161: OutStream unit tests, fix UTF_8

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OutStream.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OutStream.java
@@ -1,29 +1,37 @@
 package org.folio.rest.tools.utils;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
-import javax.ws.rs.WebApplicationException;
-
+/**
+ * Holds and writes an Object whose {@link Object#toString()} is used when invoking {@link #write(OutputStream)}.
+ *
+ * {@link #write(OutputStream)} throws a {@link NullPointerException} if no object has been set or has been set to null.
+ */
 public class OutStream implements javax.ws.rs.core.StreamingOutput {
 
   private Object data;
 
   @Override
-  public void write(OutputStream output) throws IOException, WebApplicationException {
-
-    Writer writer = new BufferedWriter(new OutputStreamWriter(output));
-    writer.write(this.data.toString());
-    writer.flush();
+  public void write(OutputStream output) throws IOException {
+    // use UTF_8, do not use Charset.getDefaultCharset()
+    output.write(data.toString().getBytes(StandardCharsets.UTF_8));
+    output.flush();
   }
 
+  /**
+   * Return the object set by the last invocation of {@link #setData(Object)}.
+   * @return
+   */
   public Object getData() {
     return data;
   }
 
+  /**
+   * Set the object whose toString() will be used by {@link #write(OutputStream)}.
+   * @param data  object to write.
+   */
   public void setData(Object data) {
     this.data = data;
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OutStreamTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OutStreamTest.java
@@ -1,0 +1,105 @@
+package org.folio.rest.tools.utils;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.After;
+import org.junit.Test;
+
+public class OutStreamTest {
+  private Charset oldDefaultCharset;
+
+  private void setDefaultCharset(Charset charset) {
+    if (oldDefaultCharset == null) {
+      oldDefaultCharset = Charset.defaultCharset();
+    }
+    try {
+      // default charset is cached by Charset, use reflection to change it
+      Class<Charset> clazz = Charset.class;
+      Field field = clazz.getDeclaredField("defaultCharset");
+      field.setAccessible(true);
+      field.set(null, charset);
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @After
+  public void tearDown() {
+    if (oldDefaultCharset == null) {
+      return;
+    }
+    // defaultCharset has been changed, restore it
+    setDefaultCharset(oldDefaultCharset);
+  }
+
+  @Test
+  public void getWithoutSet() {
+    assertNull(new OutStream().getData());
+  }
+
+  @Test
+  public void setGet() {
+    OutStream s = new OutStream();
+    s.setData("ab");
+    assertEquals("ab", s.getData());
+  }
+
+  @Test
+  public void setGet2() {
+    OutStream s = new OutStream();
+    s.setData("ab");
+    s.setData("cd");
+    assertEquals("cd", s.getData());
+  }
+
+  @Test
+  public void setGetNull() {
+    OutStream s = new OutStream();
+    s.setData("ab");
+    s.setData(null);
+    assertNull(s.getData());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void writeNull() throws IOException {
+    new OutStream().write(new ByteArrayOutputStream());
+  }
+
+  private void testBytes() {
+    try {
+      OutStream s = new OutStream();
+      s.setData("ä");
+      ByteArrayOutputStream result = new ByteArrayOutputStream();
+      s.write(result);
+      assertArrayEquals("ä".getBytes(StandardCharsets.UTF_8), result.toByteArray());
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void utf8() {
+    setDefaultCharset(StandardCharsets.UTF_8);
+    testBytes();
+  }
+
+  @Test
+  public void usAscii() {
+    setDefaultCharset(StandardCharsets.US_ASCII);
+    testBytes();
+  }
+
+  @Test
+  public void iso_8859_1() throws IOException {
+    setDefaultCharset(StandardCharsets.ISO_8859_1);
+    testBytes();
+  }
+}


### PR DESCRIPTION
* add unit tests
* add javadoc
* fix UTF_8 bug with default charset
* remove BufferedWriter/OutputStreamWriter, no buffering needed for a single write