### PR TITLE
RMB-262: Disable warning "Overriding managed version 3.5.1" in pom.xml

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mysql-postgresql-client</artifactId>
-      <version>3.5.1-FOLIO.1</version>
+      <version>3.5.1-FOLIO.1</version><!--$NO-MVN-MAN-VER$-->
     </dependency>
     <dependency>
       <groupId>xerces</groupId>


### PR DESCRIPTION
vertx-mysql-postgresql-client:3.5.1-FOLIO.1