### PR TITLE
RMB-634: Fix getConnectionConfig test assumptions

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -254,12 +254,7 @@ public class PostgresClientIT {
     c1.closeClient(context.asyncAssertSuccess());
     c2.closeClient(context.asyncAssertSuccess());
     context.assertEquals(c1, c2, "same instance");
-
-    JsonObject config1 = c1.getConnectionConfig();
-    context.assertEquals("{\"username\":\"tenant_raml_module_builder\",\"password\":\"tenant\","
-        +"\"host\":\"127.0.0.1\",\"port\":6000,\"database\":\"postgres\"}", config1.encode());
   }
-
 
   @Test
   public void getNewInstance(TestContext context) {

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collector;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.pgclient.PgConnectOptions;
@@ -40,6 +41,7 @@ import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.RowDesc;
 import org.folio.rest.persist.facets.FacetField;
 import org.folio.rest.persist.helpers.LocalRowSet;
+import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.util.ResourceUtil;
 import org.folio.rest.persist.PostgresClient.QueryHelper;
@@ -140,6 +142,22 @@ public class PostgresClientTest {
     assertThat(config.getInteger("port"), is(5433));
     assertThat(config.getString("username"), is("mySchemaName"));
     assertThat(config.getInteger("connectionReleaseDelay"), is(30000));
+  }
+
+  @Test
+  public void getConnectionConfig() throws Exception {
+    try {
+      Envs.setEnv("somehost", 10001, "someusername", "somepassword", "somedatabase");
+      JsonObject json = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
+      assertThat(json.getString("host"), is("somehost"));
+      assertThat(json.getInteger("port"), is(10001));
+      assertThat(json.getString("username"), is("someusername"));
+      assertThat(json.getString("password"), is("somepassword"));
+      assertThat(json.getString("database"), is("somedatabase"));
+    } finally {
+      // restore defaults
+      Envs.setEnv(System.getenv());
+    }
   }
 
   @Test


### PR DESCRIPTION
* Move test from PostgresClientIT to PostgresClientTest because
  it is a unit test that does not require a database connection.

* Set Envs to no longer fail the test when DB_ environment variables
  point to an external database to be used by integration tests.
  Some developers use this to avoid the startup time of embedded
  postgres.

* Use getter of JsonObject instead of JsonObject#encode() that
  changes when the iteration order of the underlying Map changes.