### PR TITLE
RMB-468: Foreign key field index

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -378,11 +378,14 @@ public class CQL2PgJSON {
         desc = " DESC";
       }  // ASC not needed, it's Postgres' default
 
-      if (modifierSet.getBase().equals("id")) {
-        order.append(PK_COLUMN_NAME).append(desc);
+      String field = modifierSet.getBase();
+      DbIndex dbIndex = dbIndexMap.computeIfAbsent(field, f -> DbSchemaUtils.getDbIndex(dbTable, f));
+      if (dbIndex.isForeignKey() || "id".equals(field)) {
+        order.append(field).append(desc);
         continue;
       }
-      IndexTextAndJsonValues vals = getIndexTextAndJsonValues(modifierSet.getBase());
+
+      IndexTextAndJsonValues vals = getIndexTextAndJsonValues(field);
 
       // if sort field is marked explicitly as number type
       if (modifiers.getCqlTermFormat() == CqlTermFormat.NUMBER) {

--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/model/DbIndex.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/model/DbIndex.java
@@ -5,6 +5,7 @@ public class DbIndex {
   private boolean ft;
   private boolean gin;
   private boolean other;
+  private boolean foreignKey;
 
   public boolean isFt() {
     return ft;
@@ -30,4 +31,11 @@ public class DbIndex {
     this.other = other;
   }
 
+  public boolean isForeignKey() {
+    return foreignKey;
+  }
+
+  public void setForeignKey(boolean foreinKey) {
+    this.foreignKey = foreinKey;
+  }
 }

--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/util/DbSchemaUtils.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/util/DbSchemaUtils.java
@@ -21,6 +21,16 @@ public class DbSchemaUtils {
   }
 
   /**
+   * @return an immutable empty List if list is null, otherwise list.
+   */
+  private static <T> List<T> emptyIfNull(List<T> list) {
+    if (list == null) {
+      return Collections.emptyList();
+    }
+    return list;
+  }
+
+  /**
    * Get index info for some table
    *
    * @param table
@@ -30,17 +40,27 @@ public class DbSchemaUtils {
   public static DbIndex getDbIndex(Table table, String indexName) {
     DbIndex dbIndexStatus = new DbIndex();
 
-    if (table != null) {
-      dbIndexStatus.setFt(checkDbIndex(indexName, table.getFullTextIndex()));
-      dbIndexStatus.setGin(checkDbIndex(indexName, table.getGinIndex()));
-      for (List<Index> index : Arrays.asList(table.getIndex(),
-        table.getUniqueIndex(), table.getLikeIndex())) {
-        dbIndexStatus.setOther(checkDbIndex(indexName, index));
-        if (dbIndexStatus.isOther()) {
-          break;
-        }
+    if (table == null) {
+      return dbIndexStatus;
+    }
+    dbIndexStatus.setFt(checkDbIndex(indexName, table.getFullTextIndex()));
+    dbIndexStatus.setGin(checkDbIndex(indexName, table.getGinIndex()));
+    for (List<Index> index : Arrays.asList(table.getIndex(),
+      table.getUniqueIndex(), table.getLikeIndex())) {
+      dbIndexStatus.setOther(checkDbIndex(indexName, index));
+      if (dbIndexStatus.isOther()) {
+        break;
       }
     }
+
+    dbIndexStatus.setForeignKey(false);
+    for (ForeignKeys foreignKeys : emptyIfNull(table.getForeignKeys())) {
+      if (indexName.equals(foreignKeys.getFieldName())) {
+        dbIndexStatus.setForeignKey(true);
+        break;
+      }
+    }
+
     return dbIndexStatus;
   }
 

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -570,6 +570,9 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "*         sortBy id                             # Jo Jane; Ka Keller; Lea Long",
     "*         sortBy id/sort.ascending              # Jo Jane; Ka Keller; Lea Long",
     "*         sortBy id/sort.descending             # Lea Long; Ka Keller; Jo Jane",
+    "*         sortBy groupId                        # Jo Jane; Ka Keller; Lea Long",
+    "*         sortBy groupId/sort.ascending         # Jo Jane; Ka Keller; Lea Long",
+    "*         sortBy groupId/sort.descending        # Lea Long; Ka Keller; Jo Jane",
     "*         sortBy name/sort.ascending            # Jo Jane; Ka Keller; Lea Long",
     "*         sortBy name/sort.ascending/string     # Jo Jane; Ka Keller; Lea Long",
     "*         sortBy name/sort.descending           # Lea Long; Ka Keller; Jo Jane",
@@ -794,6 +797,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "cql.allRecords=1 sortBy id/number                        , WHERE true ORDER BY id     ",
     "cql.allRecords=1 sortBy id/sort.descending               , WHERE true ORDER BY id DESC",
     "cql.allRecords=1 sortBy id/sort.descending age/number id , WHERE true ORDER BY id DESC\\, users.user_data->'age'\\, id",
+    "cql.allRecords=1 sortBy groupId                          , WHERE true ORDER BY groupId",
   })
   public void idColumnSort(String cql, String expectedSql) throws CQL2PgJSONException {
     CQL2PgJSON c = new CQL2PgJSON("users.user_data");

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -769,14 +769,21 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
 
   @Test
   @Parameters({
-    "id=*,                                        true",
-    "id=\"11111111-1111-1111-1111-111111111111\",  id='11111111-1111-1111-1111-111111111111'",
-    "id=\"2*\",                                  (id>='20000000-0000-0000-0000-000000000000' and "
-                                               + "id<='2fffffff-ffff-ffff-ffff-ffffffffffff')",
-    "id=\"22222222*\",                           (id>='22222222-0000-0000-0000-000000000000' and "
-                                               + "id<='22222222-ffff-ffff-ffff-ffffffffffff')",
+    "id=*,                                       true",
+    "id=\"\",                                    true",
+    "groupId=*,                                  (groupId BETWEEN '00000000-0000-0000-0000-000000000000' "
+                                                           + "AND 'ffffffff-ffff-ffff-ffff-ffffffffffff')",
+    "groupId=\"\",                               (groupId BETWEEN '00000000-0000-0000-0000-000000000000' "
+                                                           + "AND 'ffffffff-ffff-ffff-ffff-ffffffffffff')",
+    "id=\"11111111-1111-1111-1111-111111111111\",              id='11111111-1111-1111-1111-111111111111'",
+    "id=\"2*\",                                       (id BETWEEN '20000000-0000-0000-0000-000000000000' "
+                                                           + "AND '2fffffff-ffff-ffff-ffff-ffffffffffff')",
+    "id=\"22222222*\",                                (id BETWEEN '22222222-0000-0000-0000-000000000000' "
+                                                           + "AND '22222222-ffff-ffff-ffff-ffffffffffff')",
+    "groupId=\"22222222*\",                      (groupId BETWEEN '22222222-0000-0000-0000-000000000000' "
+                                                           + "AND '22222222-ffff-ffff-ffff-ffffffffffff')",
   })
-  public void pkColumnRelation(String cql, String expectedSql) throws QueryValidationException {
+  public void idColumnRelation(String cql, String expectedSql) throws QueryValidationException {
     assertEquals(expectedSql, cql2pgJson.toSql(cql).getWhere());
     assertEquals(expectedSql, cql2pgJson.toSql(cql.replace("=", "==")).getWhere());
   }
@@ -788,7 +795,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "cql.allRecords=1 sortBy id/sort.descending               , WHERE true ORDER BY id DESC",
     "cql.allRecords=1 sortBy id/sort.descending age/number id , WHERE true ORDER BY id DESC\\, users.user_data->'age'\\, id",
   })
-  public void pkColumnSort(String cql, String expectedSql) throws CQL2PgJSONException {
+  public void idColumnSort(String cql, String expectedSql) throws CQL2PgJSONException {
     CQL2PgJSON c = new CQL2PgJSON("users.user_data");
     assertEquals(expectedSql, c.toSql(cql).toString());
   }
@@ -814,6 +821,8 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "id=\"\"                                   # Jo Jane; Ka Keller; Lea Long",
     "id<>\"\"                                  #",
     "id=1*                                     # Jo Jane",
+    "id=1**                                    # Jo Jane",
+    "id=1***                                   # Jo Jane",
     "id=1z*                                    #",
     "id<>2ä*                                   # Jo Jane; Ka Keller; Lea Long",  // a umlaut
     "id<>1*                                    # Ka Keller; Lea Long",
@@ -837,12 +846,13 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "id>=11111111-1111-1111-1111-111111111110  # Jo Jane; Ka Keller; Lea Long",
     "id>=11111111-1111-1111-1111-111111111111  # Jo Jane; Ka Keller; Lea Long",
     "id>=11111111-1111-1111-1111-111111111112  # Ka Keller; Lea Long",
-    "id>=11111111-1111-111w-1111-111111111112  # ! Invalid UUID after id comparator >=",
+    "id>=11111111-1111-111w-1111-111111111112  # ! Invalid UUID after 'id>='",
     "id=/masked         11111111-1111-1111-1111-111111111111   # ! Unsupported modifier masked",
-    "id=/regexp         11111111-1111-1111-1111-111111111111   # ! Unsupported modifier regexp"
-
+    "id=/regexp         11111111-1111-1111-1111-111111111111   # ! Unsupported modifier regexp",
+    "groupId=           77777777-7777-7777-7777-777777777777   # Jo Jane",
+    "groupId<>          77777777-7777-7777-7777-777777777777   # Ka Keller; Lea Long",
   })
-  public void pKey(String testcase) {
+  public void idMatch(String testcase) {
     select(cql2pgJson, testcase);
   }
 

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/ForeignKeyGenerationTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/ForeignKeyGenerationTest.java
@@ -22,15 +22,16 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.blah == /number 123452").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE (tableb.jsonb->>'blah')::numeric =123452)", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb WHERE (tableb.jsonb->>'blah')::numeric =123452)", sql);
   }
 
   @Test
-  public void ForeignKeySearch() throws FieldException, QueryValidationException, ServerChoiceIndexesException {
+  public void ForeignKeySearchChildParent() throws FieldException, QueryValidationException, ServerChoiceIndexesException {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.prefix == 11111111-1111-1111-1111-111111111111").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE lower(f_unaccent(tableb.jsonb->>'prefix')) LIKE lower(f_unaccent('11111111-1111-1111-1111-111111111111')))", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb "
+        + "WHERE lower(f_unaccent(tableb.jsonb->>'prefix')) LIKE lower(f_unaccent('11111111-1111-1111-1111-111111111111')))", sql);
   }
 
   @Test
@@ -38,7 +39,8 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tableb.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tablea.prefix == 11111111-1111-1111-1111-111111111111").getWhere();
-    assertEquals("(tableb.jsonb->>'tableaId')::UUID IN  ( SELECT id from tablea WHERE lower(f_unaccent(tablea.jsonb->>'prefix')) LIKE lower(f_unaccent('11111111-1111-1111-1111-111111111111')))", sql);
+    assertEquals("tableb.tableaId IN  ( SELECT id FROM tablea "
+        + "WHERE lower(f_unaccent(tablea.jsonb->>'prefix')) LIKE lower(f_unaccent('11111111-1111-1111-1111-111111111111')))", sql);
   }
 
   @Test
@@ -46,7 +48,7 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.gprefix == x0").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE lower(tableb.jsonb->>'gprefix') LIKE lower('x0'))", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb WHERE lower(tableb.jsonb->>'gprefix') LIKE lower('x0'))", sql);
   }
 
   @Test
@@ -54,7 +56,8 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.ftprefix = x0").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE to_tsvector('simple', tableb.jsonb->>'ftprefix') @@ replace((to_tsquery('simple', ('''x0''')))::text, '&', '<->')::tsquery)", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb "
+        + "WHERE to_tsvector('simple', tableb.jsonb->>'ftprefix') @@ replace((to_tsquery('simple', ('''x0''')))::text, '&', '<->')::tsquery)", sql);
   }
 
   @Test
@@ -62,7 +65,7 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.prefix = *").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE true)", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb WHERE true)", sql);
   }
 
   @Test
@@ -70,7 +73,7 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tableb.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tablea.prefix = *").getWhere();
-    assertEquals("(tableb.jsonb->>'tableaId')::UUID IN  ( SELECT id from tablea WHERE true)", sql);
+    assertEquals("tableb.tableaId IN  ( SELECT id FROM tablea WHERE true)", sql);
   }
 
   @Test
@@ -100,7 +103,8 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.prefix == *").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE lower(f_unaccent(tableb.jsonb->>'prefix')) LIKE lower(f_unaccent('%')))", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb "
+        + "WHERE lower(f_unaccent(tableb.jsonb->>'prefix')) LIKE lower(f_unaccent('%')))", sql);
   }
 
   @Test
@@ -108,7 +112,9 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tablec.cindex == z1").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE tableb.id IN  ( SELECT (tablec.jsonb->>'tablebId')::UUID from tablec WHERE lower(f_unaccent(tablec.jsonb->>'cindex')) LIKE lower(f_unaccent('z1'))))",sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb "
+        + "WHERE tableb.id IN  ( SELECT tablebId FROM tablec "
+        + "WHERE lower(f_unaccent(tablec.jsonb->>'cindex')) LIKE lower(f_unaccent('z1'))))",sql);
   }
 
   @Test
@@ -116,7 +122,7 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea.json" );
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKey.json");
     String sql = cql2pgJson.toSql("tableb.otherindex >= y0").getWhere();
-    assertEquals("tablea.id IN  ( SELECT (tableb.jsonb->>'tableaId')::UUID from tableb WHERE tableb.jsonb->>'otherindex' >='y0')", sql);
+    assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb WHERE tableb.jsonb->>'otherindex' >='y0')", sql);
   }
 
   @Test
@@ -151,7 +157,9 @@ public class ForeignKeyGenerationTest  {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("instance");
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKeyInstanceItem.json");
     String sql = cql2pgJson.toSql("item.barcode == 7834324634").toString();
-    String expected = "WHERE instance.id IN  ( SELECT (holdings_record.jsonb->>'instanceId')::UUID from holdings_record WHERE holdings_record.id IN  ( SELECT (item.jsonb->>'holdingsRecordId')::UUID from item WHERE lower(f_unaccent(item.jsonb->>'barcode')) LIKE lower(f_unaccent('7834324634'))))";
+    String expected = "WHERE instance.id IN  ( SELECT instanceId FROM holdings_record "
+        + "WHERE holdings_record.id IN  ( SELECT holdingsRecordId FROM item "
+        + "WHERE lower(f_unaccent(item.jsonb->>'barcode')) LIKE lower(f_unaccent('7834324634'))))";
     assertEquals(expected, sql);
   }
 
@@ -159,8 +167,10 @@ public class ForeignKeyGenerationTest  {
   public void testSearchItemByInstanceTitle() throws Exception {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("item");
     cql2pgJson.setDbSchemaPath("templates/db_scripts/foreignKeyInstanceItem.json");
-    String sql = cql2pgJson.toSql("instance.title = 'Olmsted in Chicago'").toString();
-    String expected = "WHERE (item.jsonb->>'holdingsRecordId')::UUID IN  ( SELECT id from holdings_record WHERE (holdings_record.jsonb->>'instanceId')::UUID IN  ( SELECT id from instance WHERE to_tsvector('simple', f_unaccent(instance.jsonb->>'title')) @@ replace((to_tsquery('simple', f_unaccent(''',Olmsted''')) && to_tsquery('simple', f_unaccent('''in''')) && to_tsquery('simple', f_unaccent('''Chicago,''')))::text, '&', '<->')::tsquery))";
+    String sql = cql2pgJson.toSql("instance.title = Olmsted").toString();
+    String expected = "WHERE item.holdingsRecordId IN  ( SELECT id FROM holdings_record "
+        + "WHERE holdings_record.instanceId IN  ( SELECT id FROM instance "
+        + "WHERE to_tsvector('simple', f_unaccent(instance.jsonb->>'title')) @@ replace((to_tsquery('simple', f_unaccent('''Olmsted''')))::text, '&', '<->')::tsquery))";
     assertEquals(expected, sql);
   }
 

--- a/cql2pgjson/src/test/resources/jo-ka-lea.sql
+++ b/cql2pgjson/src/test/resources/jo-ka-lea.sql
@@ -1,5 +1,16 @@
+DELETE FROM groups;
+INSERT INTO groups VALUES
+  ('77777777-7777-7777-7777-777777777777','{"id":"77777777-7777-7777-7777-777777777777"}'),
+  ('88888888-8888-8888-8888-888888888888','{"id":"88888888-8888-8888-8888-888888888888"}'),
+  ('99999999-9999-9999-9999-999999999999','{"id":"99999999-9999-9999-9999-999999999999"}');
 DELETE FROM users;
-INSERT INTO users (id,user_data) VALUES
-    ('11111111-1111-1111-1111-111111111111','{"id":"11111111-1111-1111-1111-111111111111", "name": "Jo Jane", "status": "Active - Ready", "email": "jo@example.com", "address": {"city": "Sydhavn", "zip": 2450}, "lang": ["en", "pl"], "number": 4}'),
-    ('22222222-2222-2222-2222-222222222222','{"id":"22222222-2222-2222-2222-222222222222", "name": "Ka Keller", "status": "Inactive", "email": "ka@example.com", "address": {"city": "Fred", "zip": 1900}, "lang": ["en", "dk", "fi"]}'),
-    ('33333333-3333-3333-3333-33333333333a','{"id":"33333333-3333-3333-3333-333333333333", "name": "Lea Long", "status": "Active - Not Yet", "email": "lea@example.com", "address": {"city": "Søvang", "zip": 2791}, "lang": ["en", "dk"]}');
+INSERT INTO users (id,user_data,groupId) VALUES
+  ('11111111-1111-1111-1111-111111111111','{"id":"11111111-1111-1111-1111-111111111111",
+    "name": "Jo Jane", "status": "Active - Ready", "email": "jo@example.com",
+    "address": {"city": "Sydhavn", "zip": 2450}, "lang": ["en", "pl"], "number": 4}', '77777777-7777-7777-7777-777777777777'),
+  ('22222222-2222-2222-2222-222222222222','{"id":"22222222-2222-2222-2222-222222222222",
+    "name": "Ka Keller", "status": "Inactive", "email": "ka@example.com",
+    "address": {"city": "Fred", "zip": 1900}, "lang": ["en", "dk", "fi"]}', '88888888-8888-8888-8888-888888888888'),
+  ('33333333-3333-3333-3333-33333333333a','{"id":"33333333-3333-3333-3333-333333333333",
+    "name": "Lea Long", "status": "Active - Not Yet", "email": "lea@example.com",
+    "address": {"city": "Søvang", "zip": 2791}, "lang": ["en", "dk"]}', '99999999-9999-9999-9999-999999999999');

--- a/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
+++ b/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
@@ -59,7 +59,7 @@
       ],
       "foreignKeys": [
         {
-          "fieldName": "group",
+          "fieldName": "groupId",
           "targetTable": "groups"
         }
       ]

--- a/cql2pgjson/src/test/resources/users.sql
+++ b/cql2pgjson/src/test/resources/users.sql
@@ -1,6 +1,7 @@
-DROP TABLE IF EXISTS users cascade;
+DROP TABLE IF EXISTS users, groups cascade;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
-CREATE TABLE users (id UUID PRIMARY KEY DEFAULT uuid_generate_v1mc(), user_data JSONB NOT NULL);
+CREATE TABLE users (id UUID PRIMARY KEY DEFAULT uuid_generate_v1mc(), user_data JSONB NOT NULL, groupId UUID);
+CREATE TABLE groups (id UUID PRIMARY KEY, jsonb JSONB NOT NULL);
 CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
 CREATE OR REPLACE FUNCTION f_unaccent(text)
   RETURNS text AS

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -3,9 +3,14 @@
 These are notes to assist upgrading to newer versions.
 See the [NEWS](../NEWS.md) summary of changes for each version.
 
+* [Version 27.1](#version-27-1)
 * [Version 27](#version-27)
 * [Version 25](#version-25)
 * [Version 20](#version-20)
+
+## Version 27.1
+
+* Remove all foreign keys fields and the primary key field `id` from the all index sections of schema.json. These btree indexes are created automatically.
 
 ## Version 27
 

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -5,9 +5,12 @@
       <#if key.tOps.name() == "ADD">
         ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
           ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID REFERENCES ${myuniversity}_${mymodule}.${key.targetTable};
+        CREATE INDEX IF NOT EXISTS ${table.tableName}_${key.fieldName}_idx
+          ON ${myuniversity}_${mymodule}.${table.tableName} (${key.fieldName});
       <#else>
         ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
           DROP COLUMN IF EXISTS ${key.fieldName} CASCADE;
+        <#-- DROP COLUMN also drops the index on that column. -->
       </#if>
     </#list>
   </#if>


### PR DESCRIPTION
Always create an index for the foreign key table field that has been extracted from
the jsonb. This UUID index is smaller and faster than an index that extracts the UUID
string from the jsonb object.

Change all queries to use that field and index, for example use users.groupId in favour
of users.jsonb->>'groupId'.