### PR TITLE
RMB-350: Revert "Enable JUnit5 in Eclipse." Fix "PgUtilIT not tested"

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -75,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This reverts commit e0fb76962ed076a5e4361c38e20c2683532c9890.

This disables running JUnit tests in Eclipse.
This reenables running integration tests when invoking mvn install.

A proper solution will be done at a later time:
https://issues.folio.org/browse/RMB-351
"Enable Junit4 + Junit5 and make it work in Eclipse"