### PR TITLE
RMB-250: cql2pgjson 2.2.3: Fix fulltext search

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>org.z3950.zing</groupId>
       <artifactId>cql2pgjson</artifactId>
-      <version>2.2.1</version>
+      <version>2.2.3</version>
     </dependency>
     <dependency>
       <groupId>javax.validation</groupId>


### PR DESCRIPTION
Update to cql2pg-json 2.2.3 that contains these fixes:

* CQLPG-55: Trim trailing space and loose * that breaks fulltext search.
* CQLPG-54: Use the 'simple' dictionary for fulltext instead of 'english', to get around stopwords.