### PR TITLE
RMB-673: totalRecords exact hit count when < 1000, fixing limit=0

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -1265,7 +1265,7 @@ public final class PgUtil {
       "lower(f_unaccent(jsonb->>'" + column + "')) ";
     String cutWrappedColumn = "left(" + wrappedColumn + ",600) ";
     String countSql = preparedCql.getSchemaName()
-      + ".count_estimate('"
+      + ".count_estimate_default('"
       + "  SELECT " + StringEscapeUtils.escapeSql(wrappedColumn) + " AS data_column "
       + "  FROM " + tableName + " "
       + "  WHERE " + StringEscapeUtils.escapeSql(where)

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -2006,7 +2006,7 @@ public class PostgresClient {
       // only do estimation when filter is in use (such as CQL).
       String estQuery = SELECT + distinctOnClause + fieldName + addIdField
           + FROM + schemaName + DOT + table + SPACE + wrapper.getWhereClause();
-      queryHelper.countQuery = SELECT + "count_estimate('"
+      queryHelper.countQuery = SELECT + "count_estimate_default('"
         + org.apache.commons.lang.StringEscapeUtils.escapeSql(estQuery)
         + "')";
     }


### PR DESCRIPTION
limit=0 is used to get the totalRecords number without fetching records.
This is useless if estimated count is 8924 and actual count is 0, see
https://issues.folio.org/browse/MODORDERS-407 "Cannot create POL due to POL limit bug".

Solution: Always use `count(*) ... LIMIT 1000` to get the actual count
if the actual count is 1000. Only if >= 1000 return an estimation.

Background: We have removed this in
https://issues.folio.org/browse/RMB-591 "remove or harmonize 'optimizedSql' execution path"
for performance reasons. However,
https://issues.folio.org/browse/RMB-645 'use where-only clause for the "count query"'
removed the sortBy/order by clause from the count query reducing the execution time
of the count query.

There can still be queries where calculating the count can take long, for example
`title=int* and title=and* and title=con* and title=with*` takes 700 ms for the
performance dataset with 2.7 million records. Similar queries will take 2800 ms
for a dataset with 10 million records. And it takes even longer when the query
uses fields from instance, holding and item.

These performance issues may be addressed by changing the default `exactCount=1000`.