### PR TITLE
RMB-590: persist schema.json in rmb_internal

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -199,7 +199,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -243,8 +243,8 @@ public class TenantAPI implements Tenant {
         return pc.runSQLFile(sqlFile, true);
       } catch (IOException e) {
         throw new UncheckedIOException(e);
-      } catch (TemplateException e) {
-        throw new RuntimeException(e);
+      } catch (TemplateException e) {  // checked exception from main.tpl parsing
+        throw new IllegalArgumentException(e);
       }
     })
     .map(failedStatements -> {

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3341,6 +3341,21 @@ public class PostgresClient {
    *
    * @param sqlFile - string of sqls with executable statements
    * @param stopOnError - stop on first error
+   * @return Future with list of statements that failed; the list may be empty
+   */
+  public Future<List<String>> runSQLFile(String sqlFile, boolean stopOnError) {
+    Promise<List<String>> promise = Promise.promise();
+    runSQLFile(sqlFile, stopOnError, promise.future());
+    return promise.future();
+  }
+
+  /**
+   * Will connect to a specific database and execute the commands in the .sql file
+   * against that database.<p />
+   * NOTE: NOT tested on all types of statements - but on a lot
+   *
+   * @param sqlFile - string of sqls with executable statements
+   * @param stopOnError - stop on first error
    * @param replyHandler - the handler's result is the list of statements that failed; the list may be empty
    */
   public void runSQLFile(String sqlFile, boolean stopOnError,

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -29,6 +29,7 @@ public class SchemaMaker {
   private String newVersion;
   private String rmbVersion;
   private Schema schema;
+  private String schemaJson = "{}";
 
   /**
    * @param onTable
@@ -91,6 +92,8 @@ public class SchemaMaker {
     //version, to check if core rmb scripts need updating due to an update
     templateInput.put("rmbVersion", this.rmbVersion);
 
+    templateInput.put("schemaJson", this.getSchemaJson());
+
     this.schema.setup();
 
     templateInput.put("tables", this.schema.getTables());
@@ -149,5 +152,13 @@ public class SchemaMaker {
 
   public void setSchema(Schema schema) {
     this.schema = schema;
+  }
+
+  public String getSchemaJson() {
+    return schemaJson;
+  }
+
+  public void setSchemaJson(String schemaJson) {
+    this.schemaJson = schemaJson;
   }
 }

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
@@ -198,4 +198,7 @@ END $$;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA ${myuniversity}_${mymodule} TO ${myuniversity}_${mymodule};
 
 UPDATE ${myuniversity}_${mymodule}.rmb_internal
-  SET jsonb = jsonb || '{"rmbVersion": "${rmbVersion}", "moduleVersion": "${newVersion}"}'::jsonb;
+  SET jsonb = jsonb || jsonb_build_object(
+    'rmbVersion', '${rmbVersion}',
+    'moduleVersion', '${newVersion}',
+    'schemaJson', $mainftl$${schemaJson}$mainftl$);

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -1984,6 +1984,12 @@ public class PostgresClientIT {
     postgresClient().execute(null, "SELECT 1", list1JsonArray(), context.asyncAssertFailure());
   }
 
+  // see RunSQLIT.java for more tests
+  @Test
+  public void runSQLNull(TestContext context) throws Exception {
+    postgresClient().runSQLFile(null, false).onComplete(context.asyncAssertFailure());
+  }
+
   private PostgresClient createNumbers(TestContext context, int ...numbers) {
     String schema = PostgresClient.convertToPsqlStandard(TENANT);
     execute(context, "DROP TABLE IF EXISTS numbers CASCADE;");

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,11 @@
         <version>${junit-jupiter-version}</version>
       </dependency>
       <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>3.3.3</version>
+      </dependency>
+      <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
         <version>2.29.1</version>
@@ -177,14 +182,14 @@
         <version>5.2.4.Final</version>
       </dependency>
       <dependency>
-       <groupId>org.apache.httpcomponents</groupId>
-       <artifactId>httpclient</artifactId>
-       <version>4.5.2</version>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.2</version>
       </dependency>
       <dependency>
-       <groupId>org.folio.okapi</groupId>
-       <artifactId>okapi-common</artifactId>
-       <version>2.35.0</version>
+        <groupId>org.folio.okapi</groupId>
+        <artifactId>okapi-common</artifactId>
+        <version>2.35.0</version>
       </dependency>
 
     </dependencies>

--- a/postgres-runner/pom.xml
+++ b/postgres-runner/pom.xml
@@ -44,7 +44,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Write schema.json into rmb_internal.jsonb->>'schemaJson'
at the end of a module's tenant install or tenant upgrade.

These methods have been futurized:
* TenantAPI.postTenant
* PostgresClient.runSQLFile