### PR TITLE
Remove old ramls README RMB-203

### DIFF
--- a/domain-models-api-interfaces/ramls/README.md
+++ b/domain-models-api-interfaces/ramls/README.md
@@ -1,1 +1,0 @@
-When any schema file refers to an additional schema file, then also use that pathname of the referenced second schema as the "key" name in the RAML "schemas" section, and wherever that schema is utilised in RAML files. Also ensure that all such referenced files are below the parent file.


### PR DESCRIPTION
This old README was trying to explain the $ref complications pre-RMBv20

——
Also triggering a test of the lint-raml CI:

The lint-raml CI job now logs errors for missing JSON schema description fields.
So will now display the messages via the GitHub PR screen.

It does not cause the Jenkins build stage to fail. It will just show the errors.

FOLIO-1447