### PR TITLE
Use log4j's MDC rather than slf4j's MDC RMB-511

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -200,13 +200,13 @@
       <version>2.9.1</version>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.25</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
+      <artifactId>log4j-1.2-api</artifactId>
       <version>2.9.1</version>
     </dependency>
     <dependency>

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -63,7 +63,7 @@ import org.folio.rest.tools.utils.VertxUtils;
 import org.folio.rulez.Rules;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.rule.FactHandle;
-import org.slf4j.MDC;
+import org.apache.log4j.MDC;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;

--- a/postgres-runner/pom.xml
+++ b/postgres-runner/pom.xml
@@ -44,12 +44,6 @@
       <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-nop</artifactId>
-      <version>1.7.25</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -29,6 +29,10 @@
       <version>${droolsVersion}</version>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/rules/src/main/java/org/folio/rulez/RuleTracker.java
+++ b/rules/src/main/java/org/folio/rulez/RuleTracker.java
@@ -1,5 +1,7 @@
 package org.folio.rulez;
 
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -8,8 +10,6 @@ import org.kie.api.definition.rule.Rule;
 import org.kie.api.event.rule.AfterMatchFiredEvent;
 import org.kie.api.event.rule.DefaultAgendaEventListener;
 import org.kie.api.runtime.rule.Match;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A listener that will track all rule firings in a session.


### PR DESCRIPTION
This is because we're using log4j as logging implementation for RMB
and we've seen calls to MDC fail in some cases when using the slf4j verion.