### PR TITLE
AnnotationGrabber: Fix major bugs (Null, instanceof), add unit test.

### DIFF
--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -61,6 +61,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
         <groupId>com.github.javaparser</groupId>
         <artifactId>javaparser-core</artifactId>
         <version>3.3.0</version>

--- a/domain-models-interface-extensions/src/test/java/org/folio/rest/jaxrs/resource/TestResource.java
+++ b/domain-models-interface-extensions/src/test/java/org/folio/rest/jaxrs/resource/TestResource.java
@@ -1,0 +1,40 @@
+
+package org.folio.rest.jaxrs.resource;
+
+import java.math.BigDecimal;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import io.vertx.core.Context;
+import org.folio.rest.annotations.Validate;
+
+@Path("unittests")
+public interface TestResource {
+    @GET
+    @Path("books")
+    @Produces({
+        "application/json"
+    })
+    @Validate
+    void getRmbtestsBooks(
+        @QueryParam("author")
+        @NotNull
+        String author,
+        @QueryParam("publicationYear")
+        @NotNull
+        BigDecimal publicationYear,
+        @QueryParam("rating")
+        BigDecimal rating,
+        @QueryParam("isbn")
+        @Size(min = 10)
+        String isbn,
+        @QueryParam("facets")
+        List<String> facets, java.util.Map<String, String>okapiHeaders, io.vertx.core.Handler<io.vertx.core.AsyncResult<Response>>asyncResultHandler, Context vertxContext)
+        throws Exception
+    ;
+}

--- a/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/AnnotationGrabberTest.java
+++ b/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/AnnotationGrabberTest.java
@@ -1,0 +1,26 @@
+package org.folio.rest.tools;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import org.junit.jupiter.api.Test;
+
+public class AnnotationGrabberTest {
+  @Test
+  void generateMappings() throws Exception {
+    JsonObject mappings = AnnotationGrabber.generateMappings();
+    System.err.println(mappings.encodePrettily());
+    JsonObject unittests = mappings.getJsonObject("^/unittests");
+    assertThat(unittests.getString("class"), is("org.folio.rest.jaxrs.resource.TestResource"));
+    JsonArray books = unittests.getJsonArray("^/unittests/books/?$");
+    JsonObject book0 = books.getJsonObject(0);
+    assertThat(book0.getString("function"), is("getRmbtestsBooks"));
+    JsonObject params = book0.getJsonObject("params");
+    JsonObject param0 = params.getJsonObject("0");
+    assertThat(param0.getString("value"), is("author"));
+    assertThat(param0.getString("type"), is("java.lang.String"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
 
   <properties>
     <aspectj.version>1.8.9</aspectj.version>
+    <jackson-version>2.2.2</jackson-version>
+    <junit-jupiter-version>5.0.3</junit-jupiter-version>
+    <postgresql-embedded-version>2.6</postgresql-embedded-version>
+    <vertx-version>3.4.1</vertx-version>
+
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
     <ramlfiles_path>${project.parent.basedir}/domain-models-api-interfaces/ramls</ramlfiles_path>
@@ -36,9 +41,6 @@
     triggers a compile of that project which if it depends on the api jar will
     cause a compile problem -->
     <generated_files_path>${basedir}/src/main/java</generated_files_path>
-    <vertx-version>3.4.1</vertx-version>
-    <jackson-version>2.2.2</jackson-version>
-    <postgresql-embedded-version>2.6</postgresql-embedded-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <generate_routing_context>/rmbtests/test</generate_routing_context>
@@ -125,6 +127,16 @@
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
         <version>2.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit-jupiter-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>${junit-jupiter-version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
Fixes these major sonar bugs:
* 3 times: Use an "instanceof" or "Class.isAssignableFrom()" instead of .equals(type.getName()).
* A "NullPointerException" could be thrown; "prevObjForDefaultVal" is nullable here.