### PR TITLE
Use field path over alias to avoid collision

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/facets/base_facet_query.ftl
+++ b/domain-models-runtime/src/main/resources/templates/facets/base_facet_query.ftl
@@ -18,7 +18,7 @@ with facets as (
     FROM facets
     GROUP BY GROUPING SETS (
       <#list facets as facet>
-        ${facet.alias}<#sep>,
+        ${facet.fieldPath}<#sep>,
       </#list>
     )
  )

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -325,7 +325,7 @@ public class PostgresClientTest {
       "      count(*) as count\n" +
       "    FROM facets\n" +
       "    GROUP BY GROUPING SETS (\n" +
-      "        biz    )\n" +
+      "        jsonb->>'biz'    )\n" +
       " )\n" +
       " ,\n" +
       "   lst1 as(\n" +
@@ -389,7 +389,7 @@ public class PostgresClientTest {
       "      count(*) as count\n" +
       "    FROM facets\n" +
       "    GROUP BY GROUPING SETS (\n" +
-      "        biz    )\n" +
+      "        jsonb->>'biz'    )\n" +
       " )\n" +
       " ,\n" +
       "   lst1 as(\n" +


### PR DESCRIPTION
To fix RMB-437 where user group facets search failed due to collision between select alias and existing table column name.