### PR TITLE
Add support for application/vnd.api+json content type for POST requests

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -121,6 +121,7 @@ public class RestVerticle extends AbstractVerticle {
   private static final String       SUPPORTED_CONTENT_TYPE_FORMDATA = "multipart/form-data";
   private static final String       SUPPORTED_CONTENT_TYPE_STREAMIN = "application/octet-stream";
   private static final String       SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
+  private static final String       SUPPORTED_CONTENT_TYPE_JSON_API_DEF = "application/vnd.api+json";
   private static final String       SUPPORTED_CONTENT_TYPE_TEXT_DEF = "text/plain";
   private static final String       SUPPORTED_CONTENT_TYPE_XML_DEF  = "application/xml";
   private static final String       SUPPORTED_CONTENT_TYPE_FORM     = "application/x-www-form-urlencoded";
@@ -229,6 +230,7 @@ public class RestVerticle extends AbstractVerticle {
     // see uploadHandler further down
     router.put().handler(handler);
     router.post().consumes(SUPPORTED_CONTENT_TYPE_JSON_DEF).handler(handler);
+    router.post().consumes(SUPPORTED_CONTENT_TYPE_JSON_API_DEF).handler(handler);
     router.post().consumes(SUPPORTED_CONTENT_TYPE_TEXT_DEF).handler(handler);
     router.post().consumes(SUPPORTED_CONTENT_TYPE_XML_DEF).handler(handler);
     router.post().consumes(SUPPORTED_CONTENT_TYPE_FORM).handler(handler);


### PR DESCRIPTION
In mod-kb-ebsco-java, we use JSON API with content type application/vnd.api+json and while RMB PUT supports all content types, currently POST consumes only a subset of those content types and does not support 'application/vnd.api+json' due  to which we are getting the following error:
```org.folio.rest.RestVerticle
SEVERE: HV000116: The object to be validated must not be null.
java.lang.IllegalArgumentException: HV000116: The object to be validated must not be null.
	at org.hibernate.validator.internal.util.Contracts.assertNotNull(Contracts.java:41)
	at org.hibernate.validator.internal.engine.ValidatorImpl.validate(ValidatorImpl.java:190)
	at org.folio.rest.RestVerticle.isValidRequest(RestVerticle.java:1458)```
This PR hopefully should fix the above.