### PR TITLE
RMB-562: Switch back to upstream vertx-mysql-postgresql-client

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -140,7 +140,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-mysql-postgresql-client-jasync</artifactId>
-      <version>3.8.2-FOLIO-2</version><!--$NO-MVN-MAN-VER$-->
     </dependency>
     <dependency>
       <groupId>xerces</groupId>


### PR DESCRIPTION
We created our fork 3.8.2-FOLIO-2 with two patches. These patches
have been merged upstream:
https://github.com/vert-x3/vertx-mysql-postgresql-client/pull/136
https://github.com/vert-x3/vertx-mysql-postgresql-client/pull/164
We can drop our fork and switch back to upstream releases.