### PR TITLE
RMB-529: Vert.x 3.8.4 fixing Netty HTTP request smuggling CVE-2019-16869

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -13,6 +13,10 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 ## Version 29
 
+* [RMB-529](https://issues.folio.org/browse/RMB-529) The update to Vert.x 3.8.4 deprecates several elements,
+  including Json#mapper, Json#prettyMapper and Json#decodeValue:
+  [3.8.2 Deprecations](https://github.com/vert-x3/wiki/wiki/3.8.2-Deprecations-and-breaking-changes),
+  [3.8.3 Deprecations](https://github.com/vert-x3/wiki/wiki/3.8.3-Deprecations-and-breaking-changes)
 * [RMB-510](https://issues.folio.org/browse/RMB-510) Tenant POST `/_/tenant` must include a body. Client that
   used an empty request must now include a body with at least:
   `{"module_to":"module-id"}`. This means that for modules that are using

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.8.1</version>
+        <version>3.8.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <aspectj.version>1.9.4</aspectj.version>
-    <vertx-version>3.8.1</vertx-version>
+    <vertx-version>3.8.4</vertx-version>
   </properties>
 
   <repositories>

--- a/sample2/pom.xml
+++ b/sample2/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>3.8.1</vertx-version>
+    <vertx-version>3.8.4</vertx-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-16869
https://issues.folio.org/browse/RMB-529
https://issues.folio.org/browse/FOLIO-2368