### PR TITLE
FOLIO-601 fix raml 2

### DIFF
--- a/domain-models-api-interfaces/ramls/admin.raml
+++ b/domain-models-api-interfaces/ramls/admin.raml
@@ -180,7 +180,6 @@ traits:
               etc...
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -202,7 +201,6 @@ traits:
               then returns with the info collected during those 10 seconds
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -218,7 +216,6 @@ traits:
             Returns info about how the tables are being accessed either sequential or index scans
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -234,7 +231,6 @@ traits:
             Returns info for every table in format - table | table size | index size
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -250,7 +246,6 @@ traits:
             Returns index usage info for every table
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -266,7 +261,6 @@ traits:
             cache hit rates
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -282,7 +276,6 @@ traits:
             List of slow queries
           body:
             application/json:
-              example: "Text....."
         500:
           description: "Internal server error"
           body:
@@ -315,7 +308,6 @@ traits:
             Returns a list of the tables / indexes in the shared_buffers
           body:
             application/json:
-              example: ""
         500:
           description: "Internal server error"
           body:
@@ -330,7 +322,6 @@ traits:
         200:
           body:
             application/json:
-              example: ""
         500:
           description: "Internal server error"
           body:

--- a/domain-models-api-interfaces/ramls/examples/bulk.sample
+++ b/domain-models-api-interfaces/ramls/examples/bulk.sample
@@ -1,5 +1,5 @@
 {
-  "bulk_id": "1",
+  "bulk_id": 1,
   "error_count": 8,
   "success_count": 9,
   "error_ids": "1,2,3,4,5,6,7,8",

--- a/domain-models-api-interfaces/ramls/examples/bulks.sample
+++ b/domain-models-api-interfaces/ramls/examples/bulks.sample
@@ -1,7 +1,7 @@
 {
   "bulks": [
     {
-      "bulk_id": "1",
+      "bulk_id": 1,
       "error_count": 8,
       "success_count": 9,
       "error_ids": "1,2,3,4,5,6,7,8",

--- a/domain-models-api-interfaces/ramls/examples/bulks.sample
+++ b/domain-models-api-interfaces/ramls/examples/bulks.sample
@@ -1,0 +1,13 @@
+{
+  "bulks": [
+    {
+      "bulk_id": "1",
+      "error_count": 8,
+      "success_count": 9,
+      "error_ids": "1,2,3,4,5,6,7,8",
+      "inst_id": "my_inst",
+      "job_id": "76543331"
+    }
+  ],
+  "total_records": 1
+}

--- a/domain-models-api-interfaces/ramls/examples/job.sample
+++ b/domain-models-api-interfaces/ramls/examples/job.sample
@@ -2,6 +2,8 @@
   "_id": "12345678",
   "job_conf_id": "987654321",
   "creator": "a",
+  "status": "ready",
+  "inst_id": "my_inst",
   "parameters" : [
     {"errors":"2"},
     {"succeeded":"2"}

--- a/domain-models-api-interfaces/ramls/examples/jobs.sample
+++ b/domain-models-api-interfaces/ramls/examples/jobs.sample
@@ -1,0 +1,16 @@
+{
+  "jobs": [
+    {
+      "_id": "12345678",
+      "job_conf_id": "987654321",
+      "creator": "a",
+      "status": "ready",
+      "inst_id": "my_inst",
+      "parameters" : [
+        {"errors":"2"},
+        {"succeeded":"2"}
+      ]
+    }
+  ],
+  "total_records": 1
+}

--- a/domain-models-api-interfaces/ramls/examples/jobs_conf.sample
+++ b/domain-models-api-interfaces/ramls/examples/jobs_conf.sample
@@ -6,6 +6,7 @@
   "type": "MANUAL",
   "category": "IMPORTS",
   "enabled": true,
+  "inst_id": "my_inst",
   "creator": "joe",
   "parameters": [
     {"key1": "value"},

--- a/domain-models-api-interfaces/ramls/examples/jobs_confs.sample
+++ b/domain-models-api-interfaces/ramls/examples/jobs_confs.sample
@@ -1,0 +1,20 @@
+{
+  "job_confs": [
+    {
+      "_id": "987654321",
+      "module": "IMPORT",
+      "name": "Generic file import job",
+      "description": "Import",
+      "type": "MANUAL",
+      "category": "IMPORTS",
+      "enabled": true,
+      "inst_id": "my_inst",
+      "creator": "joe",
+      "parameters": [
+        {"key1": "value"},
+        {"key1": "value"}
+      ]
+    }
+  ],
+  "total_records": 1
+}

--- a/domain-models-api-interfaces/ramls/jobs.raml
+++ b/domain-models-api-interfaces/ramls/jobs.raml
@@ -32,7 +32,7 @@ resourceTypes:
     description: Jobs services
     type:
       collection:
-        exampleCollection: !include examples/jobs_conf.sample
+        exampleCollection: !include examples/jobs_confs.sample
         exampleItem: !include examples/jobs_conf.sample
         schemaCollection: jobs_confs
         schemaItem: jobs_conf.schema
@@ -53,7 +53,7 @@ resourceTypes:
       /jobs:
         type:
           collection:
-            exampleCollection: !include examples/job.sample
+            exampleCollection: !include examples/jobs.sample
             exampleItem: !include examples/job.sample
             schemaCollection: jobs
             schemaItem: job.schema
@@ -71,7 +71,7 @@ resourceTypes:
           /bulks:
             type:
               collection:
-                exampleCollection: !include examples/bulk.sample
+                exampleCollection: !include examples/bulks.sample
                 exampleItem: !include examples/bulk.sample
                 schemaCollection: bulks
                 schemaItem: bulk.schema


### PR DESCRIPTION
Fix the configuration of examples.
No changes to schema.

Use exampleCollection examples.
Was using exampleItem, causing the raml-cop validation warnings.

After those messages were gone there was one actual error in the examples.

Note that for the jobs_confs.sample, the collection is named "jobs_confs" in the raml file, but "job_confs" in the schema.
Made this example match its schema.