### PR TITLE
RMB-656: NPE at startup when an OPTIONS endpoint is defined in RAML

### DIFF
--- a/domain-models-api-interfaces/ramls/sample.raml
+++ b/domain-models-api-interfaces/ramls/sample.raml
@@ -129,6 +129,11 @@ traits:
         500:
           body:
             text/plain:
+    options:
+        description: "Preflight CORS for /rmbtests/test"
+        responses:
+          200:
+            description: "Return with appropriate CORS headers"
   /testStream:
     post:
       body:

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/AnnotationGrabber.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/AnnotationGrabber.java
@@ -141,8 +141,7 @@ public class AnnotationGrabber {
           for (int j = 0; j < methodAn.length; j++) {
 
             Class<? extends Annotation> type = methodAn[j].annotationType();
-            //System.out.println("Values of " + type.getName());
-            if (RTFConsts.POSSIBLE_HTTP_METHOD.contains(type.getName())) {
+            if (isPossibleHttpMethod(type.getName())) {
               // put the method - get or post, etc..
               methodObj.put(HTTP_METHOD, type.getName());
             }
@@ -287,6 +286,24 @@ public class AnnotationGrabber {
       }
     }
     return retObject;
+  }
+
+  private static boolean isPossibleHttpMethod(String method) {
+    switch (method) {
+    case "javax.ws.rs.PUT":
+    case "javax.ws.rs.POST":
+    case "javax.ws.rs.DELETE":
+    case "javax.ws.rs.GET":
+    case "javax.ws.rs.OPTIONS":
+    case "javax.ws.rs.HEAD":
+    case "javax.ws.rs.TRACE":
+    case "javax.ws.rs.CONNECT":
+    case "org.folio.rest.jaxrs.resource.support.OPTIONS":
+    case "org.folio.rest.jaxrs.resource.support.PATCH":
+      return true;
+    default:
+      return false;
+    }
   }
 
   private static String getRegexForPath(String path) {

--- a/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/RTFConsts.java
+++ b/domain-models-interface-extensions/src/main/java/org/folio/rest/tools/RTFConsts.java
@@ -23,9 +23,6 @@ public class RTFConsts {
   public static final String INTERFACE_PACKAGE      = "org.folio.rest.jaxrs.resource";
   public static final String CLIENT_GEN_PACKAGE     = "org.folio.rest.client";
 
-  public static final String  POSSIBLE_HTTP_METHOD  = "javax.ws.rs.PUT|javax.ws.rs.POST|javax.ws.rs.DELETE|javax.ws.rs.GET|"
-      + "javax.ws.rs.OPTIONS|javax.ws.rs.HEAD|javax.ws.rs.TRACE|javax.ws.rs.CONNECT|org.folio.rest.jaxrs.resource.support.PATCH";
-
   public static final int          VALIDATION_ERROR_HTTP_CODE      = 422;
   public static final String       VALIDATION_FIELD_ERROR          = "1";
 }

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -34,7 +34,6 @@
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>test</scope>

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -1,5 +1,7 @@
 package org.folio;
 
+import static io.restassured.RestAssured.given;
+
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -27,7 +29,9 @@ import org.junit.runner.RunWith;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -61,6 +65,7 @@ public class DemoRamlRestTest {
   private static int port;
   private static Locale oldLocale = Locale.getDefault();
   private static String TENANT = "folio_shared";
+  private static RequestSpecification tenant;
 
   /**
    * @param context  the test context.
@@ -72,6 +77,9 @@ public class DemoRamlRestTest {
 
     vertx = VertxUtils.getVertxWithExceptionHandler();
     port = NetworkUtils.nextFreePort();
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    tenant = new RequestSpecBuilder().addHeader("x-okapi-tenant", TENANT).build();
 
     try {
       deployRestVerticle(context);
@@ -424,6 +432,11 @@ public class DemoRamlRestTest {
   @Test
   public void testStreamChunked(TestContext context) {
     testStream(context, true);
+  }
+
+  @Test
+  public void options(TestContext context) {
+    given().spec(tenant).when().options("/rmbtests/test").then().statusCode(200);
   }
 
   /**

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -435,7 +435,7 @@ public class DemoRamlRestTest {
   }
 
   @Test
-  public void options(TestContext context) {
+  public void options() {
     given().spec(tenant).when().options("/rmbtests/test").then().statusCode(200);
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
@@ -118,4 +118,11 @@ public class BooksDemoAPI implements Rmbtests {
     asyncResultHandler.handle(Future.succeededFuture(
       PostRmbtestsTestStreamResponse.respond200WithApplicationJson(jo.encodePrettily())));
   }
+
+  @Validate
+  @Override
+  public void optionsRmbtestsTest(RoutingContext routingContext, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    asyncResultHandler.handle(Future.succeededFuture(OptionsRmbtestsTestResponse.respond200()));
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>io.rest-assured</groupId>
+        <artifactId>rest-assured</artifactId>
+        <version>4.3.0</version>
+      </dependency>
+      <dependency>
         <groupId>javax.el</groupId>
         <artifactId>javax.el-api</artifactId>
         <version>3.0.1-b06</version>


### PR DESCRIPTION
Add org.folio.rest.jaxrs.resource.support.OPTIONS as possible HTTP
method.

Move RTFConsts.POSSIBLE_HTTP_METHOD to
AnnotationGrabber.isPossibleHttpMethod and replace substring
matching by complete string matching.

Add options API endpoint to sample.raml and a rest-assured test
for it to DemoRamlRestTest.