### PR TITLE
RMB-637: Run ANALYZE after index (re-)creation

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -7,6 +7,7 @@
           ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID REFERENCES ${myuniversity}_${mymodule}.${key.targetTable};
         CREATE INDEX IF NOT EXISTS ${table.tableName}_${key.fieldName}_idx
           ON ${myuniversity}_${mymodule}.${table.tableName} (${key.fieldName});
+        INSERT INTO rmb_internal_analyze VALUES ('${table.tableName}');
       <#else>
         ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
           DROP COLUMN IF EXISTS ${key.fieldName} CASCADE;

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/indexes.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/indexes.ftl
@@ -3,7 +3,8 @@
   <#list table.index as indexes>
     DO $do$
     BEGIN
-      PERFORM ${myuniversity}_${mymodule}.rmb_internal_index('${table.tableName}_${indexes.fieldName}_idx', '${indexes.tOps.name()}',
+      PERFORM rmb_internal_index(
+      '${table.tableName}', '${table.tableName}_${indexes.fieldName}_idx', '${indexes.tOps.name()}',
       'CREATE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx ON ${myuniversity}_${mymodule}.${table.tableName} '
       <#-- Truncate using left(..., 600) to fit into the 2712 byte limit of PostgreSQL indexes (600 multi-byte characters) -->
       || $rmb$(${indexes.getFinalTruncatedSqlExpression(table.tableName)})$rmb$
@@ -17,7 +18,8 @@
   <#list table.uniqueIndex as indexes>
     DO $do$
     BEGIN
-      PERFORM ${myuniversity}_${mymodule}.rmb_internal_index('${table.tableName}_${indexes.fieldName}_idx_unique', '${indexes.tOps.name()}',
+      PERFORM rmb_internal_index(
+      '${table.tableName}', '${table.tableName}_${indexes.fieldName}_idx_unique', '${indexes.tOps.name()}',
       'CREATE UNIQUE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx_unique ON ${myuniversity}_${mymodule}.${table.tableName} '
       <#-- Do not truncate the value using left(..., 600) -- use complete value for uniqueness check -->
       || $rmb$(${indexes.getFinalSqlExpression(table.tableName)})$rmb$
@@ -31,7 +33,8 @@
   <#list table.likeIndex as indexes>
     DO $do$
     BEGIN
-      PERFORM ${myuniversity}_${mymodule}.rmb_internal_index('${table.tableName}_${indexes.fieldName}_idx_like', '${indexes.tOps.name()}',
+      PERFORM rmb_internal_index(
+      '${table.tableName}', '${table.tableName}_${indexes.fieldName}_idx_like', '${indexes.tOps.name()}',
       'CREATE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx_like ON ${myuniversity}_${mymodule}.${table.tableName} '
       || $rmb$((${indexes.getFinalSqlExpression(table.tableName)}) text_pattern_ops)$rmb$
       <#if indexes.whereClause??>|| $rmb$ ${indexes.whereClause}$rmb$</#if>);
@@ -43,7 +46,8 @@
   <#list table.ginIndex as indexes>
     DO $do$
     BEGIN
-      PERFORM ${myuniversity}_${mymodule}.rmb_internal_index('${table.tableName}_${indexes.fieldName}_idx_gin', '${indexes.tOps.name()}',
+      PERFORM rmb_internal_index(
+      '${table.tableName}', '${table.tableName}_${indexes.fieldName}_idx_gin', '${indexes.tOps.name()}',
       'CREATE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx_gin ON ${myuniversity}_${mymodule}.${table.tableName} USING GIN '
       || $rmb$((${indexes.getFinalSqlExpression(table.tableName)}) public.gin_trgm_ops)$rmb$
       <#if indexes.whereClause??>|| $rmb$ ${indexes.whereClause}$rmb$</#if>);
@@ -55,7 +59,8 @@
   <#list table.fullTextIndex as indexes>
     DO $do$
     BEGIN
-      PERFORM ${myuniversity}_${mymodule}.rmb_internal_index('${table.tableName}_${indexes.fieldName}_idx_ft', '${indexes.tOps.name()}',
+      PERFORM rmb_internal_index(
+      '${table.tableName}', '${table.tableName}_${indexes.fieldName}_idx_ft', '${indexes.tOps.name()}',
       'CREATE INDEX IF NOT EXISTS ${table.tableName}_${indexes.fieldName}_idx_ft ON ${myuniversity}_${mymodule}.${table.tableName} USING GIN '
       || $rmb$( to_tsvector('simple', ${indexes.getFinalSqlExpression(table.tableName)}) )$rmb$);
     END $do$;


### PR DESCRIPTION
* Collect tables that need ANALYZE in rmb_internal_analyze
* At the end run ANALYZE for all of them

Prepending ${myuniversity}_${mymodule}. is no longer needed
because we set search_path.