### PR TITLE
RMB-660: com.thoughtworks.xstream vulnerability (CVE-2017-7957)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,17 +49,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.thoughtworks.xstream</groupId>
-        <artifactId>xstream</artifactId>
-        <version>1.4.9</version>
-        <exclusions>
-          <exclusion>
-            <groupId>xmlpull</groupId>
-            <artifactId>xmlpull</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>3.9.1</version>


### PR DESCRIPTION
RMB's main pom.xml `<dependencyManagement>` section downgrades
com.thoughtworks.xstream:xstream to 1.4.9.
This version contains a security bug that allows attackers
to crash the server:

* https://nvd.nist.gov/vuln/detail/CVE-2017-7957
* https://x-stream.github.io/CVE-2017-7957.html

RMB neither uses nor ships this library (`mvn dependency:tree -Dincludes=xstream`).
However, RMB `<dependencyManagement>` downgrades xstream in any
RMB based module that uses xstream.

Task: Remove xstream from pom.xml `<dependencyManagement>` section.