### PR TITLE
Remove .-path components from generated $refs RMB-397

### DIFF
--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/SchemaDereferencer.java
@@ -79,7 +79,7 @@ public class SchemaDereferencer {
     if (file != null && !hasUriScheme(file)) {
       Path nPath = path.resolveSibling(file);
       //fix the problem of uri.getpath()==null in windows environment
-      jsonObject.put("$ref", nPath.toUri().toString());
+      jsonObject.put("$ref", nPath.toUri().toString().replaceAll("/\\./", "/"));
     }
   }
 }


### PR DESCRIPTION
commit 13d4695059819d7e82c095ec8bb3811c6845a057 introduced
slightly different paths (with .-path component in the result).