### PR TITLE
RMB-555: Upgrade creates duplicate foreign key constraints

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -52,7 +52,7 @@
       BEFORE INSERT OR UPDATE ON ${myuniversity}_${mymodule}.${table.tableName}
       FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.update_${table.tableName}_references();
 
-    -- Remove duplicate foreign key constraints created by RMB before 30.0.3
+    -- Remove duplicate foreign key constraints created by RMB before 30.1.0
     -- https://issues.folio.org/browse/RMB-555
     DO $$
     DECLARE
@@ -60,7 +60,7 @@
       i INT;
     BEGIN
       SELECT jsonb->>'rmbVersion' INTO version FROM rmb_internal;
-      IF version !~ '^(\d\.|1\d\.|2\d\.|30\.0\.0|30\.0\.1|30\.0\.2)' THEN
+      IF version !~ '^(\d\.|1\d\.|2\d\.|30\.0\.)' THEN
         RETURN;
       END IF;
       <#list table.foreignKeys?filter(key -> key.fieldName?? && key.tOps.name() == "ADD") as key>

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/foreign_keys.ftl
@@ -4,7 +4,21 @@
     <#list table.foreignKeys?filter(key -> key.fieldName??) as key>
       <#if key.tOps.name() == "ADD">
         ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
-          ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID REFERENCES ${myuniversity}_${mymodule}.${key.targetTable};
+          ADD COLUMN IF NOT EXISTS ${key.fieldName} UUID;
+        DO $$
+        BEGIN
+          <#-- PostgreSQL doesn't have an "ADD CONSTRAINT IF NOT EXISTS" statement.
+               Reference: https://stackoverflow.com/a/32526723
+               Try to add the constraint and ignore the exception if it already exists.
+          -->
+          BEGIN
+            ALTER TABLE ${table.tableName}
+              ADD CONSTRAINT ${key.fieldName}_${key.targetTable}_fkey
+              FOREIGN KEY (${key.fieldName}) REFERENCES ${key.targetTable};
+          EXCEPTION
+            WHEN duplicate_object OR duplicate_table THEN NULL;
+          END;
+        END $$;
         CREATE INDEX IF NOT EXISTS ${table.tableName}_${key.fieldName}_idx
           ON ${myuniversity}_${mymodule}.${table.tableName} (${key.fieldName});
         INSERT INTO rmb_internal_analyze VALUES ('${table.tableName}');
@@ -16,26 +30,46 @@
     </#list>
   </#if>
 
-  <#-- Create / Drop foreign keys function which pulls data from json into the created foreign key columns -->
+  <#-- Does foreign key list has at least one "ADD" entry? -->
   <#if (table.foreignKeys!)?filter(key -> key.fieldName?? && key.tOps.name() == "ADD")?size gt 0>
-    <#-- foreign key list has at least one "ADD" entry, create / re-create the function with the current keys -->
+
+    <#-- function which pulls data from json into the created foreign key columns -->
     CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_${table.tableName}_references()
     RETURNS TRIGGER AS $$
     BEGIN
-      <#list table.foreignKeys?filter(key -> key.fieldName??) as key>
+      <#list table.foreignKeys?filter(key -> key.fieldName?? && key.tOps.name() == "ADD") as key>
       NEW.${key.fieldName} = ${key.fieldPath};
       </#list>
       RETURN NEW;
     END;
     $$ language 'plpgsql';
 
-    <#-- in update mode try to drop the trigger and re-create (below) since there is no create trigger if not exists -->
+    <#-- in update mode try to drop the trigger and re-create (below) since there is no "CREATE TRIGGER IF NOT EXISTS" -->
     DROP TRIGGER IF EXISTS update_${table.tableName}_references ON ${myuniversity}_${mymodule}.${table.tableName} CASCADE;
 
-    <#-- Create / Drop trigger to call foreign key function -->
+    <#-- Create trigger to call foreign key function -->
     CREATE TRIGGER update_${table.tableName}_references
       BEFORE INSERT OR UPDATE ON ${myuniversity}_${mymodule}.${table.tableName}
       FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.update_${table.tableName}_references();
+
+    -- Remove duplicate foreign key constraints created by RMB before 30.0.3
+    -- https://issues.folio.org/browse/RMB-555
+    DO $$
+    DECLARE
+      version TEXT;
+      i INT;
+    BEGIN
+      SELECT jsonb->>'rmbVersion' INTO version FROM rmb_internal;
+      IF version !~ '^(\d\.|1\d\.|2\d\.|30\.0\.0|30\.0\.1|30\.0\.2)' THEN
+        RETURN;
+      END IF;
+      <#list table.foreignKeys?filter(key -> key.fieldName?? && key.tOps.name() == "ADD") as key>
+      FOR i IN 1..50 LOOP
+        EXECUTE 'ALTER TABLE ${table.tableName} DROP CONSTRAINT IF EXISTS '
+                || '${key.fieldName}_${key.targetTable}_fkey' || i;
+      END LOOP;
+      </#list>
+    END $$;
 
   <#else>
     <#-- foreign key list is empty, attempt to drop trigger and then function -->

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/main.ftl
@@ -175,7 +175,7 @@ DECLARE
 BEGIN
   FOR aname IN SELECT name FROM ${myuniversity}_${mymodule}.rmb_internal_index WHERE remove = TRUE
   LOOP
-    EXECUTE format('DROP INDEX IF EXISTS %s', aname);
+    EXECUTE 'DROP INDEX IF EXISTS ' || aname;
   END LOOP;
 END $$;
 
@@ -202,7 +202,7 @@ BEGIN
       '${myuniversity}_${mymodule}.\1',
       'g');
     IF newindexdef <> i.indexdef THEN
-      EXECUTE format('DROP INDEX %I.%I', i.schemaname, i.indexname);
+      EXECUTE 'DROP INDEX ' || i.indexname;
       EXECUTE newindexdef;
       EXECUTE 'INSERT INTO rmb_internal_analyze VALUES ($1)' USING i.tablename;
     END IF;
@@ -217,7 +217,7 @@ DECLARE
 BEGIN
   FOR t IN SELECT DISTINCT tablename FROM rmb_internal_analyze
   LOOP
-    EXECUTE format('ANALYZE %I', t);
+    EXECUTE 'ANALYZE ' || t;
   END LOOP;
 END $$;
 TRUNCATE rmb_internal_analyze;

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/rmb_internal_index.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/rmb_internal_index.ftl
@@ -12,6 +12,8 @@ DECLARE
   prepareddef text;
 BEGIN
   IF tops = 'DELETE' THEN
+    -- use case insensitive %s, not case sensitive %I
+    -- no SQL injection because the names are hard-coded in schema.json
     EXECUTE format('DROP INDEX IF EXISTS %s', aname);
     EXECUTE 'DELETE FROM ${myuniversity}_${mymodule}.rmb_internal_index WHERE name = $1' USING aname;
     RETURN;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerIT.java
@@ -38,7 +38,8 @@ public class SchemaMakerIT extends PostgresClientITBase {
           tenantOperation, "mod-foo-18.2.3", "mod-foo-18.2.4");
       String json = ResourceUtil.asString("templates/db_scripts/" + filename);
       schemaMaker.setSchema(ObjectMapperTool.getMapper().readValue(json, Schema.class));
-      runSqlFileAsSuperuser(context, schemaMaker.generateDDL());
+      String sql = schemaMaker.generateDDL();
+      runSqlFileAsSuperuser(context, sql);
     } catch (Exception e) {
       context.fail(e);
     }
@@ -224,9 +225,30 @@ public class SchemaMakerIT extends PostgresClientITBase {
     runSchema(context, TenantOperation.CREATE, "compoundIndex.json");
   }
 
+  private int countConstraints(TestContext context) {
+    return selectInteger(context, "SELECT count(*) FROM pg_catalog.pg_constraint"
+        + " WHERE conname LIKE 'holdingsrecordid_holdings_record_fkey%'"
+        + " AND connamespace = (SELECT oid FROM pg_catalog.pg_namespace"
+        + "                     WHERE nspname = 'sometenant_raml_module_builder')");
+  }
+
   @Test
   public void foreignKey(TestContext context) {
     runSchema(context, TenantOperation.CREATE, "schemaInstanceItem.json");
+    // create 2 duplicate constraints
+    String sql = "ALTER TABLE sometenant_raml_module_builder.item"
+        + " ADD CONSTRAINT holdingsRecordId_holdings_record_fkey%d"
+        + " FOREIGN KEY (holdingsRecordId)"
+        + " REFERENCES sometenant_raml_module_builder.holdings_record";
+    executeSuperuser(context, String.format(sql, 1));
+    executeSuperuser(context, String.format(sql, 50));
+    // pretend that the last install/upgrade was made with RMB 29.3.2
+    executeSuperuser(context, "UPDATE sometenant_raml_module_builder.rmb_internal"
+        + " SET jsonb = jsonb || jsonb_build_object('rmbVersion', '29.3.2')");
+    assertThat(countConstraints(context), is(3));
+    // should remove the 2 duplicate constraints
+    runSchema(context, TenantOperation.UPDATE, "schemaInstanceItem.json");
+    assertThat(countConstraints(context), is(1));
   }
 
   private void assertSelectSingle(TestContext context, String sql, String expected) {


### PR DESCRIPTION
No longer create duplicate foreign key constraints on upgrade.

Delete all existing duplicate foreign key constraints that
RMB < 30.0.3 has created.

Replace each case sensitive format() %I placeholder by a
case insensitive form, either %s placeholder or || concatenation,
resulting in identifier downcasing:
https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS