### PR TITLE
FOLIO-601 fix raml 1

### DIFF
--- a/domain-models-api-interfaces/raml/book.schema
+++ b/domain-models-api-interfaces/raml/book.schema
@@ -55,7 +55,7 @@
       "type":"integer"
     },        
     "metaData": {
-      "$ref": "metadata.schema"
+      "$ref": "raml-util/schemas/metadata.schema"
     }
   },
   "additionalProperties": false,

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -50,7 +50,7 @@ schemas:
                    "datetime": 1341533193,
                    "genre": "science",
                    "author": "Mary Roach",
-                   "link": "http://e-bookmobile.com/books/Stiff",
+                   "link": "http://e-bookmobile.com/books/Stiff"
                  },
                  "success": true,
                  "status": 200

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -47,7 +47,9 @@ schemas:
                    "id": "SbBGk",
                    "title": "Stiff: The Curious Lives of Human Cadavers",
                    "description": null,
-                   "datetime": 1341533193,
+                   "datetime": {
+                     "date": "2117-08-03"
+                   },
                    "genre": "science",
                    "author": "Mary Roach",
                    "link": "http://e-bookmobile.com/books/Stiff"

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -71,19 +71,19 @@ schemas:
           schema: book
       responses:
         201:
-         body:
-           application/json:
-            example: !include examples/bulk.sample
-         headers:
-           Location:
+          body:
+            application/json:
+              example: !include examples/bulk.sample
+          headers:
+            Location:
   /test:
     post:
       body:
         application/json:
       responses:
         200:
-         body:
-           application/json:
+          body:
+            application/json:
         302:
           headers:
             Location:

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -55,7 +55,11 @@ schemas:
                    "link": "http://e-bookmobile.com/books/Stiff"
                  },
                  "success": true,
-                 "status": 200
+                 "status": 200,
+                 "metaData": {
+                   "createdDate": "2017-04-01T23:11:00.000Z",
+                   "createdByUserId": "dee12548-9cee-45fa-bbae-675c1cc0ce3b"
+                 }
                }
 
     put:

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -67,7 +67,6 @@ schemas:
       body:
         application/json:
           schema: book
-          example: ""
       responses:
         201:
          body:

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -6,7 +6,7 @@ version: v1
 
 schemas:
   - book: !include book.schema
-  - metadata.schema: !include raml-util/schemas/metadata.schema
+  - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
  
 /rmbtests:
   /books:

--- a/domain-models-api-interfaces/raml/sample.raml
+++ b/domain-models-api-interfaces/raml/sample.raml
@@ -73,7 +73,7 @@ schemas:
         201:
          body:
            application/json:
-            example: examples/bulk.sample
+            example: !include examples/bulk.sample
          headers:
            Location:
   /test:


### PR DESCRIPTION
In sample.raml

Fix some old errors that cluttered the raml-cop output.

Fixed the schema $ref to metadata.schema
This is an example of RMB-30.
Because we have the raml-util local, it is easy to link to with a relative reference with no dot-dots.
