### PR TITLE
Use vertx-mysql-postgresql-client-3.5.1-FOLIO.1 RMB-154

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -121,6 +121,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mysql-postgresql-client</artifactId>
+      <version>3.5.1-FOLIO.1</version>
     </dependency>
     <dependency>
       <groupId>xerces</groupId>


### PR DESCRIPTION
This is a patched version from Vert.x 3.5.1 that releases unused
connections after 1 minute (in any pool).