### PR TITLE
RMB-591

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -1183,12 +1183,11 @@ public final class PgUtil {
       "lower(f_unaccent(jsonb->>'" + column + "')) ";
     String cutWrappedColumn = "left(" + wrappedColumn + ",600) ";
     String countSql = "(" + preparedCql.getSchemaName()
-      + ".count_estimate_optimized('SELECT " + StringEscapeUtils.escapeSql(wrappedColumn)
-      + " AS data_column "
-      + "FROM " + tableName + " "
-      + "WHERE " + StringEscapeUtils.escapeSql(where)
-      + "'))" +
-      " AS count";
+      + ".count_estimate('"
+      + "  SELECT " + StringEscapeUtils.escapeSql(wrappedColumn) + " AS data_column "
+      + "  FROM " + tableName + " "
+      + "  WHERE " + StringEscapeUtils.escapeSql(where)
+      + "')) AS count";
     String sql =
         " WITH "
       + " headrecords AS ("

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -2,47 +2,45 @@ package org.folio.rest.persist;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Map;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.io.IOException;
-
-import javax.ws.rs.core.Response;
-
-import org.apache.commons.lang.StringEscapeUtils;
-import org.folio.rest.tools.utils.ObjectMapperTool;
-import org.folio.rest.tools.utils.OutStream;
-import org.folio.rest.tools.utils.TenantTool;
-import org.folio.rest.tools.utils.ValidationHelper;
-import org.folio.util.UuidUtil;
-import org.folio.cql2pgjson.CQL2PgJSON;
-import org.folio.cql2pgjson.exception.FieldException;
-import org.folio.cql2pgjson.exception.QueryValidationException;
-import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
-import org.folio.rest.jaxrs.model.Diagnostic;
-import org.folio.rest.persist.facets.FacetField;
-import org.folio.rest.persist.facets.FacetManager;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.sql.ResultSet;
 import io.vertx.ext.web.RoutingContext;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.cql2pgjson.exception.QueryValidationException;
+import org.folio.rest.jaxrs.model.Diagnostic;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.ResultInfo;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.persist.facets.FacetField;
+import org.folio.rest.persist.facets.FacetManager;
+import org.folio.rest.tools.utils.ObjectMapperTool;
+import org.folio.rest.tools.utils.OutStream;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.util.UuidUtil;
 import org.z3950.zing.cql.CQLDefaultNodeVisitor;
 import org.z3950.zing.cql.CQLNode;
 import org.z3950.zing.cql.CQLParseException;
@@ -1189,34 +1187,33 @@ public final class PgUtil {
       + "  WHERE " + StringEscapeUtils.escapeSql(where)
       + "')) AS count";
     String sql =
-        " WITH "
-      + " headrecords AS ("
+      " WITH "
+        + " headrecords AS ("
         + "   SELECT jsonb, (" + wrappedColumn + ") AS data_column FROM " + tableName
-      + "   WHERE (" + where + ")"
+        + "   WHERE (" + where + ")"
         + "     AND " + cutWrappedColumn + lessGreater
         + "             ( SELECT " + cutWrappedColumn
-      + "               FROM " + tableName
+        + "               FROM " + tableName
         + "               ORDER BY " + cutWrappedColumn + ascDesc
-      + "               OFFSET " + optimizedSqlSize + " LIMIT 1"
-      + "             )"
+        + "               OFFSET " + optimizedSqlSize + " LIMIT 1"
+        + "             )"
         + "   ORDER BY " + cutWrappedColumn + ascDesc
-      + "   LIMIT " + limit + " OFFSET " + offset
-      + " ), "
-      + " allrecords AS ("
+        + "   LIMIT " + limit + " OFFSET " + offset
+        + " ), "
+        + " allrecords AS ("
         + "   SELECT jsonb, " + wrappedColumn + " AS data_column FROM " + tableName
-      + "   WHERE (" + where + ")"
-      + "     AND (SELECT COUNT(*) FROM headrecords) < " + limit
-      + " )"
-        + " SELECT jsonb, data_column,  " +
-        countSql
-      + "   FROM headrecords"
-      + "   WHERE (SELECT COUNT(*) FROM headrecords) >= " + limit
-      + " UNION"
+        + "   WHERE (" + where + ")"
+        + "     AND (SELECT COUNT(*) FROM headrecords) < " + limit
+        + " )"
+        + " SELECT jsonb, data_column, " + countSql
+        + "   FROM headrecords"
+        + "   WHERE (SELECT COUNT(*) FROM headrecords) >= " + limit
+        + " UNION"
         + " (SELECT jsonb, data_column, " + countSql
-      + "   FROM allrecords"
+        + "   FROM allrecords"
         + "   ORDER BY data_column " + ascDesc
-      + "   LIMIT " + limit + " OFFSET " + offset
-      + " )"
+        + "   LIMIT " + limit + " OFFSET " + offset
+        + " )"
         + " ORDER BY data_column " + ascDesc;
 
     logger.info("optimized SQL generated from CQL: " + sql);

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1871,7 +1871,7 @@ public class PostgresClient {
     }
     if (!wrapper.getWhereClause().isEmpty()) {
       // only do estimation when filter is in use (such as CQL).
-      queryHelper.countQuery = SELECT + "count_estimate_default('"
+      queryHelper.countQuery = SELECT + "count_estimate_optimized('"
         + org.apache.commons.lang.StringEscapeUtils.escapeSql(mainQuery)
         + "')";
     }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1871,7 +1871,7 @@ public class PostgresClient {
     }
     if (!wrapper.getWhereClause().isEmpty()) {
       // only do estimation when filter is in use (such as CQL).
-      queryHelper.countQuery = SELECT + "count_estimate_optimized('"
+      queryHelper.countQuery = SELECT + "count_estimate('"
         + org.apache.commons.lang.StringEscapeUtils.escapeSql(mainQuery)
         + "')";
     }

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
@@ -36,6 +36,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.count_estimate_optimized(query text) RETURNS bigint AS $$
+DECLARE
+count bigint;
+est_count bigint;
+q text;
+BEGIN
+est_count = ${myuniversity}_${mymodule}.count_estimate_smart2(${exactCount}, ${exactCount}, query);
+IF est_count > 4*${exactCount} THEN
+RETURN est_count;
+END IF;
+q = 'SELECT COUNT(*) FROM (' || query || ' LIMIT ${exactCount}) x';
+EXECUTE q INTO count;
+IF count < ${exactCount} THEN
+RETURN count;
+END IF;
+RETURN est_count;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+
+
 -- function used to convert accented strings into unaccented string
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.f_unaccent(text)
   RETURNS text AS
@@ -94,7 +114,7 @@ $$ language 'plpgsql';
 
 -- Concatenate the parameters using space as separator
 create or replace function ${myuniversity}_${mymodule}.concat_space_sql(VARIADIC text[])
-RETURNS text AS $$ select concat_ws(' ', VARIADIC $1); 
+RETURNS text AS $$ select concat_ws(' ', VARIADIC $1);
 $$ LANGUAGE SQL IMMUTABLE PARALLEL SAFE STRICT;
 
 -- For each element of the jsonb_array take the value of field; concatenate them using space as separator

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
@@ -37,9 +37,10 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
 
--- In order not to calculate possibly unnecessary precise count, primarily estimate the count by explain select (see: count_estimate_smart2).
--- If the approximate count is more than desirable exact records counts multiplied by 4 (empiric constant) return it
--- Otherwise calculate precise count and return it if it is less than desirable exact records, otherwise return approximate count
+-- In order not to calculate possibly unnecessary precise count, primarily estimate the count by
+-- explain select (see: count_estimate_smart2). If the approximate count is more than desirable
+-- exact records counts multiplied by 4 (empiric constant) return it. Otherwise return precise
+-- count if it is less than desirable exact records. Otherwise return approximate count.
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.count_estimate(query text) RETURNS bigint AS $$
 DECLARE
   count bigint;
@@ -57,7 +58,7 @@ BEGIN
   END IF;
   RETURN est_count;
 END;
-$$ LANGUAGE plpgsql STABLE;
+$$ LANGUAGE plpgsql STABLE STRICT;
 
 
 -- function used to convert accented strings into unaccented string

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
@@ -42,20 +42,20 @@ $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 -- Otherwise calculate precise count and return it if it is less than desirable exact records, otherwise return approximate count
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.count_estimate(query text) RETURNS bigint AS $$
 DECLARE
-count bigint;
-est_count bigint;
-q text;
+  count bigint;
+  est_count bigint;
+  q text;
 BEGIN
-est_count = ${myuniversity}_${mymodule}.count_estimate_smart2(${exactCount}, ${exactCount}, query);
-IF est_count > 4*${exactCount} THEN
-RETURN est_count;
-END IF;
-q = 'SELECT COUNT(*) FROM (' || query || ' LIMIT ${exactCount}) x';
-EXECUTE q INTO count;
-IF count < ${exactCount} THEN
-RETURN count;
-END IF;
-RETURN est_count;
+  est_count = ${myuniversity}_${mymodule}.count_estimate_smart2(${exactCount}, ${exactCount}, query);
+  IF est_count > 4*${exactCount} THEN
+    RETURN est_count;
+  END IF;
+  q = 'SELECT COUNT(*) FROM (' || query || ' LIMIT ${exactCount}) x';
+  EXECUTE q INTO count;
+  IF count < ${exactCount} THEN
+    RETURN count;
+  END IF;
+  RETURN est_count;
 END;
 $$ LANGUAGE plpgsql STABLE;
 

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl
@@ -36,7 +36,11 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE STRICT;
 
-CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.count_estimate_optimized(query text) RETURNS bigint AS $$
+
+-- In order not to calculate possibly unnecessary precise count, primarily estimate the count by explain select (see: count_estimate_smart2).
+-- If the approximate count is more than desirable exact records counts multiplied by 4 (empiric constant) return it
+-- Otherwise calculate precise count and return it if it is less than desirable exact records, otherwise return approximate count
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.count_estimate(query text) RETURNS bigint AS $$
 DECLARE
 count bigint;
 est_count bigint;
@@ -53,7 +57,7 @@ RETURN count;
 END IF;
 RETURN est_count;
 END;
-$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+$$ LANGUAGE plpgsql STABLE;
 
 
 -- function used to convert accented strings into unaccented string

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/LoadGeneralFunctions.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/LoadGeneralFunctions.java
@@ -12,7 +12,7 @@ public class LoadGeneralFunctions {
       String sql = IOUtils.toString(
         LoadGeneralFunctions.class.getClassLoader().getResourceAsStream("templates/db_scripts/general_functions.ftl"), "UTF-8");
       sql = sql.replace("${myuniversity}_${mymodule}.", rep);
-      sql = sql.replace("${exactCount}", "100");
+      sql = sql.replace("${exactCount}", "1000");
       postgresClient.getClient().update(sql, context.asyncAssertSuccess(reply -> async.complete()));
     } catch (IOException ex) {
       context.fail(ex);


### PR DESCRIPTION
* Always return some estimated totalRecords value for optimized get sql: PgUtil.getWithOptimizedSql.
* No longer use SQL FUNCTION count_estimate_default. It may take long for full text queries when running `SELECT COUNT(*) ... LIMIT 1000`. Instead take the estimation of Postgres' EXPLAIN. Only if that estimation is < 4000 run `SELECT COUNT(*) ... LIMIT 1000`.
* Change ${exactCount} used in unit testing from 100 to 1000 in LoadGeneralFunctions.java. This is required to make PostgresClientIT.getCQLWrapperJsonbField succeed. 1000 is the default: https://github.com/folio-org/raml-module-builder/blob/v29.4.0/dbschema/src/main/java/org/folio/rest/persist/ddlgen/Schema.java#L15