### PR TITLE
RMB-607: ${myuniversity}_${mymodule}.gin_trgm_ops

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
@@ -170,7 +170,8 @@ BEGIN
 END $$;
 
 -- Fix functions calls with "public." in indexes https://issues.folio.org/browse/RMB-583
--- All functions have been moved from public schema into ${myuniversity}_${mymodule} schema.
+-- All functions (except functions of Postgres extensions) have been moved
+-- from public schema into ${myuniversity}_${mymodule} schema.
 -- https://github.com/folio-org/raml-module-builder/commit/872c1f80da4c8d49e6836ca9221f637dc5e7420b
 DO $$
 DECLARE
@@ -187,8 +188,9 @@ BEGIN
   LOOP
     newindexdef := regexp_replace(i.indexdef,
       -- \m = beginning of a word, \M = end of a word
-      '\mpublic.(f_unaccent|gin_trgm_ops|concat_space_sql|concat_array_object_values|concat_array_object)\M',
-      '${myuniversity}_${mymodule}.\1');
+      '\mpublic\.(f_unaccent|concat_space_sql|concat_array_object_values|concat_array_object)\M',
+      '${myuniversity}_${mymodule}.\1',
+      'g');
     IF newindexdef <> i.indexdef THEN
       EXECUTE format('DROP INDEX %I.%I', i.schemaname, i.indexname);
       EXECUTE newindexdef;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
@@ -342,7 +342,8 @@ public class SchemaMakerIT extends PostgresClientITBase {
   @Test
   public void replacePublicSchemaFunctions(TestContext context) throws InterruptedException {
     runSchema(context, TenantOperation.CREATE, "schema.json");
-    String indexdef = "CREATE INDEX foo ON " + schema + ".test_tenantapi USING btree (public.f_unaccent((jsonb ->> 'foo'::text)))";
+    String indexdef = "CREATE INDEX foo ON " + schema + ".test_tenantapi USING btree "
+        + "(COALESCE(public.f_unaccent((jsonb ->> 'foo'::text)), public.f_unaccent((jsonb ->> 'bar'::text))))";
     String sql = "CREATE OR REPLACE FUNCTION public.f_unaccent(text) RETURNS text AS 'SELECT $1' LANGUAGE sql;"
         + "UPDATE " + schema + ".rmb_internal SET jsonb = jsonb || '{\"rmbVersion\": \"29.1.0\"}'::jsonb;"
         + indexdef;


### PR DESCRIPTION
No longer incorrectly replace `public.gin_trgm_ops` by `${myuniversity}_${mymodule}.gin_trgm_ops`.
Replace all public.* occurrence, not only the first one, and add unit test for this.