### PR TITLE
RMB-662: Remove parseDatabaseSchemaString and org.json:json

### DIFF
--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -33,11 +33,6 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20180813</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/cql2pgjson-cli/src/main/java/org/z3950/zing/cql/cql2pgjsoncli/CQL2PGCLIMain.java
+++ b/cql2pgjson-cli/src/main/java/org/z3950/zing/cql/cql2pgjsoncli/CQL2PGCLIMain.java
@@ -1,12 +1,9 @@
 package org.z3950.zing.cql.cql2pgjsoncli;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.IntConsumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,8 +19,6 @@ import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.cql2pgjson.exception.QueryValidationException;
 import org.folio.cql2pgjson.model.SqlSelect;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 public class CQL2PGCLIMain {
 
@@ -105,31 +100,4 @@ public class CQL2PGCLIMain {
     return String.format("select * from %s where %s order by %s",
         dbName, sql.getWhere(), orderby);
   }
-
-  /*
-    If the string is valid JSON, read the values from the JSON object. If the
-    string is a path to a JSON file, load the file and read the JSON from the
-    file
-  */
-  static Map<String, String> parseDatabaseSchemaString(String dbsString) throws
-      IOException {
-    JSONObject fieldSchemaJson = null;
-    Map<String, String> fieldSchemaMap = new HashMap<>();
-    try {
-      fieldSchemaJson = new JSONObject(dbsString);
-    } catch( JSONException je ) {
-      System.out.println(String.format("Unable to parse %s as JSON: %s",
-          dbsString, je.getLocalizedMessage()));
-    }
-    if(fieldSchemaJson == null) {
-      String fieldSchemaJsonText = readFile(dbsString, StandardCharsets.UTF_8);
-      fieldSchemaJson = new JSONObject(fieldSchemaJsonText);
-    }
-    for(String key : fieldSchemaJson.keySet()) {
-      String value = readFile(fieldSchemaJson.getString(key), StandardCharsets.UTF_8);
-      fieldSchemaMap.put(key, value);
-    }
-    return fieldSchemaMap;
-  }
-
 }

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -45,12 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-      <version>20180813</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.z3950.zing</groupId>
       <artifactId>cql-java</artifactId>
       <version>1.13</version>


### PR DESCRIPTION
CQL2PGCLIMain.parseDatabaseSchemaString is an internal
method (package-private) that is not used.

The package dependency org.json:json violates Apache 2.0
license because it has this incompatible license requirement:
"The Software shall be used for Good, not Evil."
https://github.com/stleary/JSON-java/blob/20200518/LICENSE

If anyone needs the functionality of the method
parseDatabaseSchemaString that is only 25 lines long it
should be re-implemented using Vert.x JsonObject or
jackson-databind.

Tasks:
* Remove method CQL2PGCLIMain.parseDatabaseSchemaString
* Remove package org.json:json from dependencies.