### PR TITLE
Upgrade Vert.x 3.9.1; mention vertx-stack-depchain, jackson

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -58,6 +58,10 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
   JSON files, otherwise GenerateRunner/SchemaDereferencer will fail with
   InvocationTargetException/DecodeException "Failed to decode".
   Hint: Use `for i in *; do jq empty $i || echo $i; done` to list invalid JSONs.
+* Update Vert.x to 3.9.1, consider using
+  [Bill of Materials (Maven BOM)](https://github.com/vert-x3/vertx-stack#bills-of-materials-maven-bom)
+  for io.vertx, com.fasterxml.jackson.core and com.fasterxml.jackson.dataformat dependencies. Remove jackson-databind
+  dependency from pom.xml if module doesn't use it directly.
 
 ## Version 29.5
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,35 +64,9 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.1</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <!-- jackson security update because of jackson-databind:
-             https://issues.folio.org/browse/FOLIO-2341
-             https://issues.folio.org/browse/RMB-504
-	     TODO: Remove these jackson dependencies when vertx-stack-depchain
-	     contains jackson-databind >= 2.10.0
-      -->
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.10.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.10.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.10.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>2.10.1</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -19,7 +19,7 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <aspectj.version>1.9.4</aspectj.version>
-    <vertx-version>3.8.5</vertx-version>
+    <vertx-version>3.9.1</vertx-version>
   </properties>
 
   <repositories>

--- a/sample2/pom.xml
+++ b/sample2/pom.xml
@@ -18,7 +18,7 @@
     <maven.compiler.source>1.7</maven.compiler.source>
     <maven.compiler.target>1.7</maven.compiler.target>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <vertx-version>3.8.5</vertx-version>
+    <vertx-version>3.9.1</vertx-version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Upgrade Vert.x to the latest released version 3.9.1 that contains several
bug fixes:
* https://github.com/vert-x3/wiki/wiki/3.9.1-Release-Notes
* https://github.com/vert-x3/wiki/wiki/3.9.1-Deprecations-and-breaking-changes

Add to upgrading notes
* Upgrade to Vert.x 3.9.1
* Using vertx-stack-depchain
* Dropping unused jackson-databind dependency