### PR TITLE
RMB-114: Security update postgres-embedded:2.6

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -96,7 +96,7 @@
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>
       <artifactId>postgresql-embedded</artifactId>
-      <version>2.5</version>
+      <version>${postgresql-embedded-version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -2053,8 +2053,10 @@ public class PostgresClient {
         locale = "american_usa";
       }
 
-      final PostgresConfig config = new PostgresConfig(Version.V9_6_5, new AbstractPostgresConfig.Net(DEFAULT_IP, port),
-        new AbstractPostgresConfig.Storage(database), new AbstractPostgresConfig.Timeout(20000),
+      final PostgresConfig config = new PostgresConfig(Version.Main.PRODUCTION,
+        new AbstractPostgresConfig.Net(DEFAULT_IP, port),
+        new AbstractPostgresConfig.Storage(database),
+        new AbstractPostgresConfig.Timeout(20000),
         new AbstractPostgresConfig.Credentials(username, password));
 
       config.getAdditionalInitDbParams().addAll(Arrays.asList(

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <generated_files_path>${basedir}/src/main/java</generated_files_path>
     <vertx-version>3.4.1</vertx-version>
     <jackson-version>2.2.2</jackson-version>
+    <postgresql-embedded-version>2.6</postgresql-embedded-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <generate_routing_context>/rmbtests/test</generate_routing_context>

--- a/postgres-runner/pom.xml
+++ b/postgres-runner/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>
       <artifactId>postgresql-embedded</artifactId>
-      <version>2.2</version>
+      <version>${postgresql-embedded-version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
Three security vulnerabilities have been fixed by PostgreSQL 10.1, 9.6.6, 9.5.10:

* CVE-2017-12172: Start scripts permit database administrator to modify root-owned files
* CVE-2017-15098: Memory disclosure in JSON functions
* CVE-2017-15099: INSERT ... ON CONFLICT DO UPDATE fails to enforce SELECT privileges

This PostgreSQL update also fixes a number of bugs reported in the last few months.

https://www.postgresql.org/about/news/1801/