### PR TITLE
Return with 500 status when there is an Exception in RestVerticle.route

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -357,7 +357,7 @@ public class RestVerticle extends AbstractVerticle {
    * @param regex2Pattern  create a map of regular expression to url path
    * @param rc  RoutingContext of this URL
    */
-  private void route(MappedClasses mappedURLs, Set<String> urlPaths, Map<String, Pattern> regex2Pattern,
+  void route(MappedClasses mappedURLs, Set<String> urlPaths, Map<String, Pattern> regex2Pattern,
       RoutingContext rc) {
     long start = System.nanoTime();
     try {
@@ -564,6 +564,7 @@ public class RestVerticle extends AbstractVerticle {
       }
     } catch (Exception e) {
       log.error(e.getMessage(), e);
+      endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });
     }
   }
 
@@ -841,7 +842,7 @@ public class RestVerticle extends AbstractVerticle {
     }
   }
 
-  private void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message, boolean[] isValid) {
+  void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message, boolean[] isValid) {
     if (isValid[0]) {
       HttpServerResponse response = rc.response();
       if (!response.closed()) {

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -5,19 +5,18 @@ import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.oneOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.folio.rest.jaxrs.model.Book;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
 
 class RestVerticleTest {
 
@@ -149,5 +148,19 @@ class RestVerticleTest {
     Book book = new Book();
     RestVerticle.populateMetaData(book, null, null);
     assertThat(book.getMetadata(), is(nullValue()));
+  }
+
+  @Test
+  void routeExceptionReturns500() {
+    class MyRestVerticle extends RestVerticle {
+      public int status = -1;
+      @Override
+      void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message, boolean[] isValid) {
+        this.status = status;
+      }
+    };
+    MyRestVerticle myRestVerticle = new MyRestVerticle();
+    myRestVerticle.route(null, null, null, null);
+    assertThat(myRestVerticle.status, is(500));
   }
 }


### PR DESCRIPTION
The current implementation logs the exception but doesn't return to the calling client.