### PR TITLE
RMB-540: Unique index must not truncate to 600 characters - 29.1 backport

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See the file ["LICENSE"](LICENSE) for more information.
     * [CQL: Matching undefined or empty values](#cql-matching-undefined-or-empty-values)
     * [CQL: Matching array elements](#cql-matching-array-elements)
     * [CQL: @-relation modifiers for array searches](#cql--relation-modifiers-for-array-searches)
+    * [CQL2PgJSON: Multi Field Index](#cql2pgjson-multi-field-index)
     * [CQL2PgJSON: Foreign key cross table index queries](#cql2pgjson-foreign-key-cross-table-index-queries)
     * [CQL2PgJSON: Foreign key tableAlias and targetTableAlias](#cql2pgjson-foreign-key-tablealias-and-targettablealias)
     * [CQL2PgJSON: Exceptions](#cql2pgjson-exceptions)
@@ -1146,7 +1147,7 @@ CQL2PGjson allows generating and querying indexes that contain multiple columns.
 	```
 	
 * multiFieldNames
-	This is a comma seperated list of json fields that are to be concatenated together via concat_ws with a space character. 
+	This is a comma separated list of json fields that are to be concatenated together via concat_ws with a space character.
 	example:
 	```
 		"fieldName": "address",
@@ -1443,16 +1444,20 @@ For each **table** in `tables` property:
     * `stringType` - defaults to true - if this is set to false than the assumption is that the field is not of type text therefore ignoring the removeAccents and caseSensitive parameters.
     * `arrayModifiers` - specifies array relation modifiers supported for some index. The modifiers must exactly match the name of the property in the JSON object within the array.
     * `arraySubfield` - is the key of the object that is used for the primary term when array relation modifiers are in use. This is typically also defined when `arrayModifiers` are also defined.
+    * `multiFieldNames` - see [CQL2PgJSON: Multi Field Index](#cql2pgjson-multi-field-index) above
+    * `sqlExpression` - see [CQL2PgJSON: Multi Field Index](#cql2pgjson-multi-field-index) above
     * Do not manually add an index for an `id` field or a foreign key field, they get indexed automatically.
 7. `ginIndex` - generate an inverted index on the JSON using the `gin_trgm_ops` extension. Allows for left and right truncation LIKE queries and regex queries to run in an optimal manner (similar to a simple search engine). Note that the generated index is large and does not support the full field match (SQL `=` operator and CQL `==` operator without wildcards). See the `likeIndex` for available options.
 8. `uniqueIndex` - create a unique index on a field in the JSON
     * the `tOps` indicates the table operation - ADD means to create this index, DELETE indicates this index should be removed
     * the `whereClause` allows you to create partial indexes, for example:  "whereClause": "WHERE (jsonb->>'enabled')::boolean = true"
+    * Adding a record will fail if the b-tree index byte size limit of 2712 is exceeded. Consider enforcing a length limit on the field, for example by adding a 600 character limit (multi-byte characters) to the RAML specification.
     * See additional options in the likeIndex section above
 9. `index` - create a btree index on a field in the JSON
     * the `tOps` indicates the table operation - ADD means to create this index, DELETE indicates this index should be removed
     * the `whereClause` allows you to create partial indexes, for example:  "whereClause": "WHERE (jsonb->>'enabled')::boolean = true"
     * See additional options in the likeIndex section above
+    * The expression is wrapped into left(..., 600) to prevent exceeding the b-tree byte size limit of 2712. Special case: sqlExpression is not wrapped.
 10. `fullTextIndex` - create a full text index using the tsvector features of postgres.
     * `removeAccents` can be used, the default `caseSensitive: false` cannot be changed because tsvector always converts to lower case.
     * See [CQL: Matching full text](#cql-matching-full-text) to learn how word splitting works.

--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -870,15 +870,15 @@ public class CQL2PgJSON {
       String term = "'" + Cql2SqlUtil.cql2like(node.getTerm()) + "'";
       String indexMod;
 
-      if(schemaIndex != null && schemaIndex.getMultiFieldNames() != null) {
+      if (schemaIndex != null && schemaIndex.getMultiFieldNames() != null) {
         indexMod = schemaIndex.getFinalSqlExpression(targetTable.getTableName());
-      } else if(schemaIndex != null && schemaIndex.getSqlExpression() != null) {
+      } else if (schemaIndex != null && schemaIndex.getSqlExpression() != null) {
         indexMod = schemaIndex.getSqlExpression();
       } else {
         indexMod = wrapInLowerUnaccent(indexText, schemaIndex);
       }
 
-      if(schemaIndex != null) {
+      if (schemaIndex != null && schemaIndex == dbIndex.getIndex()) {
         sql = createLikeLengthCase(comparator, indexMod, schemaIndex, likeOperator, term);
       } else {
         sql = indexMod + " " + likeOperator + " " + wrapInLowerUnaccent(term, schemaIndex);

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CompoundIndexTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CompoundIndexTest.java
@@ -25,10 +25,7 @@ public class CompoundIndexTest {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea");
     cql2pgJson.setDbSchemaPath("templates/db_scripts/compoundIndex.json");
     String sql = cql2pgJson.toSql("barcode == y").toString();
-    String expected = "WHERE CASE WHEN length(lower(f_unaccent('y'))) <= 600 "
-      + "THEN left(lower(f_unaccent(concat_space_sql(tablea.jsonb->>'department' , tablea.jsonb->>'staffnumber'))),600) LIKE lower(f_unaccent('y')) "
-      + "ELSE left(lower(f_unaccent(concat_space_sql(tablea.jsonb->>'department' , tablea.jsonb->>'staffnumber'))),600) LIKE left(lower(f_unaccent('y')),600) "
-      + "AND lower(f_unaccent(concat_space_sql(tablea.jsonb->>'department' , tablea.jsonb->>'staffnumber'))) LIKE lower(f_unaccent('y')) END";
+    String expected = "WHERE lower(f_unaccent(concat_space_sql(tablea.jsonb->>'department' , tablea.jsonb->>'staffnumber'))) LIKE lower(f_unaccent('y'))";
     assertEquals(expected, sql);
   }
 
@@ -37,10 +34,7 @@ public class CompoundIndexTest {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON("tablea");
     cql2pgJson.setDbSchemaPath("templates/db_scripts/compoundIndex.json");
     String sql = cql2pgJson.toSql("fullname == \"John Smith\"").toString();
-    String expected = "WHERE CASE WHEN length(lower('John Smith')) <= 600 "
-        + "THEN left(lower(concat_space_sql(tablea.jsonb->>'firstName' , tablea.jsonb->>'lastName')),600) LIKE lower('John Smith') "
-        + "ELSE left(lower(concat_space_sql(tablea.jsonb->>'firstName' , tablea.jsonb->>'lastName')),600) LIKE left(lower('John Smith'),600) "
-        + "AND lower(concat_space_sql(tablea.jsonb->>'firstName' , tablea.jsonb->>'lastName')) LIKE lower('John Smith') END";
+    String expected = "WHERE lower(concat_space_sql(tablea.jsonb->>'firstName' , tablea.jsonb->>'lastName')) LIKE lower('John Smith')";
     assertEquals(expected, sql);
   }
 

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/ForeignKeyGenerationTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/ForeignKeyGenerationTest.java
@@ -57,13 +57,9 @@ public class ForeignKeyGenerationTest  {
   @Test
   public void searchWithLowerConstant() throws FieldException, QueryValidationException, ServerChoiceIndexesException {
     String sql = cql2pgJson("tablea.json", "foreignKey.json")
-        .toSql("tableb.gprefix == x0").getWhere();
+        .toSql("tableb.gprefix == x0").getWhere();  // ginx index
     assertEquals("tablea.id IN  ( SELECT tableaId FROM tableb WHERE"
-        + " CASE WHEN length(lower('x0')) <= 600"
-        + " THEN left(lower(tableb.jsonb->>'gprefix'),600) LIKE lower('x0')"
-        + " ELSE left(lower(tableb.jsonb->>'gprefix'),600) LIKE left(lower('x0'),600)"
-        + " AND lower(tableb.jsonb->>'gprefix') LIKE lower('x0')"
-        + " END)", sql);
+        + " lower(tableb.jsonb->>'gprefix') LIKE lower('x0'))", sql);
   }
 
   @Test

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/indexes.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/indexes.ftl
@@ -2,8 +2,9 @@
   <#if table.index??>
     <#list table.index as indexes>
     <#if indexes.tOps.name() == "ADD">
+    <#-- Truncate using left(..., 600) to fit into the 2712 byte limit of PostgreSQL indexes (600 multi-byte characters) -->
     CREATE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx ON ${myuniversity}_${mymodule}.${table.tableName}
-    (left(${indexes.getFinalSqlExpression(table.tableName)},600))
+    (${indexes.getFinalTruncatedSqlExpression(table.tableName)})
      <#if indexes.whereClause??> ${indexes.whereClause};<#else>;</#if>
     <#else>
     DROP INDEX IF EXISTS ${table.tableName}_${indexes.fieldName}_idx;
@@ -11,12 +12,13 @@
     </#list>
   </#if>
 
-  <#-- Create / Drop unique indexes -->
+  <#-- Create / Drop unique btree indexes -->
   <#if table.uniqueIndex??>
     <#list table.uniqueIndex as indexes>
     <#if indexes.tOps.name() == "ADD">
+    <#-- Do not truncate the value using left(..., 600) -- use complete value for uniqueness check -->
     CREATE UNIQUE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx_unique ON ${myuniversity}_${mymodule}.${table.tableName}
-    (left(${indexes.getFinalSqlExpression(table.tableName)},600))
+    (${indexes.getFinalSqlExpression(table.tableName)})
      <#if indexes.whereClause??> ${indexes.whereClause};<#else>;</#if>
     <#else>
     DROP INDEX IF EXISTS ${table.tableName}_${indexes.fieldName}_idx_unique;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -343,8 +343,8 @@ public class SchemaMakerTest {
 
     // by default all indexes are wrapped with lower/f_unaccent
     // except full text which only obeys f_unaccent
-    assertThat(ddl, containsString("(left(lower(f_unaccent(jsonb->>'id')),600))"));
-    assertThat(ddl, containsString("(left(lower(f_unaccent(jsonb->>'name')),600))"));
+    assertThat(ddl, containsString("(left(lower(f_unaccent(jsonb->>'title')),600))"));  // index
+    assertThat(ddl, containsString("(lower(f_unaccent(jsonb->>'name')))"));             // unique index
     assertThat(ddl, containsString("((lower(f_unaccent(jsonb->>'type')))text_pattern_ops)"));
     assertThat(ddl, containsString("GIN((lower(f_unaccent(jsonb->>'title')))gin_trgm_ops)"));
     assertThat(ddl, containsString("GIN(to_tsvector('simple', f_unaccent(jsonb->>'title')))"));

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/test_indexes.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/test_indexes.json
@@ -4,7 +4,7 @@
       "tableName": "item",
       "index": [
         {
-          "fieldName": "id",
+          "fieldName": "title",
           "tOps": "ADD"
         }
       ],


### PR DESCRIPTION
Merge pull request #592 from folio-org/RMB-540-unique-index-truncation