### PR TITLE
Add Test for fulltext, special characters in CQL to SQL

### DIFF
--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -942,6 +942,43 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     logger.fine("basicFT: " + testcase + " OK ");
   }
 
+  /**
+   * Isolated fulltext search tests for special characters.
+   *
+   * The use of a single equal operator '=' results in a fulltext search.
+   * Additional characters are tested to ensure that they do not cause any problems.
+   *.
+   * This uses www, xxx, yyy, and zzz to explicitly avoid potential stop-words.
+   *
+   * @param testcase conditions expected to pass.
+   */
+  @Test
+  @Parameters({
+    "text='text' # a; b; c; d; e; f",
+    "text='text without www' # a",
+    "text='text with' # b; c; d; e; f",
+    "text='text with xxx-yyy' # b",
+    "text='text with xxx-' # c",
+    "text='text with xxx' # c",
+    "text='text with yyy' # d",
+    "text='text with -yyy' # d",
+    "text='text with zzz' # e; f",
+    "text='text with zzz\\?\\*\\\\‘’‛′＇ŉ&' # f",
+    "text='\" text with zzz' # e; f",
+    "text='\"text with zzz\"' # e; f",
+    "text='\\'text with zzz\\'' # e; f",
+    "text='xxx test with' # ",  // if order is ignored, then should instead find "c".
+    "text='xxx- test with' # ", // if order is ignored, then should instead find "c".
+    "text='test xxx- with' # "  // if order is ignored, then should instead find "c".
+  })
+  public void specialFT(String testcase)
+    throws IOException, FieldException, ServerChoiceIndexesException {
+    logger.info("specialFT: " + testcase);
+    CQL2PgJSON aCql2pgJson = new CQL2PgJSON("instances.jsonb");
+    select(aCql2pgJson, "special-fulltext.sql", testcase);
+    logger.info("specialFT: " + testcase + " OK ");
+  }
+
   @Test
   @Parameters({
     // email works different, no need to test here. See basicFT()

--- a/cql2pgjson/src/test/resources/special-fulltext.sql
+++ b/cql2pgjson/src/test/resources/special-fulltext.sql
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS instances;
+CREATE TABLE instances (id text PRIMARY KEY, jsonb JSONB NOT NULL);
+INSERT INTO instances (id, jsonb) VALUES
+  ('a', '{"name":"a","text":"text without www"}'),
+  ('b', '{"name":"b","text":"text with xxx-yyy"}'),
+  ('c', '{"name":"c","text":"text with xxx-"}'),
+  ('d', '{"name":"d","text":"text with -yyy"}'),
+  ('e', '{"name":"e","text":"text with zzz?"}'),
+  ('f', '{"name":"f","text":"text with zzz?*‘’‛′＇ŉ&"}');
+


### PR DESCRIPTION
This is a small set of tests written to expect certain behavior by the fulltext search.

While investigating UIREQ-401, I discovered that the behavior of the fulltext search has different behavior based on the version of the raml module builder. It appears that when raml module builder was recently updated (see below), this behavior changed.

We don’t yet have test coverage in this module to help identify any potential logic breaking problems for this specific behavior.

The fulltext search for `Externredovisning i icke-noterade`, which will be changed to `a b c-d` for brevity, would yield `... to_tsquery('simple', 'a<->b<->c-d') ...` in circulation.
 The master branch for this module (as of commit a7ac2c9a), would instead yield the following snippet `... replace(
  (to_tsquery('simple', f_unaccent(''',a''')) && to_tsquery('simple', f_unaccent('''b''')) && to_tsquery('simple', f_unaccent('''c-d,''')))::text, '&', '<->'
 )::tsquery ...`.

This is a substantial difference in PostgreSQL fulltext search logic.

There are some areas in the tests where it is unclear to me if the current behavior is correct or not and needs further clarification.

My current question is which of the following should be returned as valid matches for a fulltext search of `a b c-d`:
 1. "a b c-d"
 1. "a b c"
 1. "b a c-d"
 1. "a-b c d"

see: https://issues.folio.org/browse/UIREQ-401
see: https://issues.folio.org/browse/RMB-301
see: https://github.com/folio-org/raml-module-builder/blob/a7ac2c9af785cd6324e5b010ad6b6524c5f9e01d/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java#L807