### PR TITLE
Drop obsolete rmb_internal_index.

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/rmb_internal_index.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/rmb_internal_index.ftl
@@ -1,8 +1,10 @@
--- Recreate index if its definition has changed,
--- drop it and replace by the replacement if a prepared replacement index exists,
--- drop it if tops = 'DELETE'.
--- Update its entry in table rmb_internal_index.
--- Add an entry in table rmb_internal_analyze if ALTER INDEX or CREATE INDEX was executed.
+DROP FUNCTION IF EXISTS rmb_internal_index(aname text, tops text, newdef text);
+
+-- This function recreates index if its definition has changed,
+-- drops it and replaces it by the replacement if a prepared replacement index exists,
+-- drops it if tops = 'DELETE'.
+-- Updates its entry in table rmb_internal_index.
+-- Adds an entry in table rmb_internal_analyze if ALTER INDEX or CREATE INDEX was executed.
 CREATE OR REPLACE FUNCTION rmb_internal_index(
   atable text, aname text, tops text, newdef text) RETURNS void AS
 $$


### PR DESCRIPTION
The drop was forgotten in RMB-637 = PR #692 and causes
differences when comparing fresh install and upgrade.