### PR TITLE
RMB-648: Fix hibernate-validator privilege escalation (CVE-2017-7536)

### DIFF
--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -15,7 +15,7 @@
       <artifactId>vertx-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
     </dependency>
     <dependency>
@@ -27,13 +27,17 @@
       <artifactId>validation-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.el</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
     </dependency>
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.20.0-GA</version>
+      <version>3.27.0-GA</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -91,21 +91,9 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.el</groupId>
-      <artifactId>javax.el-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>cql2pgjson</artifactId>
       <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>javax.validation</groupId>
-      <artifactId>validation-api</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
       <dependency>
         <groupId>javax.el</groupId>
         <artifactId>javax.el-api</artifactId>
-        <version>2.2.4</version>
+        <version>3.0.1-b06</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -147,9 +147,14 @@
         <version>1.1.0.Final</version>
       </dependency>
       <dependency>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>5.2.4.Final</version>
+        <version>6.1.5.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>3.0.1-b11</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>


### PR DESCRIPTION
* Upgrade hibernate-validator from 5.2.4.Final to 6.1.5.Final to
  fix CVE-2017-7536:
  https://nvd.nist.gov/vuln/detail/CVE-2017-7536
  https://github.com/advisories/GHSA-xxgp-pcfc-3vgc
  https://hibernate.atlassian.net/browse/HV-1498

* Adjust hibernate-validator groupId, it has moved from
  org.hibernate to org.hibernate.validator

* Update all validation dependencies to latest versions:
  javax.el:javax.el-api, org.javassist:javassist.

* Add org.glassfish:javax.el needed for latest hibernate-validator.

* Remove validation dependencies from domain-models-runtime,
  the transitive dependency via domain-models-api-aspects
  is sufficient.