### PR TITLE
RMB-622: PgExceptionUtil.getMessage: Compose a message of all fields

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -3,7 +3,7 @@
 These are notes to assist upgrading to newer versions.
 See the [NEWS](../NEWS.md) summary of changes for each version.
 
-* [Version 30.0](#version-30)
+* [Version 30.0](#version-300)
 * [Version 29.5](#version-295)
 * [Version 29.2](#version-292)
 * [Version 29](#version-29)
@@ -38,9 +38,10 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
     connection, use `PostgresClient.startTx()`. For modules that wish to use
     vertx-pg-client directly, `PostgresClient.getConnection`  is offered -
     it returns `PgConnection` from the pool that is managed by `PostgresClient`.
-  * Exceptions thrown by new client is `io.vertx.pgclient.PgException`. Was
-    `com.github.jasync.sql.db.postgresql.exceptions.GenericDatabaseException`
-    before. The `getMessage()` only contains message! Not details, code.
+  * Replace `exception.getMessage` by `PgExceptionUtil.getMessage(exception)`
+    to mimic the old `GenericDatabaseException.getMessage(e)` because the
+    new `PgException.getMessage(e)` returns the message field only, no SQL error code,
+    no detail.
   * `PgExceptionFacade.getTable` removed.
   * `PgExceptionFacade.getIndex` removed.
   * `PgExceptionFacade.selectStream` without SQLConnection has been

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionFacade.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionFacade.java
@@ -46,6 +46,13 @@ public class PgExceptionFacade {
   }
 
   /**
+   * @return the severity ('S' field), or empty String if not available or unknown
+   */
+  public String getSeverity() {
+    return fields.getOrDefault('S', "");
+  }
+
+  /**
    * @return the error message ('M' field), or empty String if not available or unknown
    */
   public String getMessage() {

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionUtil.java
@@ -103,6 +103,39 @@ public final class PgExceptionUtil {
     }
   }
 
+  /**
+   * Compose a message of all PgException fields.
+   *
+   * <p>Example output:
+   *
+   * <p>{@code ErrorMessage(fields=[(Severity, ERROR), (SQLSTATE, 23505),
+   *     (Message, duplicate key value violates unique constraint "t_text_key"),
+   *     (Detail, Key (text)=(a) already exists.)]}
+   *
+   * <p>This is similar to {@link com.github.jasync.sql.db.postgresql.exceptions.GenericDatabaseException#getMessage()
+   * GenericDatabaseException#getMessage()} that returns
+   *
+   * <p>{@code ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 23505),
+   *     (Message, duplicate key value violates unique constraint "t_text_key"),
+   *     (Detail, Key (text)=(a) already exists.), (s, public), (t, t), (n, t_text_key),
+   *     (File, nbtinsert.c), (Line, 427), (Routine, _bt_check_unique)])}
+   *
+   * <p>Use this method where PgException.getMessage() returning the message field only is not sufficient.
+   *
+   * @return all PgException fields if throwable is a PgException, throwable.getMessage() otherwise
+   */
+  public static String getMessage(Throwable throwable) {
+    if (!(throwable instanceof PgException)) {
+      return throwable.getMessage();
+    }
+    PgException e = (PgException) throwable;
+    return "ErrorMessage(fields=["
+        + "(Severity, " + e.getSeverity() + "), "
+        + "(SQLSTATE, " + e.getCode() + "), "
+        + "(Message, " + e.getMessage() + "), "
+        + "(Detail, " + e.getDetail() + ")])";
+  }
+
   public static Map<Character, String> getBadRequestFields(Throwable throwable) {
     if (!(throwable instanceof PgException)) {
       return null;
@@ -110,6 +143,7 @@ public final class PgExceptionUtil {
     Map<Character, String> map = new HashMap<>();
     map.put('M', ((PgException) throwable).getMessage());
     map.put('D', ((PgException) throwable).getDetail());
+    map.put('S', ((PgException) throwable).getSeverity());
     map.put('C', ((PgException) throwable).getCode());
     return map;
   }
@@ -120,6 +154,6 @@ public final class PgExceptionUtil {
    * @return
    */
   public static PgException createPgExceptionFromMap(Map<Character, String> map) {
-    return new PgException(map.get('M'), null, map.get('C'), map.get('D'));
+    return new PgException(map.get('M'), map.get('S'), map.get('C'), map.get('D'));
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgExceptionFacadeTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgExceptionFacadeTest.java
@@ -1,0 +1,33 @@
+package org.folio.rest.persist;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Map;
+
+import io.vertx.pgclient.PgException;
+import org.junit.jupiter.api.Test;
+
+public class PgExceptionFacadeTest {
+  @Test
+  void getter() {
+    PgExceptionFacade f = new PgExceptionFacade(new PgException("msg", "FINAL WARNING", "22P02", "very bad"));
+    assertThat(f.getMessage(), is("msg"));
+    assertThat(f.getSeverity(), is("FINAL WARNING"));
+    assertThat(f.getSqlState(), is("22P02"));
+    assertThat(f.getDetail(), is("very bad"));
+    Map<Character,String> fields = f.getFields();
+    assertThat(fields.get('M'), is("msg"));
+    assertThat(fields.get('S'), is("FINAL WARNING"));
+    assertThat(fields.get('C'), is("22P02"));
+    assertThat(fields.get('D'), is("very bad"));
+  }
+
+  @Test
+  void isInvalidTextRepresentation() {
+    PgExceptionFacade f = new PgExceptionFacade(new PgException(null, null, "22P02", null));
+    assertThat(f.isInvalidTextRepresentation(), is(true));
+    PgExceptionFacade f2 = new PgExceptionFacade(new PgException(null, null, "22P03", null));
+    assertThat(f2.isInvalidTextRepresentation(), is(false));
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgExceptionUtilTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgExceptionUtilTest.java
@@ -3,7 +3,7 @@ package org.folio.rest.persist;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.pgclient.PgException;
 import java.util.HashMap;
@@ -81,7 +81,7 @@ public class PgExceptionUtilTest {
   @Test
   public void testBadUUID() {
     try {
-      UUID t = UUID.fromString("bad-uid");
+      UUID.fromString("bad-uid");
     } catch (Exception ex) {
       String actual = PgExceptionUtil.badRequestMessage(ex);
       assertThat(actual, is("Invalid UUID string: bad-uid"));
@@ -89,9 +89,23 @@ public class PgExceptionUtilTest {
   }
 
   @Test
+  public void getMessageOther() {
+    assertThat(PgExceptionUtil.getMessage(new RuntimeException("foo")), is("foo"));
+  }
+
+  @Test
+  public void getMessagePgException() {
+    PgException e = new PgException("my message", "my severity", "00742", "error sits in front of the screen");
+    assertThat(PgExceptionUtil.getMessage(e),
+        is("ErrorMessage(fields=[(Severity, my severity), (SQLSTATE, 00742), " +
+            "(Message, my message), (Detail, error sits in front of the screen)])"));
+  }
+
+  @Test
   public void testCreatePgExceptionFromMap() {
     Map<Character, String> fields1 = new HashMap<>();
     fields1.put('M', "valueM");
+    fields1.put('S', "valueS");
     fields1.put('D', "ValueD");
     fields1.put('C', "ValueC");
 


### PR DESCRIPTION
Use all fields: message, detail, SQL error code, severity.
PgException.getMessage() only returns the message field.