### PR TITLE
RMB-143: Version update: vertx 3.5.1, jackson 2.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,8 @@
 
   <properties>
     <aspectj.version>1.8.9</aspectj.version>
-    <jackson-version>2.2.2</jackson-version>
     <junit-jupiter-version>5.0.3</junit-jupiter-version>
     <postgresql-embedded-version>2.6</postgresql-embedded-version>
-    <vertx-version>3.4.1</vertx-version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -70,53 +68,20 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-core</artifactId>
-        <version>${vertx-version}</version>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.5.1</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-hazelcast</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-unit</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-mail-client</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-dropwizard-metrics</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-mysql-postgresql-client</artifactId>
-        <version>${vertx-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson-version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson-version}</version>
-      </dependency>
-      <dependency>
+        <!-- vertx-stack-depchain sets the version for
+             com.fasterxml.jackson.core:jackson-core and
+             com.fasterxml.jackson.core:jackson-databind
+             https://github.com/vert-x3/vertx-dependencies/blob/master/pom.xml
+        -->
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>${jackson-version}</version>
+        <version>2.9.4</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>


### PR DESCRIPTION
Use vertx-stack-depchain.
mod-users and mod-inventory-storage build with this change.
mod-configuration build with this change if you update vertx-unit to 3.5.1.