### PR TITLE
RMB-318: Drop deprecated dot (db.port) variables, use underscore (DB_PORT)

### DIFF
--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -35,20 +35,24 @@ public enum Envs {
     } else if (key.equalsIgnoreCase(MAXPOOL)) {
       return MAXPOOL;
     }
-    return key;
+    return key.toLowerCase();
   }
 
   public static JsonObject allDBConfs() {
     JsonObject obj = new JsonObject();
-    env.forEach((key, value) -> {
-      // also accept deprecated keys like "db.host" for "DB_HOST".
-      if (key.startsWith("db.") || key.startsWith("DB_")) {
-        key = toCamelCase(key.substring(3).toLowerCase());
-        if (key.equals(PORT) || key.equals(TIMEOUT) || key.equals(MAXPOOL)) {
+    env.forEach((envKey, value) -> {
+      if (! envKey.startsWith("DB_")) {
+        return;
+      }
+      String key = toCamelCase(envKey.substring(3));
+      if (key.equals(PORT) || key.equals(TIMEOUT) || key.equals(MAXPOOL)) {
+        try {
           obj.put(key, Integer.parseInt(value));
-        } else {
-          obj.put(key, value);
+        } catch (NumberFormatException e) {
+          throw new NumberFormatException(envKey + ": " + e.getMessage());
         }
+      } else {
+        obj.put(key, value);
       }
     });
     return obj;

--- a/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
+++ b/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
@@ -8,19 +8,25 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import io.vertx.core.json.JsonObject;
 
 public class EnvsTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Before
   public void setUp() {
     Map<String, String> map = new HashMap<>();
     map.put("DB_HOST", "example.com");
     map.put("DB_QUERYTIMEOUT", "8");
     map.put("DB_MAXPOOLSIZE", "5");
-    // deprecated key db.username for allDBConfs()
+    // we dropped support for dot form. check that it is ignored
     map.put("db.username", "superwoman");
+    map.put("DB.USERNAME", "superwoman");
     Envs.setEnv(Collections.unmodifiableMap(map));
   }
 
@@ -52,11 +58,20 @@ public class EnvsTest {
   @Test
   public void allDBConfs() {
     JsonObject json = Envs.allDBConfs();
-    assertEquals(4, json.size());
+    assertEquals(3, json.size());
     assertEquals("example.com", json.getValue("host"));
     assertEquals(Integer.valueOf(8), json.getValue("queryTimeout"));
     assertEquals(Integer.valueOf(5), json.getValue("maxPoolSize"));
-    assertEquals("superwoman", json.getValue("username"));
   }
 
+  @Test
+  public void numberFormatException() {
+    Envs.setEnv(Collections.singletonMap("DB_PORT", "qqq"));
+
+    thrown.expect(NumberFormatException.class);
+    thrown.expectMessage("DB_PORT");
+    thrown.expectMessage("qqq");
+
+    Envs.allDBConfs();
+  }
 }


### PR DESCRIPTION
* Breaking change for the database config environment variables.
* Report environment variable name if parsing int fails.