### PR TITLE
FOLIO-351 NewlineAtEndOfFile=lf

### DIFF
--- a/codestyles.xml
+++ b/codestyles.xml
@@ -5,7 +5,9 @@
 
 <module name="Checker">
   <property name="fileExtensions" value="java, xml, json, properties" />
-  <module name="NewlineAtEndOfFile"/>
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>


### PR DESCRIPTION
Change Checkstyle's NewlineAtEndOfFile from system to lf to match .editorconfig's end_of_line = lf