### PR TITLE
RMB-183

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1720,7 +1720,7 @@ public class PostgresClient {
               o = mapper.readValue(jo.toString(), clazz);
             } catch (UnrecognizedPropertyException e1) {
               // this is a facet query , and this is the count entry {"count": 11}
-              rowCount = new JsonObject(tempList.get(i).getString("jsonb")).getInteger(countField);
+              rowCount = new JsonObject(tempList.get(i).getString(DEFAULT_JSONB_FIELD_NAME)).getInteger(countField);
               continue;
             }
           }


### PR DESCRIPTION
change order of fields in the select clause so that the count function is last and the order passed in as the fields to select is maintained. this allows the api to recieve a "distinct(id), jsonb" fields paramter and work as the distinct needs to appear first which was not happening before as the count was always first