### PR TITLE
DMOD-161 extract VertxUtils.getVertxFromContextOrNew()

### DIFF
--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/ClientGenerator.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/ClientGenerator.java
@@ -170,15 +170,8 @@ public class ClientGenerator {
       conBody.invoke(options, "setConnectTimeout").arg(connTO);
       conBody.invoke(options, "setIdleTimeout").arg(idleTO);
 
-      JExpression x2 = jCodeModel.ref(io.vertx.core.Vertx.class).staticInvoke("currentContext");
-      JVar context = conBody.decl(jCodeModel._ref(io.vertx.core.Context.class), "context", x2);
-      JVar vertxVar = conBody.decl(jCodeModel._ref(io.vertx.core.Vertx.class), "vertx");
-
-      JConditional _if = conBody._if(context.eq(JExpr._null()));
-      _if._then().assign(vertxVar, jCodeModel.ref(io.vertx.core.Vertx.class).staticInvoke("vertx"));
-      _if._else().assign(vertxVar, context.invoke("owner"));
-
-      conBody.assign(httpClient, vertxVar.invoke("createHttpClient").arg(options));
+      JExpression vertx = jCodeModel.ref("org.folio.rest.tools.utils.VertxUtils").staticInvoke("getVertxFromContextOrNew");
+      conBody.assign(httpClient, vertx.invoke("createHttpClient").arg(options));
 
       /* constructor, init the httpClient */
       JMethod consructor2 = constructor(JMod.PUBLIC);

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient.java
@@ -8,13 +8,13 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.IOUtils;
 import org.folio.rest.tools.parser.JsonPathParser;
+import org.folio.rest.tools.utils.VertxUtils;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.CacheStats;
 import com.google.common.cache.LoadingCache;
 
-import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
@@ -60,13 +60,8 @@ public class HttpModuleClient {
     this.idleTO = idleTO;
     options = new HttpClientOptions().setLogActivity(true).setKeepAlive(keepAlive)
         .setDefaultHost(host).setDefaultPort(port).setConnectTimeout(connTO).setIdleTimeout(idleTO);
-    Context context = Vertx.currentContext();
     this.autoCloseConnections = autoCloseConnections;
-    if (context == null) {
-        vertx = Vertx.vertx();
-    } else {
-        vertx = context.owner();
-    }
+    vertx = VertxUtils.getVertxFromContextOrNew();
     setDefaultHeaders();
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/VertxUtils.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/VertxUtils.java
@@ -1,0 +1,25 @@
+package org.folio.rest.tools.utils;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+
+public class VertxUtils {
+    private VertxUtils() {
+      throw new UnsupportedOperationException("Cannot instantiate utility class.");
+    }
+
+    /**
+     * Return the Vertx of the current context; if there isn't a current context
+     * create and return a new Vertx with default options.
+     * @return the Vertx
+     */
+    public static Vertx getVertxFromContextOrNew() {
+      Context context = Vertx.currentContext();
+
+      if (context == null) {
+          return Vertx.vertx();
+      }
+
+      return context.owner();
+    }
+}


### PR DESCRIPTION
* Extract duplicated code into function getVertxFromContextOrNew().
* Reduce number of lines of constructor generated by ClientGenerator from 21 below 20 to comply with coding guidelines.