### PR TITLE
RMB-460: Add an option to specify path to sql script file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,7 +1389,8 @@ The fields in the **script** section include:
 
 1. `run` - either `before` or `after` the tables / views are generated
 2. `snippet` - the SQL to run
-3. `fromModuleVersion` - same as `fromModuleVersion` for table
+3. `snippetPath` - relative path to a file with SQL script to run. If `snippetPath` is set then `snippet` field will be ignored.  
+4. `fromModuleVersion` - same as `fromModuleVersion` for table
 
 
 The tables / views will be generated in the schema named tenantid_modulename

--- a/dbschema/src/main/java/org/folio/rest/persist/ddlgen/Script.java
+++ b/dbschema/src/main/java/org/folio/rest/persist/ddlgen/Script.java
@@ -8,6 +8,7 @@ public class Script extends Versioned {
 
   private String run;
   private String snippet;
+  private String snippetPath;
 
   public String getRun() {
     return run;
@@ -21,5 +22,10 @@ public class Script extends Versioned {
   public void setSnippet(String snippet) {
     this.snippet = snippet;
   }
-
+  public String getSnippetPath() {
+    return snippetPath;
+  }
+  public void setSnippetPath(String snippetPath) {
+    this.snippetPath = snippetPath;
+  }
 }

--- a/dbschema/src/test/java/org/folio/rest/tools/utils/ObjectMapperToolTest.java
+++ b/dbschema/src/test/java/org/folio/rest/tools/utils/ObjectMapperToolTest.java
@@ -28,6 +28,12 @@ class ObjectMapperToolTest {
       .isRemoveAccents(), is(true));
     assertThat(dbSchema.getTables().get(0).getFullTextIndex().get(0)
       .isRemoveAccents(), is(false));
+    assertThat(dbSchema.getScripts().get(0)
+      .getSnippetPath(), is("script.sql"));
+    assertThat(dbSchema.getScripts().get(0)
+      .getRun(), is("before"));
+    assertThat(dbSchema.getScripts().get(0)
+      .getFromModuleVersion(), is("mod-foo-18.2.2"));
 
   }
 }

--- a/dbschema/src/test/resources/schema.json
+++ b/dbschema/src/test/resources/schema.json
@@ -4,12 +4,18 @@
       "tableName": "item",
       "withAuditing": true,
       "auditingSnippet": {
-        "insert": { "declare": "-- extra declare for insert",
-                    "statement": "-- extra statement for insert" },
-        "update": { "declare": "-- extra declare for update",
-                    "statement": "-- extra statement for update" },
-        "delete": { "declare": "-- extra declare for delete",
-                    "statement": "-- extra statement for delete" }
+        "insert": {
+          "declare": "-- extra declare for insert",
+          "statement": "-- extra statement for insert"
+        },
+        "update": {
+          "declare": "-- extra declare for update",
+          "statement": "-- extra statement for update"
+        },
+        "delete": {
+          "declare": "-- extra declare for delete",
+          "statement": "-- extra statement for delete"
+        }
       },
       "index": [
         {
@@ -30,7 +36,9 @@
           "caseSensitive": false,
           "removeAccents": true,
           "arraySubfield": "name",
-          "arrayModifiers": [ "languageId" ]
+          "arrayModifiers": [
+            "languageId"
+          ]
         }
       ],
       "ginIndex": [
@@ -48,6 +56,13 @@
           "tOps": "ADD"
         }
       ]
+    }
+  ],
+  "scripts": [
+    {
+      "run": "before",
+      "snippetPath": "script.sql",
+      "fromModuleVersion": "mod-foo-18.2.2"
     }
   ]
 }

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
@@ -27,7 +27,11 @@ SET search_path TO ${myuniversity}_${mymodule},  public;
         <#if mode.name() != "CREATE">
 -- Run script - created in version ${(script.fromModuleVersion)!0}
         </#if>
-        ${script.snippet}
+        <#if script.snippetPath??>
+          <#include script.snippetPath>
+        <#elseif script.snippet??>
+          ${script.snippet}
+        </#if>
       </#if>
     </#if>
   </#list>
@@ -131,7 +135,11 @@ SET search_path TO ${myuniversity}_${mymodule},  public;
         <#if mode.name() != "CREATE">
 -- Run script - created in version ${(script.fromModuleVersion)!0}
         </#if>
-        ${script.snippet}
+        <#if script.snippetPath??>
+          <#include script.snippetPath>
+        <#elseif script.snippet??>
+          ${script.snippet}
+        </#if>
       </#if>
     </#if>
   </#list>

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -176,6 +176,35 @@ public class SchemaMakerTest {
         "select * from end;"));
   }
 
+  @Test
+  public void createScriptFromFilePresent() throws IOException, TemplateException {
+
+    SchemaMaker schemaMaker = new SchemaMaker("harvard", "circ", TenantOperation.CREATE,
+      "mod-foo-18.2.3", "mod-foo-18.2.4");
+
+    String json = ResourceUtil.asString("templates/db_scripts/scriptWithSnippetPath.json");
+    schemaMaker.setSchema(ObjectMapperTool.getMapper().readValue(json, Schema.class));
+
+    assertThat(tidy(schemaMaker.generateDDL()), containsString(
+      "select * from file_start;"));
+  }
+
+  @Test
+  public void createScriptFromFileAndSnippetPresent() throws IOException, TemplateException {
+
+    SchemaMaker schemaMaker = new SchemaMaker("harvard", "circ", TenantOperation.CREATE,
+      "mod-foo-18.2.3", "mod-foo-18.2.4");
+
+    String json = ResourceUtil.asString("templates/db_scripts/scriptWithSnippetPathAndSnippet.json");
+    schemaMaker.setSchema(ObjectMapperTool.getMapper().readValue(json, Schema.class));
+
+    assertThat(tidy(schemaMaker.generateDDL()), containsString(
+      "select * from start;"));
+
+    assertThat(tidy(schemaMaker.generateDDL()), containsString(
+      "select * from file_start;"));
+  }
+
 
   @Test
   public void delete() throws IOException, TemplateException {

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/script.sql
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/script.sql
@@ -1,0 +1,1 @@
+select * from file_start;

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/scriptWithSnippetPath.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/scriptWithSnippetPath.json
@@ -1,0 +1,9 @@
+{
+  "scripts": [
+    {
+      "run": "before",
+      "snippetPath": "script.sql",
+      "fromModuleVersion": "mod-foo-18.2.2"
+    }
+  ]
+}

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/scriptWithSnippetPathAndSnippet.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/scriptWithSnippetPathAndSnippet.json
@@ -1,0 +1,14 @@
+{
+  "scripts": [
+    {
+      "run": "before",
+      "snippet": "select * from start; ",
+      "fromModuleVersion": "mod-foo-18.2.2"
+    },
+    {
+      "run": "before",
+      "snippetPath": "script.sql",
+      "fromModuleVersion": "mod-foo-18.2.2"
+    }
+  ]
+}


### PR DESCRIPTION
Associated jira: https://issues.folio.org/browse/RMB-460. 
Currently some modules have "snippet" set to a very long sql script, that is difficult to read on one line (e.g. https://github.com/folio-org/mod-notes/blob/master/src/main/resources/templates/db_scripts/schema.json). Modules often store a readable version in a separate sql file alongside schema.json, so it would prevent duplication if we could reference sql files directly.