### PR TITLE
Minimum java version runtime check.

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -132,6 +132,12 @@ public class RestVerticle extends AbstractVerticle {
   private static final Logger       log                             = LoggerFactory.getLogger(className);
   private static final ObjectMapper MAPPER                          = ObjectMapperTool.getMapper();
   private static final String       DEFAULT_SCHEMA                  = "public";
+  /**
+   * Minimum java version used for runtime check.
+   *
+   * For compile time check see raml-module-builder/pom.xml maven-enforcer-plugin requireJavaVersion.
+   */
+  private static final String       MINIMUM_JAVA_VERSION              = "1.8.0_101";
 
   private static ValidatorFactory   validationFactory;
   private static String             deploymentId                     = "";
@@ -153,6 +159,31 @@ public class RestVerticle extends AbstractVerticle {
     //passed in the request body in put and post requests. The constraints validated by this factory
     //are the ones in the json schemas accompanying the raml files
     validationFactory = Validation.buildDefaultValidatorFactory();
+    checkJavaVersion(System.getProperty("java.runtime.version"));
+  }
+
+  /**
+   * Compare java version strings of the form 1.8.0_191
+   */
+  static int compareJavaVersion(String versionA, String versionB) {
+    String [] a = versionA.split("[^0-9]+");
+    String [] b = versionB.split("[^0-9]+");
+    for (int i=0; i<4; i++) {
+      int compare = Integer.compare(Integer.parseInt(a[i]), Integer.parseInt(b[i]));
+      if (compare != 0) {
+        return compare;
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * @throws InternalError if javaVersion is less than {@link #MINIMUM_JAVA_VERSION}
+   */
+  static void checkJavaVersion(String javaVersion) {
+    if (compareJavaVersion(javaVersion, MINIMUM_JAVA_VERSION) < 0) {
+      throw new InternalError("Minimum java version is " + MINIMUM_JAVA_VERSION + " but found " + javaVersion);
+    }
   }
 
   // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest;
 
 import static org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit.*;
+import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
@@ -37,5 +38,16 @@ class RestVerticleTest {
   @Test
   void parseEnumNonEnumClass() throws Exception {
     assertThat(RestVerticle.parseEnum("java.util.Vector", "foo", "bar"), is(nullValue()));
+  }
+
+  @Test
+  void javaVersion() {
+    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_4"), is(0));
+    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_5"), is(lessThan(0)));
+    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_10"), is(lessThan(0)));
+    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.10_3"), is(lessThan(0)));
+    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.10.2_3"), is(lessThan(0)));
+    assertThrows(InternalError.class, () -> RestVerticle.checkJavaVersion("1.8.0_99"));
+    RestVerticle.checkJavaVersion("1.8.0_1000000");  // assert no exception
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
                     https://dev.folio.org/guides/troubleshooting/#missing-certificate-authority-for-lets-encrypt
                   </message>
                   <version>1.8.0-101</version>
+                  <!-- for runtime check see domain-models-runtime RestVerticle.MINIMUM_JAVA_VERSION -->
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
There was a bug report about an old java version on slack in #mod-circulation-dev yesterday.

This runtime check will give a good error message for all modules that use rmb.

At some time in future we will require java 11 where this will be useful.