### PR TITLE
[RMB-320] Updating records containing metadata causes exceptions in database trigger

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -1551,24 +1551,22 @@ public class RestVerticle extends AbstractVerticle {
         JsonObject j = new JsonObject(json);
         userId = j.getString("user_id");
       }
-      if(userId != null){
-        Metadata md = new Metadata();
-        md.setUpdatedDate(new Date());
-        md.setCreatedDate(new Date());
-        md.setCreatedByUserId(userId);
-        md.setUpdatedByUserId(userId);
-        try{
+
+      Metadata md = new Metadata();
+      md.setUpdatedDate(new Date());
+      md.setCreatedDate(new Date());
+      md.setCreatedByUserId(userId);
+      md.setUpdatedByUserId(userId);
+      try {
           /* if a metadata section is passed in by client, we cannot assume it is correct.
            * entity.getClass().getMethod("getMetaData",
           new Class[] { }).invoke(entity);*/
-          entity.getClass().getMethod("setMetadata",
-            new Class[] { Metadata.class }).invoke(entity,  md);
-        }
-        catch(Exception e){
-          //do nothing - if this is thrown then the setMetaData() failed, assume pojo
-          // (aka) json schema - didnt include a reference to it.
-          log.debug(e.getMessage(), e);
-        }
+        entity.getClass().getMethod("setMetadata",
+          new Class[]{Metadata.class}).invoke(entity, md);
+      } catch (Exception e) {
+        //do nothing - if this is thrown then the setMetaData() failed, assume pojo
+        // (aka) json schema - didnt include a reference to it.
+        log.debug(e.getMessage(), e);
       }
     } catch (Exception e) {
       log.warn("Problem parsing " + OKAPI_HEADER_TOKEN + " header, for path " + path + " - " + e.getMessage());

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/metadata.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/metadata.ftl
@@ -5,7 +5,7 @@
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.${table.tableName}_set_md()
 RETURNS TRIGGER AS $$
 BEGIN
-  NEW.creation_date = to_timestamp(NEW.jsonb->'metadata'->>'createdDate', 'YYYY-MM-DD"T"HH24:MI:SS.MS');
+  NEW.creation_date = (NEW.jsonb->'metadata'->>'createdDate')::timestamp at time zone 'UTC';
   NEW.created_by = NEW.jsonb->'metadata'->>'createdByUserId';
   RETURN NEW;
 END;
@@ -34,7 +34,7 @@ BEGIN
 
   SET TIME ZONE 'UTC';
 
-  updatedDate = NEW.jsonb->'metadata'->>'updatedDate';
+  updatedDate = (NEW.jsonb->'metadata'->>'updatedDate')::timestamp at time zone 'UTC';
   updatedBy = NEW.jsonb->'metadata'->>'updatedByUserId';
 
   injectedMetadata = jsonb_build_object(

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
@@ -1,0 +1,183 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.UpdateResult;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.rest.tools.utils.VertxUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+
+@RunWith(VertxUnitRunner.class)
+public class MetadataTriggerIT {
+
+  private static final String TENANT_ID = "test_tenant";
+  private static final String TABLE = "test_md_trigger_table";
+
+  private static Vertx vertx;
+
+  @BeforeClass
+  public static void setUp(TestContext context) {
+    vertx = VertxUtils.getVertxWithExceptionHandler();
+    try {
+      PostgresClient.getInstance(vertx).startEmbeddedPostgres();
+    } catch (IOException e) {
+      context.fail(e);
+    }
+
+    Async async = context.async();
+    int port = NetworkUtils.nextFreePort();
+
+    DeploymentOptions options = new DeploymentOptions().setConfig(new JsonObject().put("http.port", port));
+    vertx.deployVerticle(RestVerticle.class, options, deploy -> {
+      TenantClient tenantClient = new TenantClient("http://localhost:" + port, TENANT_ID, "token");
+      try {
+        tenantClient.postTenant(null, post -> async.complete());
+      } catch (Exception e) {
+        context.fail(e);
+      }
+    });
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    PostgresClient.stopEmbeddedPostgres();
+  }
+
+  @Test
+  public void isSuccessWhenUpdateEmptyMetadataWithEmptyMetadata(TestContext context) {
+
+    String id = "e2a5133a-0e16-48ea-9226-01fc047625bb";
+
+    JsonObject cr = new JsonObject()
+      .put("id", id)
+      .put("value", 1);
+
+    JsonObject upd = new JsonObject()
+      .put("id", id)
+      .put("value", 2);
+
+    save(id, cr)
+      .compose(s -> update(id, upd))
+      .compose(ur -> ur.getUpdated() == 0 ? failedFuture("Update failed") : succeededFuture())
+      .setHandler(context.asyncAssertSuccess());
+
+  }
+
+  @Test
+  public void isSuccessWhenUpdateMetadataWithEmptyMetadata(TestContext context) {
+
+    String id = "b82eea1b-aaaa-4658-84c7-f872d713072e";
+    String userId = "a218fbec-eaed-4c47-8aa1-d8bdc24c50d1";
+
+    JsonObject crMd = new JsonObject()
+      .put("createdDate", "2019-01-01T00:00:00.000+0000")
+      .put("createdByUserId", userId);
+
+    JsonObject cr = new JsonObject()
+      .put("id", id)
+      .put("value", 1)
+      .put("metadata", crMd);
+
+    JsonObject upd = new JsonObject()
+      .put("id", id)
+      .put("value", 2);
+
+    save(id, cr)
+      .compose(s -> update(id, upd))
+      .compose(ur -> ur.getUpdated() == 0 ? failedFuture("Update failed") : succeededFuture())
+      .setHandler(context.asyncAssertSuccess());
+
+  }
+
+  @Test
+  public void isSuccessWhenUpdateEmptyMetadataWithMetadata(TestContext context) {
+
+    String id = "072dbc6c-7c68-4992-8e23-6df6f26a9c5b";
+    String userId = "84c759de-dd8e-4f84-9b19-4c4775dd4c99";
+
+    JsonObject cr = new JsonObject()
+      .put("id", id)
+      .put("value", 1);
+
+    JsonObject updMd = new JsonObject()
+      .put("updatedDate", "2019-01-02T00:00:00.000+0000")
+      .put("updatedByUserId", userId);
+
+    JsonObject upd = new JsonObject()
+      .put("id", id)
+      .put("value", 2)
+      .put("metadata", updMd);
+
+    save(id, cr)
+      .compose(s -> update(id, upd))
+      .compose(ur -> ur.getUpdated() == 0 ? failedFuture("Update failed") : succeededFuture())
+      .setHandler(context.asyncAssertSuccess());
+
+  }
+
+  @Test
+  public void isSuccessWhenUpdateMetadataWithMetadata(TestContext context) {
+
+    String id = "8c2fbb4c-d845-4607-b840-adbdc53fe3b5";
+    String userId = "a218fbec-eaed-4c47-8aa1-d8bdc24c50d1";
+
+    JsonObject crMd = new JsonObject()
+      .put("createdDate", "2019-01-01T00:00:00.000+0000")
+      .put("createdByUserId", userId);
+
+    JsonObject cr = new JsonObject()
+      .put("id", id)
+      .put("value", 1)
+      .put("metadata", crMd);
+
+    JsonObject updMd = new JsonObject()
+      .put("updatedDate", "2019-01-02T00:00:00.000+0000")
+      .put("updatedByUserId", userId);
+
+    JsonObject upd = new JsonObject()
+      .put("id", id)
+      .put("value", 2)
+      .put("metadata", updMd);
+
+    save(id, cr)
+      .compose(s -> update(id, upd))
+      .compose(ur -> ur.getUpdated() == 0 ? failedFuture("Update failed") : succeededFuture())
+      .setHandler(context.asyncAssertSuccess());
+
+  }
+
+  private Future<String> save(String id, JsonObject entity) {
+
+    Future<String> future = Future.future();
+    PostgresClient pgClient = PostgresClient.getInstance(vertx, TENANT_ID);
+    pgClient.save(TABLE, id, entity, future);
+
+    return future;
+  }
+
+  private Future<UpdateResult> update(String id, JsonObject entity) {
+
+    Future<UpdateResult> future = Future.future();
+    PostgresClient pgClient = PostgresClient.getInstance(vertx, TENANT_ID);
+    pgClient.update(TABLE, entity, id, future);
+
+    return future;
+  }
+
+
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
@@ -48,8 +48,8 @@ public class MetadataTriggerIT {
   }
 
   @AfterClass
-  public static void tearDown() {
-    PostgresClient.stopEmbeddedPostgres();
+  public static void tearDown(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/MetadataTriggerIT.java
@@ -17,8 +17,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 
@@ -33,11 +31,7 @@ public class MetadataTriggerIT {
   @BeforeClass
   public static void setUp(TestContext context) {
     vertx = VertxUtils.getVertxWithExceptionHandler();
-    try {
-      PostgresClient.getInstance(vertx).startEmbeddedPostgres();
-    } catch (IOException e) {
-      context.fail(e);
-    }
+    PostgresClient.getInstance(vertx);
 
     Async async = context.async();
     int port = NetworkUtils.nextFreePort();

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schema.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schema.json
@@ -4,6 +4,11 @@
       "tableName": "test_tenantapi",
       "pkColumnName": "_id",
       "generateId": true
+    },
+    {
+      "tableName": "test_md_trigger_table",
+      "pkColumnName": "_id",
+      "withMetadata": true
     }
   ]
 }


### PR DESCRIPTION
- Make metadata update trigger work regardless any metadata field presence
- Metadata update trigger - set date format with zone offset, perform conversion with UTC timezone
- RestVertice - fill in metadata regardless userId presence

Issue link: [RMB-320](https://issues.folio.org/browse/RMB-320)