### PR TITLE
Explain case and accents sensitiviy, and array matching

### DIFF
--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -320,7 +320,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   }
   @Test
   @Parameters({
-    "name ==\"LEA long\"           #", // == means exact match, case and everything
+    "name ==\"LEA long\"           #", // == means field match
   })
   public void caseSensitive(String testcase) {
     select(cql2pgjsonRespectCase,testcase);
@@ -900,7 +900,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "Long                           # Lea Long",
     "Lon                            #",
     "ong                            #",
-    "cql.serverChoice==example      #", // == means exact match
+    "cql.serverChoice==example      #", // == means field match
     "email==ka@example.com          # Ka Keller",
     "email=ka@example.com           # Ka Keller",
     "email=ka@*                     # Ka Keller",
@@ -908,7 +908,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     // like (.+)@(.*)(\.)(??.+) is considered an email, and comes up
     // as one token. Anything else will be tokenized at the '@' and '.'
     // into separate tokens. The end result is that email-looking things
-    // will only do exact match, and truncation breaks (unless the top-domain
+    // will only do field match, and truncation breaks (unless the top-domain
     // is longer than two characters, and we mention two characters and
     // truncate the rest)
     //


### PR DESCRIPTION
Use field match for ==, this is better wording than exact match.

Remove /respectCase and /respectAccents documentation, they
are no longer supported.

Explain that case and accent sensitivity is taken from indexes.

Remove hack for index access, we provide @-relation instead.