### PR TITLE
RMB-280 configure local apidocs

### DIFF
--- a/domain-models-api-interfaces/ramls/admin.raml
+++ b/domain-models-api-interfaces/ramls/admin.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Admin API
-baseUri: http://localhost:8081/{version}
+baseUri: http://localhost:8081
 version: v1
 
 traits:

--- a/domain-models-api-interfaces/ramls/jobs.raml
+++ b/domain-models-api-interfaces/ramls/jobs.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: Admin API
-baseUri: http://localhost:8081/v1
+baseUri: http://localhost:8081
 version: v1
 
 types:

--- a/domain-models-api-interfaces/ramls/sample.raml
+++ b/domain-models-api-interfaces/ramls/sample.raml
@@ -1,7 +1,7 @@
 #%RAML 1.0
 
 title: e-BookMobile API
-baseUri: http://localhost:8081/{version}
+baseUri: http://localhost:8081
 version: v1
 
 types:

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -420,7 +420,7 @@
               </target>
             </configuration>
           </execution>
-          <!-- Replace the baseUri and the protocols in the RAMLs that have been copied to
+          <!-- Replace the baseUri in the RAMLs that have been copied to
           apidocs directory so that they can be used via the local html api console. -->
           <execution>
             <phase>prepare-package</phase>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -420,6 +420,21 @@
               </target>
             </configuration>
           </execution>
+          <!-- Replace the baseUri and the protocols in the RAMLs that have been copied to
+          apidocs directory so that they can be used via the local html api console. -->
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <replaceregexp match="baseUri:.+$" replace="baseUri: http://localhost:{http.port}" byline="true">
+                  <fileset dir="${basedir}/target/classes/apidocs/raml" includes="**/*.raml"/>
+                </replaceregexp>
+              </target>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
 


### PR DESCRIPTION
Enables http.port to be set for whatever port the local development server is using for this module.