### PR TITLE
Upgrade vert.x from 3.8.4 to 3.8.5 fixing CompositeFuture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.8.4</version>
+        <version>3.8.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <aspectj.version>1.9.4</aspectj.version>
-    <vertx-version>3.8.4</vertx-version>
+    <vertx-version>3.8.5</vertx-version>
   </properties>
 
   <repositories>

--- a/sample2/pom.xml
+++ b/sample2/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>3.8.4</vertx-version>
+    <vertx-version>3.8.5</vertx-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Release notes: https://github.com/vert-x3/wiki/wiki/3.8.5-Release-Notes
3.8.5 Deprecations and breaking changes: https://github.com/vert-x3/wiki/wiki/3.8.5-Deprecations-and-breaking-changes