### PR TITLE
RMB-451: Fix SchemaMaker foreign key targetPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -1117,7 +1117,7 @@ The field in the child table points to the primary key `id` field of the parent 
           "caseSensitive": false,
           "removeAccents": true
         }
-      ],
+      ]
     },
     {
       "tableName": "holdings_record",

--- a/domain-models-runtime-it/src/main/resources/templates/db_scripts/schema.json
+++ b/domain-models-runtime-it/src/main/resources/templates/db_scripts/schema.json
@@ -8,11 +8,49 @@
       "auditingFieldName" : "beeHistory"
     },
     {
+      "tableName": "instance",
+      "index": [
+        {
+          "fieldName": "title",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
+    },
+    {
+      "tableName": "holdings_record",
+      "foreignKeys": [
+        {
+          "fieldName": "instanceId",
+          "targetTable":      "instance",
+          "targetTableAlias": "instance",
+          "tableAlias": "holdingsRecord",
+          "tOps": "ADD"
+        }
+      ]
+    },
+    {
       "tableName" : "myitems",
       "withMetadata" : true,
       "withAuditing" : true,
       "auditingTableName" : "myitems_audit",
-      "auditingFieldName" : "myitemsAudit"
+      "auditingFieldName" : "myitemsAudit",
+      "foreignKeys": [
+        {
+          "fieldName": "holdingsRecordId",
+          "targetTable":      "holdings_record",
+          "targetTableAlias": "holdingsRecord",
+          "tableAlias": "myitems",
+          "tOps": "ADD"
+        },
+        {
+          "targetPath": ["holdingsRecordId", "instanceId"],
+          "targetTable":      "instance",
+          "targetTableAlias": "instance",
+          "tableAlias": "myitems"
+        }
+      ]
     }
   ]
 }

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.26-incubating</version>
+      <version>2.3.29</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -138,11 +138,13 @@ public class SchemaMaker {
 
         List<ForeignKeys> fKeys = t.getForeignKeys();
         if(fKeys != null){
-          for (int j = 0; j < fKeys.size(); j++) {
+          for (ForeignKeys f : fKeys) {
+            if (f.getFieldName() == null) {  // e.g. "targetPath"
+              continue;
+            }
             //NOTE , FK are created on fields without the lowercasing / unaccenting
             //meaning, there needs to be an index created without lowercasing / unaccenting
             //otherwise no index will be used
-            ForeignKeys f = fKeys.get(j);
             f.setFieldPath(convertDotPath2PostgresNotation("NEW",f.getFieldName(), true , null, false));
             f.setFieldName(normalizeFieldName(f.getFieldName()));
           }

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -1,14 +1,15 @@
 
   <#-- Create / Drop foreign keys -->
   <#if table.foreignKeys??>
-    ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
-    <#list table.foreignKeys as key>
+    <#list table.foreignKeys?filter(key -> key.fieldName??) as key>
       <#if key.tOps.name() == "ADD">
-        ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID REFERENCES ${myuniversity}_${mymodule}.${key.targetTable}<#sep>,
+        ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
+          ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID REFERENCES ${myuniversity}_${mymodule}.${key.targetTable};
       <#else>
-        DROP COLUMN IF EXISTS ${key.fieldName} CASCADE;
+        ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
+          DROP COLUMN IF EXISTS ${key.fieldName} CASCADE;
       </#if>
-    </#list>;
+    </#list>
   </#if>
 
   <#-- Create / Drop foreign keys function which pulls data from json into the created foreign key columns -->
@@ -17,7 +18,7 @@
     CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_${table.tableName}_references()
     RETURNS TRIGGER AS $$
     BEGIN
-      <#list table.foreignKeys as key>
+      <#list table.foreignKeys?filter(key -> key.fieldName??) as key>
       NEW.${key.fieldName} = ${key.fieldPath};
       </#list>
       RETURN NEW;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
@@ -205,4 +205,9 @@ public class SchemaMakerIT extends PostgresClientITBase {
     executeSuperuser(context, "UPDATE " + table + " SET id='" + uuid2 + "'");
     assertIdJsonb(context, uuid2, uuid2);
   }
+
+  @Test
+  public void foreignKey(TestContext context) {
+    runSchema(context, TenantOperation.CREATE, "schemaInstanceItem.json");
+  }
 }

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schemaInstanceItem.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schemaInstanceItem.json
@@ -1,0 +1,35 @@
+{
+  "tables": [
+    {
+      "tableName": "instance"
+    },
+    {
+      "tableName": "holdings_record",
+      "foreignKeys": [
+        {
+          "fieldName": "instanceId",
+          "targetTable":      "instance",
+          "targetTableAlias": "instance",
+          "tableAlias": "holdingsRecord"
+        }
+      ]
+    },
+    {
+      "tableName": "item",
+      "foreignKeys": [
+        {
+          "fieldName": "holdingsRecordId",
+          "targetTable":      "holdings_record",
+          "targetTableAlias": "holdingsRecord",
+          "tableAlias": "item"
+        },
+        {
+          "targetPath": ["holdingsRecordId", "instanceId"],
+          "targetTable":      "instance",
+          "targetTableAlias": "instance",
+          "tableAlias": "item"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
A foreign key "targetPath" entry does not have a "fieldName" property.
This results in an unexpected null value in SchemaMaker.java and foreign_keys.ftl SQL generation.
Fix: Skip those entries.