### PR TITLE
Adjust count query RMB-422

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3625,7 +3625,7 @@ public class PostgresClient {
 
    ParsedQuery pq = new ParsedQuery();
 
-   int idx = query.toUpperCase().indexOf(" " + FROM + " ");
+   int idx = query.toUpperCase().indexOf(FROM);
    pq.setCountQuery("SELECT COUNT(" + countOn + ") " + query.substring(idx).trim());
 
    pq.setQueryWithoutLimOff(queryWithoutLimitOffset);

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3648,20 +3648,18 @@ public class PostgresClient {
    return pq;
   }
 
-  private static String escape(String str){
+  private static String escape(String str) {
     StringBuilder sb = new StringBuilder();
-    for (char c : str.toCharArray())
-    {
-        switch(c)
-        {
-            case '(':
-            case ')':
-            case '\\':
-                sb.append('\\');
-                // intended fall-through
-            default:
-                sb.append(c);
-        }
+    for (char c : str.toCharArray()) {
+      switch (c) {
+        case '(':
+        case ')':
+        case '\\':
+          sb.append('\\');
+        // intended fall-through
+        default:
+          sb.append(c);
+      }
     }
     return sb.toString();
   }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3625,7 +3625,7 @@ public class PostgresClient {
 
    ParsedQuery pq = new ParsedQuery();
 
-   int idx = query.toUpperCase().indexOf(" FROM ");
+   int idx = query.toUpperCase().indexOf(" " + FROM + " ");
    pq.setCountQuery("SELECT COUNT(" + countOn + ") " + query.substring(idx).trim());
 
    pq.setQueryWithoutLimOff(queryWithoutLimitOffset);

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -609,4 +609,26 @@ public class PostgresClientTest {
     }
   }
 
+  @Test
+  public void parseQueryTest1() {
+    String whereFromCQLtoPG = "id in (select t.id from (select id as id, "
+      + "jsonb_array_elements(instance.jsonb->'contributors') as c) as t "
+      + "where to_tsvector('simple', f_unaccent(t.c->>'name')) @@ to_tsquery('simple', f_unaccent('novik')) "
+      + "and to_tsvector('simple', f_unaccent(t.c->>'contributorNameTypeId')) @@ to_tsquery('simple', f_unaccent('personal')))";
+    String whereClause = "WHERE " + whereFromCQLtoPG + " LIMIT 10 OFFSET 0";
+    String selectClause = "SELECT jsonb,id FROM test_tenant_mod_inventory_storage.instance " + whereClause;
+    ParsedQuery parseQuery = PostgresClient.parseQuery(selectClause);
+    assertThat(parseQuery.getWhereClause().toLowerCase(), containsString(whereFromCQLtoPG.toLowerCase()));
+    assertThat(parseQuery.getCountQuery().toLowerCase(), containsString(whereFromCQLtoPG.toLowerCase()));
+  }
+
+  @Test
+  public void parseQueryTest2() {
+    String whereFromCQLtoPG = "id = '68b6a052-5e73-4f04-90ab-273694d125bd'";
+    String whereClause = "WHERE " + whereFromCQLtoPG + " LIMIT 1 OFFSET 0";
+    String selectClause = "SELECT * FROM test_tenant_mod_inventory_storage.instance " + whereClause;
+    ParsedQuery parseQuery = PostgresClient.parseQuery(selectClause);
+    assertThat(parseQuery.getWhereClause().toLowerCase(), containsString(whereFromCQLtoPG.toLowerCase()));
+    assertThat(parseQuery.getCountQuery().toLowerCase(), containsString(whereFromCQLtoPG.toLowerCase()));
+  }
 }


### PR DESCRIPTION
This fixes the code to dig out the query for "Counting". The original query returned by CQL2pgJSON is corrupted. Actually, re-parsing SQL is a very bad idea. Eventually, the Cql2PG should return a "SQL" object where the where-clause (WITHOUT "where") and sorting are separate entities so they can be shuffled around for later usage.
