### PR TITLE
RMB-496: connectionReleaseDelay: Use 1 minute as default, add config

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,16 @@ RMB implementing modules expect a set of environment variables to be passed in a
  - DB_QUERYTIMEOUT
  - DB_CHARSET
  - DB_MAXPOOLSIZE
+ - DB_CONNECTION_RELEASE_DELAY
  - DB_EXPLAIN_QUERY_THRESHOLD
 
+The first five are mandatory, the others are optional.
+
 Environment variables with periods/dots in their names are deprecated in RMB because a period is [not POSIX compliant](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html) and therefore some shells, notably, the BusyBox /bin/sh included in Alpine Linux, strip them (reference: [warning in OpenJDK docs](https://hub.docker.com/_/openjdk/)).
+
+See the [Vert.x Async PostgreSQL Client Configuration documentation](https://vertx.io/docs/vertx-mysql-postgresql-client/java/#_configuration) for the details.
+
+The environment variable `DB_CONNECTION_RELEASE_DELAY` sets the delay in milliseconds after which an idle connection is closed. Use 0 to keep idle connections open forever. RMB's default is one minute (60000 ms).
 
 The environment variable `DB_EXPLAIN_QUERY_THRESHOLD` is not observed by
 Postgres itself, but is a value - in milliseconds - that triggers query

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ RMB implementing modules expect a set of environment variables to be passed in a
  - DB_QUERYTIMEOUT
  - DB_CHARSET
  - DB_MAXPOOLSIZE
- - DB_CONNECTION_RELEASE_DELAY
+ - DB_CONNECTIONRELEASEDELAY
  - DB_EXPLAIN_QUERY_THRESHOLD
 
 The first five are mandatory, the others are optional.
@@ -289,7 +289,7 @@ Environment variables with periods/dots in their names are deprecated in RMB bec
 
 See the [Vert.x Async PostgreSQL Client Configuration documentation](https://vertx.io/docs/vertx-mysql-postgresql-client/java/#_configuration) for the details.
 
-The environment variable `DB_CONNECTION_RELEASE_DELAY` sets the delay in milliseconds after which an idle connection is closed. Use 0 to keep idle connections open forever. RMB's default is one minute (60000 ms).
+The environment variable `DB_CONNECTIONRELEASEDELAY` sets the delay in milliseconds after which an idle connection is closed. Use 0 to keep idle connections open forever. RMB's default is one minute (60000 ms).
 
 The environment variable `DB_EXPLAIN_QUERY_THRESHOLD` is not observed by
 Postgres itself, but is a value - in milliseconds - that triggers query

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -13,11 +13,13 @@ public enum Envs {
   DB_QUERYTIMEOUT,
   DB_CHARSET,
   DB_MAXPOOLSIZE,
+  DB_CONNECTION_RELEASE_DELAY,
   DB_EXPLAIN_QUERY_THRESHOLD;
 
   private static final String PORT = "port";
   private static final String TIMEOUT = "queryTimeout";
   private static final String MAXPOOL = "maxPoolSize";
+  private static final String CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
 
   private static Map<String, String> env = System.getenv();
 
@@ -35,6 +37,8 @@ public enum Envs {
       return TIMEOUT;
     } else if (key.equalsIgnoreCase(MAXPOOL)) {
       return MAXPOOL;
+    } else if (key.equalsIgnoreCase(CONNECTION_RELEASE_DELAY)) {
+      return CONNECTION_RELEASE_DELAY;
     }
     return key.toLowerCase();
   }

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -13,13 +13,8 @@ public enum Envs {
   DB_QUERYTIMEOUT,
   DB_CHARSET,
   DB_MAXPOOLSIZE,
-  DB_CONNECTION_RELEASE_DELAY,
+  DB_CONNECTIONRELEASEDELAY,
   DB_EXPLAIN_QUERY_THRESHOLD;
-
-  private static final String PORT = "port";
-  private static final String TIMEOUT = "queryTimeout";
-  private static final String MAXPOOL = "maxPoolSize";
-  private static final String CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
 
   private static Map<String, String> env = System.getenv();
 
@@ -31,42 +26,50 @@ public enum Envs {
     return env.get(key.name());
   }
 
-  private static String toCamelCase(String key) {
-    // two strings need camelCasing
-    if (key.equalsIgnoreCase(TIMEOUT)) {
-      return TIMEOUT;
-    } else if (key.equalsIgnoreCase(MAXPOOL)) {
-      return MAXPOOL;
-    } else if (key.equalsIgnoreCase(CONNECTION_RELEASE_DELAY)) {
-      return CONNECTION_RELEASE_DELAY;
+  private static String configKey(Envs envs) {
+    switch (envs) {
+    case DB_QUERYTIMEOUT:            return "queryTimeout";
+    case DB_MAXPOOLSIZE:             return "maxPoolSize";
+    case DB_CONNECTIONRELEASEDELAY:  return "connectionReleaseDelay";
+    case DB_EXPLAIN_QUERY_THRESHOLD: return envs.name();
+    default:                         return envs.name().substring(3).toLowerCase();
     }
-    return key.toLowerCase();
+  }
+
+  private static Object configValue(Envs envs, String value) {
+    try {
+      switch (envs) {
+      case DB_PORT:
+      case DB_QUERYTIMEOUT:
+      case DB_MAXPOOLSIZE:
+      case DB_CONNECTIONRELEASEDELAY:
+        return Integer.parseInt(value);
+      case DB_EXPLAIN_QUERY_THRESHOLD:
+        return Long.parseLong(value);
+      default:
+        return value;
+      }
+    } catch (NumberFormatException e) {
+      throw new NumberFormatException(envs.name() + ": " + e.getMessage());
+    }
   }
 
   public static JsonObject allDBConfs() {
     JsonObject obj = new JsonObject();
-    env.forEach((envKey, value) -> {
-      if (! envKey.startsWith("DB_")) {
+    env.forEach((envKeyString, value) -> {
+      if (! envKeyString.startsWith("DB_")) {
         return;
       }
-      if (envKey.equals(DB_EXPLAIN_QUERY_THRESHOLD.name())) {
-        try {
-          obj.put(envKey, Long.parseLong(value));
-        } catch (NumberFormatException e) {
-          throw new NumberFormatException(envKey + ": " + e.getMessage());
-        }
+      Envs envKey;
+      try {
+        envKey = Envs.valueOf(envKeyString);
+      } catch (IllegalArgumentException e) {
+        // skip unknown DB_ keys, for example DB_RUNNER_PORT.
         return;
       }
-      String key = toCamelCase(envKey.substring(3));
-      if (key.equals(PORT) || key.equals(TIMEOUT) || key.equals(MAXPOOL)) {
-        try {
-          obj.put(key, Integer.parseInt(value));
-        } catch (NumberFormatException e) {
-          throw new NumberFormatException(envKey + ": " + e.getMessage());
-        }
-      } else {
-        obj.put(key, value);
-      }
+      String configKey = configKey(envKey);
+      Object configValue = configValue(envKey, value);
+      obj.put(configKey, configValue);
     });
     return obj;
   }

--- a/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
+++ b/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
@@ -24,6 +24,7 @@ public class EnvsTest {
     map.put("DB_HOST", "example.com");
     map.put("DB_QUERYTIMEOUT", "8");
     map.put("DB_MAXPOOLSIZE", "5");
+    map.put("DB_CONNECTION_RELEASE_DELAY", "12345");
     map.put("DB_EXPLAIN_QUERY_THRESHOLD", "100");
     // we dropped support for dot form. check that it is ignored
     map.put("db.username", "superwoman");
@@ -52,6 +53,11 @@ public class EnvsTest {
   }
 
   @Test
+  public void connectionReleaseDelay() {
+    assertEquals("12345", Envs.getEnv(Envs.DB_CONNECTION_RELEASE_DELAY));
+  }
+
+  @Test
   public void database() {
     assertNull(Envs.getEnv(Envs.DB_DATABASE));
   }
@@ -64,7 +70,7 @@ public class EnvsTest {
   @Test
   public void allDBConfs() {
     JsonObject json = Envs.allDBConfs();
-    assertEquals(4, json.size());
+    assertEquals(5, json.size());
     assertEquals("example.com", json.getValue("host"));
     assertEquals(Integer.valueOf(8), json.getValue("queryTimeout"));
     assertEquals(Integer.valueOf(5), json.getValue("maxPoolSize"));

--- a/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
+++ b/domain-models-interface-extensions/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
@@ -24,7 +24,7 @@ public class EnvsTest {
     map.put("DB_HOST", "example.com");
     map.put("DB_QUERYTIMEOUT", "8");
     map.put("DB_MAXPOOLSIZE", "5");
-    map.put("DB_CONNECTION_RELEASE_DELAY", "12345");
+    map.put("DB_CONNECTIONRELEASEDELAY", "12345");
     map.put("DB_EXPLAIN_QUERY_THRESHOLD", "100");
     // we dropped support for dot form. check that it is ignored
     map.put("db.username", "superwoman");
@@ -54,7 +54,7 @@ public class EnvsTest {
 
   @Test
   public void connectionReleaseDelay() {
-    assertEquals("12345", Envs.getEnv(Envs.DB_CONNECTION_RELEASE_DELAY));
+    assertEquals("12345", Envs.getEnv(Envs.DB_CONNECTIONRELEASEDELAY));
   }
 
   @Test
@@ -74,6 +74,7 @@ public class EnvsTest {
     assertEquals("example.com", json.getValue("host"));
     assertEquals(Integer.valueOf(8), json.getValue("queryTimeout"));
     assertEquals(Integer.valueOf(5), json.getValue("maxPoolSize"));
+    assertEquals(Integer.valueOf(12345), json.getValue("connectionReleaseDelay"));
     assertEquals(Long.valueOf(100), json.getValue(Envs.DB_EXPLAIN_QUERY_THRESHOLD.name()));
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -102,6 +102,9 @@ public class PostgresClient {
   private static final String    ID_FIELD                 = "id";
   private static final String    RETURNING_ID             = " RETURNING id ";
 
+  private static final String    CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
+  /** default release delay in milliseconds; after this time an idle database connection is closed */
+  private static final int       DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
   private static final String    POSTGRES_LOCALHOST_CONFIG = "/postgres-conf.json";
   private static final int       EMBEDDED_POSTGRES_PORT   = 6000;
 
@@ -530,6 +533,9 @@ public class PostgresClient {
       //passed in port as well. useful when multiple modules start up an embedded postgres
       //in a single server.
       config.put(PORT, embeddedPort);
+    }
+    if (! config.containsKey(CONNECTION_RELEASE_DELAY)) {
+      config.put(CONNECTION_RELEASE_DELAY, DEFAULT_CONNECTION_RELEASE_DELAY);
     }
     return config;
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -115,6 +115,7 @@ public class PostgresClientTest {
     assertThat(config.getString("host"), is("127.0.0.1"));
     assertThat(config.getInteger("port"), is(6000));
     assertThat(config.getString("username"), is("username"));
+    assertThat(config.getInteger("connectionReleaseDelay"), is(60000));
   }
 
   @Test
@@ -127,6 +128,7 @@ public class PostgresClientTest {
     assertThat(config.getString("host"), is("127.0.0.1"));
     assertThat(config.getInteger("port"), is(port));
     assertThat(config.getString("username"), is("barschema"));
+    assertThat(config.getInteger("connectionReleaseDelay"), is(60000));
   }
 
   @Test
@@ -135,11 +137,13 @@ public class PostgresClientTest {
     JsonObject env = new JsonObject()
         .put("DB_EXPLAIN_QUERY_THRESHOLD", 1200L)
         .put("host", "example.com")
-        .put("port", 9876);
+        .put("port", 9876)
+        .put("connectionReleaseDelay", 90000);
     JsonObject config = PostgresClient.getPostgreSQLClientConfig("footenant", "aSchemaName", env);
     assertThat(config.getString("host"), is("example.com"));
     assertThat(config.getInteger("port"), is(9876));
     assertThat(config.getString("username"), is("aSchemaName"));
+    assertThat(config.getInteger("connectionReleaseDelay"), is(90000));
     assertThat(PostgresClient.getExplainQueryThreshold(), is(1200L));
     PostgresClient.setExplainQueryThreshold(previous);
   }
@@ -152,6 +156,7 @@ public class PostgresClientTest {
     assertThat(config.getString("host"), is("localhost"));
     assertThat(config.getInteger("port"), is(5433));
     assertThat(config.getString("username"), is("postgres"));
+    assertThat(config.getInteger("connectionReleaseDelay"), is(30000));
   }
 
   @Test
@@ -162,6 +167,7 @@ public class PostgresClientTest {
     assertThat(config.getString("host"), is("localhost"));
     assertThat(config.getInteger("port"), is(5433));
     assertThat(config.getString("username"), is("mySchemaName"));
+    assertThat(config.getInteger("connectionReleaseDelay"), is(30000));
   }
 
   @Test

--- a/domain-models-runtime/src/test/resources/my-postgres-conf.json
+++ b/domain-models-runtime/src/test/resources/my-postgres-conf.json
@@ -3,5 +3,6 @@
 "port": 5433,
 "username": "postgres",
 "password": "postgres",
-"database": "postgres"
+"database": "postgres",
+"connectionReleaseDelay": 30000
 }


### PR DESCRIPTION
I forgot to enable connectionReleaseDelay in RMB-485.
* Use 1 minute delay as default (the same default we had before: https://github.com/folio-org/vertx-mysql-postgresql-client/blob/release-connection-pool-3-5-1-folio-1/src/main/java/io/vertx/ext/asyncsql/impl/pool/AsyncConnectionPool.java#L52 ).
* Allow DB_CONNECTIONRELEASEDELAY environment variable to overwrite the default.
* Document this in RMB README.