### PR TITLE
RMB-661: Use log4j 2.13.3 fixing SMTPS host mismatch (CVE-2020-9488)

### DIFF
--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -87,12 +87,10 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.9.1</version>
     </dependency>
   </dependencies>
 

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -171,17 +171,14 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
-      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
         <version>4.13</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.13.3</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>org.aspectj</groupId>
         <artifactId>aspectjrt</artifactId>
         <version>${aspectj.version}</version>


### PR DESCRIPTION
Upgrade log4j from 2.9.1 to 2.13.3.

The SmtpAppender did not verify the host name matched the SSL/TLS
certificate of an SMTPS connection which could allow an attacker
with man-in-the-middle access to intercept log messages sent
through SMTPS.

This affects log4j < 2.13.2. Fix: Upgrade to log4j >= 2.13.2.

References:
https://nvd.nist.gov/vuln/detail/CVE-2020-9488
https://issues.apache.org/jira/browse/LOG4J2-2819