### PR TITLE
RMB-569: Upgrade using schema.json comparison

### DIFF
--- a/dbschema/src/main/java/org/folio/rest/persist/ddlgen/ForeignKeys.java
+++ b/dbschema/src/main/java/org/folio/rest/persist/ddlgen/ForeignKeys.java
@@ -129,7 +129,8 @@ public class ForeignKeys extends Field {
     return "ForeignKeys [tableAlias=" + tableAlias + ", targetTable=" + targetTable
         + ", targetTableAlias=" + targetTableAlias
         + ", fieldName=" + fieldName
-        + (targetPath == null ? "" : "targetPath=" + targetPath)
+        + (targetPath == null ? "" : ", targetPath=" + targetPath)
+        + ", tOps=" + gettOps()
         + "]";
   }
 

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -16,8 +16,8 @@
   </#if>
 
   <#-- Create / Drop foreign keys function which pulls data from json into the created foreign key columns -->
-  <#if table.foreignKeys??>
-    <#-- foreign key list has at least one entry, create / re-create the function with the current keys -->
+  <#if (table.foreignKeys!)?filter(key -> key.fieldName?? && key.tOps.name() == "ADD")?size gt 0>
+    <#-- foreign key list has at least one "ADD" entry, create / re-create the function with the current keys -->
     CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_${table.tableName}_references()
     RETURNS TRIGGER AS $$
     BEGIN
@@ -37,7 +37,7 @@
       FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.update_${table.tableName}_references();
 
   <#else>
-    <#-- foreign key list is empty attempt to drop trigger and then function -->
+    <#-- foreign key list is empty, attempt to drop trigger and then function -->
     DROP TRIGGER IF EXISTS update_${table.tableName}_references ON ${myuniversity}_${mymodule}.${table.tableName} CASCADE;
     DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.update_${table.tableName}_references();
   </#if>

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
@@ -87,7 +87,11 @@ REVOKE CREATE ON SCHEMA public FROM PUBLIC;
       FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_id_in_jsonb();
   <#else>
     DROP TABLE IF EXISTS ${myuniversity}_${mymodule}.${table.tableName} CASCADE;
+    <#if table.auditingTableName??>
     DROP TABLE IF EXISTS ${myuniversity}_${mymodule}.${table.auditingTableName} CASCADE;
+    </#if>
+    -- drop function that updates foreign key fields
+    DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.update_${table.tableName}_references();
   </#if>
 
   <#if table.mode != "delete">

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -18,6 +18,7 @@ import org.folio.rest.jaxrs.model.Book;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.ddlgen.Schema;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
@@ -315,7 +316,7 @@ public class TenantAPIIT {
   private void postWithSqlFileException(TestContext context, Class<? extends Exception> exceptionClass) {
     TenantAPI tenantAPI = new TenantAPI() {
       @Override
-      public String sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity)
+      public String sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity, Schema previousSchema)
           throws IOException, TemplateException {
         switch (exceptionClass.getName()) {
         case "java.io.IOException": throw new IOException();

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/client/HttpModuleClient2Test.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/client/HttpModuleClient2Test.java
@@ -1,5 +1,8 @@
 package org.folio.rest.tools.client;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
@@ -131,6 +134,7 @@ public class HttpModuleClient2Test {
 
     CompletableFuture<Response> cf = httpModuleClient2.request("/test");
     Response response = cf.get(5, TimeUnit.SECONDS);
-    context.assertTrue(response.error.getString("errorMessage").startsWith("Connection refused"));
+    // don't compare against locale dependent error message
+    assertThat(response.getError().encodePrettily(), containsString("" + port2));
   }
 }

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey1.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey1.json
@@ -1,0 +1,28 @@
+{
+  "tables": [
+    {
+      "tableName": "fka",
+      "fromModuleVersion": "18.2.5",
+      "foreignKeys": [
+        {
+          "fieldName":        "refa",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        }
+      ]
+    },
+    {
+      "tableName": "fkb",
+      "fromModuleVersion": "18.2.5",
+      "foreignKeys": [
+        {
+          "fieldName":        "reff",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        }
+      ]
+    }
+  ]
+}

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey2.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey2.json
@@ -1,0 +1,46 @@
+{
+  "tables": [
+    {
+      "tableName": "fka",
+      "fromModuleVersion": "18.2.5",
+      "foreignKeys": [
+        {
+          "fieldName":        "refb",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        },
+        {
+          "fieldName":        "refc",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        }
+      ]
+    },
+    {
+      "tableName": "fkb",
+      "fromModuleVersion": "18.2.5",
+      "foreignKeys": [
+        {
+          "fieldName":        "refd",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        },
+        {
+          "fieldName":        "refe",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        },
+        {
+          "fieldName":        "reff",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias":       "ref"
+        }
+      ]
+    }
+  ]
+}

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/indexUpgrade.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/indexUpgrade.json
@@ -1,6 +1,18 @@
 {
   "tables": [
     {
+      "tableName": "test_tenantapi",
+      "fromModuleVersion": "18.2.5",
+      "foreignKeys": [
+        {
+          "fieldName": "refField",
+          "targetTable":      "ref",
+          "targetTableAlias": "ref",
+          "tableAlias": "ref"
+        }
+      ]
+    },
+    {
       "tableName": "tablea",
       "index": [
         {


### PR DESCRIPTION
* SchemaMaker: new previousSchema variable, can trigger deletion of tables and foreign keys
* foreign_keys.ftl: Only create foreign key trigger if an "ADD" foreign key entry exists
* foreign_keys.ftl: Don't drop auditing table when auditing table name is null
* SchemaMakerTest: Extract duplicate code into schema and schemaMaker methods.
* TenantAPI: Use schema.json comparison for upgrades.