### PR TITLE
RMB-442: jackson-databind 2.9.9.2, fixes 2 security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,10 +85,10 @@
 	     https://issues.folio.org/browse/RMB-315
              https://issues.folio.org/browse/RMB-377
              TODO: Remove this jackson-databind dependency when vertx-stack-depchain
-             contains jackson-databind >= 2.9.9.1 -->
+             contains jackson-databind >= 2.9.9.2 -->
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.1</version>
+        <version>2.9.9.2</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>


### PR DESCRIPTION
 CVE-2019-14379, CVE-2019-14439