### PR TITLE
Remove empty JSON "required" property

### DIFF
--- a/domain-models-runtime-it/ramls/bee.json
+++ b/domain-models-runtime-it/ramls/bee.json
@@ -16,7 +16,5 @@
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly" : true
     }
-  },
-  "required": [
-  ]
+  }
 }

--- a/domain-models-runtime-it/ramls/myitem.json
+++ b/domain-models-runtime-it/ramls/myitem.json
@@ -16,7 +16,5 @@
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly" : true
     }
-  },
-  "required": [
-  ]
+  }
 }


### PR DESCRIPTION
The "required" property must have elements.
So remove it entirely when intended to be empty.