### PR TITLE
DMOD-165 fix db. DB_ environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,14 +166,14 @@ To run the configuration module, navigate to the `/target/` directory in the con
 
 RMB implementing modules expect a set of environment variables to be passed in at module startup. The environment variables expected by RMB modules are:
 
- - db.host 
- - db.port
- - db.username 
- - db.password 
- - db.database 
- - db.queryTimeout
- - db.charset 
- - db.maxPoolSize
+ - DB_HOST
+ - DB_PORT
+ - DB_USERNAME
+ - DB_PASSWORD
+ - DB_DATABASE
+ - DB_QUERYTIMEOUT
+ - DB_CHARSET
+ - DB_MAXPOOLSIZE
 
 See https://github.com/folio-org/okapi/blob/master/doc/guide.md#environment-variables for more information on how to deploy environment variables to RMB modules via Okapi.
 

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -34,6 +34,12 @@
       <artifactId>xpp3</artifactId>
       <version>1.1.4c</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/MDGenerator.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/MDGenerator.java
@@ -86,9 +86,9 @@ public enum MDGenerator {
     envs.add(new JsonObject().put("name", Envs.DB_DATABASE));
     envs.add(new JsonObject().put("name", Envs.DB_PASSWORD));
     envs.add(new JsonObject().put("name", Envs.DB_CHARSET));
-    envs.add(new JsonObject().put("name", Envs.DB_USER));
-    envs.add(new JsonObject().put("name", Envs.DB_TIMEOUT));
-    envs.add(new JsonObject().put("name", Envs.DB_MAXPOOL));
+    envs.add(new JsonObject().put("name", Envs.DB_USERNAME));
+    envs.add(new JsonObject().put("name", Envs.DB_QUERYTIMEOUT));
+    envs.add(new JsonObject().put("name", Envs.DB_MAXPOOLSIZE));
     md.put("env", envs);
   }
 

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -2,51 +2,55 @@ package org.folio.rest.tools.utils;
 
 import io.vertx.core.json.JsonObject;
 
-import java.util.Iterator;
 import java.util.Map;
 
-
 public enum Envs {
+  DB_HOST,
+  DB_PORT,
+  DB_USERNAME,
+  DB_PASSWORD,
+  DB_DATABASE,
+  DB_QUERYTIMEOUT,
+  DB_CHARSET,
+  DB_MAXPOOLSIZE;
 
-  INSTANCE;
+  private static final String PORT = "port";
+  private static final String TIMEOUT = "queryTimeout";
+  private static final String MAXPOOL = "maxPoolSize";
 
-  public static final String DB_HOST = "db.host";
-  public static final String DB_PORT = "db.port";
-  public static final String DB_USER = "db.username";
-  public static final String DB_PASSWORD = "db.password";
-  public static final String DB_DATABASE = "db.database";
-  public static final String DB_TIMEOUT = "db.queryTimeout";
-  public static final String DB_CHARSET = "db.charset";
-  public static final String DB_MAXPOOL = "db.maxPoolSize";
-
-  private static Map<String, String> envs = null;
+  static Map<String, String> env = null;
 
   static {
-    envs = System.getenv();
+    env = System.getenv();
   }
 
-  public static String getEnv(String key){
-    return envs.get(key);
+  public static String getEnv(Envs key){
+    return env.get(key.name());
   }
 
-  public static JsonObject allDBConfs(){
+  private static String toCamelCase(String key) {
+    // two strings need camelCasing
+    if (key.equalsIgnoreCase(TIMEOUT)) {
+      return TIMEOUT;
+    } else if (key.equalsIgnoreCase(MAXPOOL)) {
+      return MAXPOOL;
+    }
+    return key;
+  }
+
+  public static JsonObject allDBConfs() {
     JsonObject obj = new JsonObject();
-    Iterator<Map.Entry<String, String>> iter = envs.entrySet().iterator();
-    while (iter.hasNext()) {
-      Map.Entry<String, String> entry = iter.next();
-      String key = entry.getKey();
-      if(key.startsWith("db.")){
-        String value = entry.getValue();
-        if(value != null){
-          if(key.equals(DB_PORT) || key.equals(DB_TIMEOUT) || key.equals(DB_MAXPOOL)){
-            obj.put(key.substring(3), Integer.valueOf(value).intValue());
-          }
-          else {
-            obj.put(key.substring(3), value);
-          }
+    env.forEach((key, value) -> {
+      // also accept deprecated keys like "db.host" for "DB_HOST".
+      if (key.startsWith("db.") || key.startsWith("DB_")) {
+        key = toCamelCase(key.substring(3).toLowerCase());
+        if (key.equals(PORT) || key.equals(TIMEOUT) || key.equals(MAXPOOL)) {
+          obj.put(key, Integer.parseInt(value));
+        } else {
+          obj.put(key, value);
         }
       }
-    }
+    });
     return obj;
   }
 


### PR DESCRIPTION
Bash doesn't allow environment variables like db.host that contain a dot. Therefore replacing dot by underscore. Converting to the usual uppercase.

allDBConfs() also returns the values from deprecated variables with dot.