### PR TITLE
Update SchemaDereferencer.java

### DIFF
--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
@@ -13,7 +13,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import java.net.URI;
-import java.net.URISyntaxException;
 
 public class SchemaDereferencer {
 

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
@@ -56,7 +56,7 @@ public class SchemaDereferencer {
    * <li>If the base path is <code>"/home/peter"</code> the ref
    * becomes <code>"$ref": "file:/home/peter/dir/a.json"</code>.
    * <li>If the base path is <code>"C:\Users\peter"</code> the ref
-   * becomes <code>"$ref": "file:C:%5CUsers%5Cpeter%5Cdir%5Ca.json"</code>.
+   * becomes <code>"$ref": "file:///C:\Users\peter\dir\a.json"</code>.
    * </ul>
    *
    * <p>The absolute path is needed for generating the code from raml files

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
@@ -79,12 +79,8 @@ public class SchemaDereferencer {
     String file = jsonObject.getString("$ref");
     if (file != null && !hasUriScheme(file)) {
       Path nPath = path.resolveSibling(file);
-      try {
-        URI u = new URI("file", nPath.toAbsolutePath().normalize().toString(), null);
-        jsonObject.put("$ref", u.toString());
-      } catch (URISyntaxException ex) {
-        throw new IOException(ex.getLocalizedMessage());
-      }
+      //fix the problem of uri.getpath()==null in windows environment
+      jsonObject.put("$ref", nPath.toUri().toString());
     }
   }
 }


### PR DESCRIPTION
I modified the fixupRef fuction to generate a correct absolute path of $ref. The path will have a slash before the drive letter and it will go well when we use URI's getPath() function  in windows environment.