### PR TITLE
RMB-504: Jackson-* version 2.10.0, fixes jackson-databind security.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,17 +79,26 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- jackson security update because of jackson-databind:
+             https://issues.folio.org/browse/FOLIO-2341
+             https://issues.folio.org/browse/RMB-504
+	     TODO: Remove these jackson dependencies when vertx-stack-depchain
+	     contains jackson-databind >= 2.10.0
+      -->
       <dependency>
-        <!-- Security update:
-             https://issues.folio.org/browse/FOLIO-1682
-             https://issues.folio.org/browse/RMB-315
-	     https://issues.folio.org/browse/RMB-377
-             https://issues.folio.org/browse/RMB-477
-             TODO: Remove this jackson-databind dependency when vertx-stack-depchain
-             contains jackson-databind >= 2.9.10 -->
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>2.10.0</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.10</version>
+        <version>2.10.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>2.10.0</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>


### PR DESCRIPTION
Three serialization gadget (= polymorphic typing) security vulnerability issues have been reported against jackson-databind versions before 2.9.10.1:

jackson-databind 2.9.10.1 (released 2019-10-20) fixes
* commons-dbcp, p6spy (https://nvd.nist.gov/vuln/detail/CVE-2019-16942 / https://nvd.nist.gov/vuln/detail/CVE-2019-16943 = https://github.com/FasterXML/jackson-databind/issues/2478
* log4j-extras/1.2 (https://nvd.nist.gov/vuln/detail/CVE-2019-17531 = https://github.com/FasterXML/jackson-databind/issues/2498)

jackson-databind 2.9.10.2 (https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches) (not yet released) fixes
* ehcache/JNDI (CVEs to be allocated = https://github.com/FasterXML/jackson-databind/issues/2526)

See also
* https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062
* Jackson 2.10 features (esp "Safe Default Typing" to vanquish stream of CVE patches!) https://medium.com/@cowtowncoder/jackson-2-10-features-cd880674d8a2