### PR TITLE
RMB-632: Tenant upgrade fails on foreignKey targetPath

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -127,6 +127,14 @@ public class SchemaMaker {
   }
 
   /**
+   * @return fieldName is the same and not null, or fieldPath is the same and not null
+   */
+  static boolean sameForeignKey(ForeignKeys a, ForeignKeys b) {
+    return (a.getFieldName() != null && a.getFieldName().equals(b.getFieldName())) ||
+        (a.getFieldPath() != null && a.getFieldPath().equals(b.getFieldPath()));
+  }
+
+  /**
    * @return the tables of schema plus tables to delete (tables that exist in previousSchema but not in schema);
    *   add foreign keys to delete (those that exist in previousSchema but not in schema).
    *   Nothing to do for indexes because rmb_internal_index handles them.
@@ -155,8 +163,8 @@ public class SchemaMaker {
           newTable.getForeignKeys() == null ? Collections.emptyList() : newTable.getForeignKeys();
       List<ForeignKeys> allForeignKeys = new ArrayList<>(newForeignKeys);
       oldForeignKeys.forEach(oldForeignKey -> {
-        if (newForeignKeys.stream().anyMatch(newForeignKey ->
-            oldForeignKey.getFieldName().equals(newForeignKey.getFieldName()))) {
+        if (newForeignKeys.stream()
+            .anyMatch(newForeignKey -> sameForeignKey(oldForeignKey, newForeignKey))) {
           // an entry for oldForeignKey exists in newForeignKeys, nothing to do
           return;
         }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import org.folio.rest.tools.utils.ObjectMapperTool;
 import org.folio.util.ResourceUtil;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -217,7 +218,6 @@ public class SchemaMakerTest {
       "select * from file_start;"));
   }
 
-
   @Test
   public void delete() throws IOException, TemplateException {
 
@@ -363,5 +363,34 @@ public class SchemaMakerTest {
     assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refd")));
     assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refe")));
     assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS reff")));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "a,  , a,  , true",
+    " , b,  , b, true",
+    "a, b, a, b, true",
+    "a, b, c, d, false",
+    "a, a, b, b, false",
+    "a, b, b, a, false",
+    " ,  ,  ,  , false",
+  })
+  public void sameForeignKeyNullsString(String fieldNameA, String fieldPathA,
+                                        String fieldNameB, String fieldPathB, boolean expected) {
+    ForeignKeys a = new ForeignKeys();
+    if (fieldNameA != null) {
+      a.setFieldName(fieldNameA);
+    }
+    if (fieldPathA != null) {
+      a.setFieldPath(fieldPathA);
+    }
+    ForeignKeys b = new ForeignKeys();
+    if (fieldNameB != null) {
+      b.setFieldName(fieldNameB);
+    }
+    if (fieldPathB != null) {
+      b.setFieldPath(fieldPathB);
+    }
+    assertThat(SchemaMaker.sameForeignKey(a, b), is(expected));
   }
 }


### PR DESCRIPTION
If fieldName is null compare targetPath to match old foreignKey and new foreignKey entry.
This avoids any NullPointerException.