### PR TITLE
RMB-536: Missing f_unaccent for compound fields full text index (#583)

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -317,21 +317,6 @@ public class CQL2PgJSON {
     return new CQLFeatureUnsupportedException("Not implemented yet: " + node.getClass().getName());
   }
 
-  private static String wrapInLowerUnaccent(String term, boolean lower, boolean unaccent) {
-    if (lower) {
-      if (unaccent) {
-        return "lower(f_unaccent(" + term + "))";
-      } else {
-        return "lower(" + term + ")";
-      }
-    } else {
-      if (unaccent) {
-        return "f_unaccent(" + term + ")";
-      } else {
-        return term;
-      }
-    }
-  }
 
   /**
    * Return $term, lower($term), f_unaccent($term) or lower(f_unaccent($term))
@@ -342,7 +327,7 @@ public class CQL2PgJSON {
    * @return wrapped term
    */
   private static String wrapInLowerUnaccent(String term, CqlModifiers cqlModifiers) {
-    return wrapInLowerUnaccent(term,
+    return Cql2PgUtil.wrapInLowerUnaccent(term,
         cqlModifiers.getCqlCase() != CqlCase.RESPECT_CASE,
         cqlModifiers.getCqlAccents() != CqlAccents.RESPECT_ACCENTS);
   }
@@ -356,9 +341,9 @@ public class CQL2PgJSON {
    */
   private static String wrapInLowerUnaccent(String term, Index index) {
     if (index == null) {
-      return wrapInLowerUnaccent(term, true, true);
+      return Cql2PgUtil.wrapInLowerUnaccent(term, true, true);
     } else {
-      return wrapInLowerUnaccent(term, ! index.isCaseSensitive(), index.isRemoveAccents());
+      return Cql2PgUtil.wrapInLowerUnaccent(term, ! index.isCaseSensitive(), index.isRemoveAccents());
     }
   }
 
@@ -845,11 +830,11 @@ public class CQL2PgJSON {
         throw new QueryValidationException("CQL: Unknown full text comparator '" + comparator + "'");
     }
     if(schemaIndex != null && schemaIndex.getMultiFieldNames() != null) {
-      indexText = wrapInLowerUnaccent(schemaIndex.getFinalSqlExpression(targettable.getTableName()),  /* lower */ false, removeAccents);
+      indexText = schemaIndex.getFinalSqlExpression(targettable.getTableName());
     } else if(schemaIndex != null && schemaIndex.getSqlExpression() != null) {
       indexText = schemaIndex.getSqlExpression();
     } else {
-      indexText = wrapInLowerUnaccent(indexText, /* lower */ false, removeAccents);
+      indexText = Cql2PgUtil.wrapInLowerUnaccent(indexText, /* lower */ false, removeAccents);
     }
     String sql = "to_tsvector('simple', " + indexText + ") "
       + "@@ " + tsTerm;

--- a/dbschema/src/main/java/org/folio/cql2pgjson/util/Cql2PgUtil.java
+++ b/dbschema/src/main/java/org/folio/cql2pgjson/util/Cql2PgUtil.java
@@ -250,4 +250,20 @@ public final class Cql2PgUtil {
     }
     result.append('\'');
   }
+
+  public static String wrapInLowerUnaccent(String term, boolean lower, boolean unaccent) {
+    if (lower) {
+      if (unaccent) {
+        return "lower(f_unaccent(" + term + "))";
+      } else {
+        return "lower(" + term + ")";
+      }
+    } else {
+      if (unaccent) {
+        return "f_unaccent(" + term + ")";
+      } else {
+        return term;
+      }
+    }
+  }
 }

--- a/dbschema/src/main/java/org/folio/rest/persist/ddlgen/Index.java
+++ b/dbschema/src/main/java/org/folio/rest/persist/ddlgen/Index.java
@@ -102,7 +102,7 @@ public class Index extends TableIndexes {
       appendExpandedTerm(tableLoc, splitIndex[i], result);
     }
     result.append(")");
-    return result.toString();
+    return Cql2PgUtil.wrapInLowerUnaccent(result.toString(), caseSensitive , removeAccents) ;
   }
 
   protected static void appendExpandedTerm(String table, String term, StringBuilder result) {

--- a/dbschema/src/test/java/org/folio/rest/persist/ddlgen/IndexTest.java
+++ b/dbschema/src/test/java/org/folio/rest/persist/ddlgen/IndexTest.java
@@ -48,7 +48,7 @@ class IndexTest {
     idx.setFieldPath("testIdx");
     idx.setFieldName("testIdx");
     idx.setMultiFieldNames("field1,field2,field3");
-    assertEquals("concat_space_sql(test_table.jsonb->>'field1' , test_table.jsonb->>'field2' , test_table.jsonb->>'field3')",idx.getFinalSqlExpression("test_table"));
+    assertEquals("f_unaccent(concat_space_sql(test_table.jsonb->>'field1' , test_table.jsonb->>'field2' , test_table.jsonb->>'field3'))",idx.getFinalSqlExpression("test_table"));
 
   }
 
@@ -58,7 +58,7 @@ class IndexTest {
     idx.setFieldPath("testIdx");
     idx.setFieldName("testIdx");
     idx.setMultiFieldNames("field1[*].test,field2[*].name,field3.blah.blah2[*].foo");
-    assertEquals("concat_space_sql(concat_array_object_values(test_table.jsonb->'field1','test') , concat_array_object_values(test_table.jsonb->'field2','name') , concat_array_object_values(test_table.jsonb->'field3'->'blah'->'blah2','foo'))",idx.getFinalSqlExpression("test_table"));
+    assertEquals("f_unaccent(concat_space_sql(concat_array_object_values(test_table.jsonb->'field1','test') , concat_array_object_values(test_table.jsonb->'field2','name') , concat_array_object_values(test_table.jsonb->'field3'->'blah'->'blah2','foo')))",idx.getFinalSqlExpression("test_table"));
 
   }
   @Test
@@ -74,7 +74,7 @@ class IndexTest {
     Index idx = new Index();
     idx.setFieldName("testIdx");
     idx.setMultiFieldNames("blah.blah2.field1,blah.blah2.field2");
-    assertEquals("concat_space_sql(test_table.jsonb->'blah'->'blah2'->>'field1' , test_table.jsonb->'blah'->'blah2'->>'field2')",idx.getFinalSqlExpression("test_table"));
+    assertEquals("f_unaccent(concat_space_sql(test_table.jsonb->'blah'->'blah2'->>'field1' , test_table.jsonb->'blah'->'blah2'->>'field2'))",idx.getFinalSqlExpression("test_table"));
   }
   @Test
   void nullSQLExpression() {
@@ -83,5 +83,49 @@ class IndexTest {
     idx.setFieldName("testIdx");
     idx.setSqlExpression(null);
     assertEquals("testIdx",idx.getFinalSqlExpression("test_table"));
+  }
+
+  @Test
+  void sqlsetMultiFieldNamesWrapSetCaseSensitiveSetRemoveAccents() {
+    Index idx = new Index();
+    idx.setFieldPath("testIdx");
+    idx.setFieldName("testIdx");
+    idx.setCaseSensitive(true);
+    idx.setRemoveAccents(true);
+    idx.setMultiFieldNames("test1,test2.test3");
+    assertEquals("lower(f_unaccent(concat_space_sql(test_table.jsonb->>'test1' , test_table.jsonb->'test2'->>'test3')))",idx.getFinalSqlExpression("test_table"));
+  }
+
+  @Test
+  void sqlsetMultiFieldNamesWrapSetRemoveAccents() {
+    Index idx = new Index();
+    idx.setFieldPath("testIdx");
+    idx.setFieldName("testIdx");
+    idx.setCaseSensitive(false);
+    idx.setRemoveAccents(true);
+    idx.setMultiFieldNames("test1,test2.test3");
+    assertEquals("f_unaccent(concat_space_sql(test_table.jsonb->>'test1' , test_table.jsonb->'test2'->>'test3'))",idx.getFinalSqlExpression("test_table"));
+  }
+
+  @Test
+  void sqlsetMultiFieldNamesWrapSetCaseSensitive() {
+    Index idx = new Index();
+    idx.setFieldPath("testIdx");
+    idx.setFieldName("testIdx");
+    idx.setCaseSensitive(true);
+    idx.setRemoveAccents(false);
+    idx.setMultiFieldNames("test1,test2.test3");
+    assertEquals("lower(concat_space_sql(test_table.jsonb->>'test1' , test_table.jsonb->'test2'->>'test3'))",idx.getFinalSqlExpression("test_table"));
+  }
+
+  @Test
+  void sqlsetMultiFieldNamesWrap() {
+    Index idx = new Index();
+    idx.setFieldPath("testIdx");
+    idx.setFieldName("testIdx");
+    idx.setCaseSensitive(false);
+    idx.setRemoveAccents(false);
+    idx.setMultiFieldNames("test1,test2.test3");
+    assertEquals("concat_space_sql(test_table.jsonb->>'test1' , test_table.jsonb->'test2'->>'test3')",idx.getFinalSqlExpression("test_table"));
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -85,8 +85,8 @@ public class SchemaMakerTest {
 
     assertThat(result,containsString("((concat_space_sql(concat_array_object_values(tablea.jsonb->'user','firstName') , concat_array_object_values(tablea.jsonb->'user','lastName'))) gin_trgm_ops)"));
     assertThat(result,containsString("((concat_space_sql(concat_array_object_values(tablea.jsonb->'user'->'info','firstName') , concat_array_object_values(tablea.jsonb->'user'->'info','lastName'))) gin_trgm_ops)"));
-    assertThat(result,containsString("( to_tsvector('simple', concat_space_sql(concat_array_object_values(tablea.jsonb->'field1','firstName') , concat_array_object_values(tablea.jsonb->'field2','lastName'))) )"));
-    assertThat(result,containsString("( to_tsvector('simple', concat_space_sql(concat_array_object_values(tablea.jsonb->'field1'->'info','firstName') , concat_array_object_values(tablea.jsonb->'field2'->'info','lastName'))) )"));
+    assertThat(result,containsString("( to_tsvector('simple', lower(concat_space_sql(concat_array_object_values(tablea.jsonb->'field1','firstName') , concat_array_object_values(tablea.jsonb->'field2','lastName')))) )"));
+    assertThat(result,containsString("( to_tsvector('simple', lower(concat_space_sql(concat_array_object_values(tablea.jsonb->'field1'->'info','firstName') , concat_array_object_values(tablea.jsonb->'field2'->'info','lastName')))) )"));
   }
 
   @Test


### PR DESCRIPTION
Cherry-pick from master to b29.1.

* moved wrapping into the index to create the correct index in generation and querying.
* fix for unit tests to match new function added to index code.
* added new Unit tests for code coverage.
* Revert "added new Unit tests for code coverage." This reverts commit 52917cf87d3c7e7255131e30995aec4ea9f750bd.
* updates for unit tests
* final update to unit tests for expected
* Updates for feedback