### PR TITLE
Use locale C for embedded postgres

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1870,7 +1870,7 @@ public class PostgresClient {
       String password = postgreSQLClientConfig.getString(PASSWORD);
       String database = postgreSQLClientConfig.getString(DATABASE);
 
-      String locale = "en_US.UTF-8";
+      String locale = "C";
       String OS = System.getProperty("os.name").toLowerCase();
       if(OS.indexOf("win") >= 0){
         locale = "american_usa";

--- a/postgres-runner/src/main/java/org/folio/rest/persist/PostgresRunner.java
+++ b/postgres-runner/src/main/java/org/folio/rest/persist/PostgresRunner.java
@@ -231,7 +231,7 @@ public class PostgresRunner extends AbstractVerticle {
           new PostgresConfig.Timeout(),
           new PostgresConfig.Credentials(username, password));
 
-      String locale = "en_US.UTF-8";
+      String locale = "C";
       if (System.getProperty("os.name").toLowerCase().contains("win")) {
         locale = "american_usa";
       }


### PR DESCRIPTION
Use locale C on Unix. It should be a dummy sort, byte-wise, and thus give same results everywhere.