### PR TITLE
RMB-687: ResponseException for TenantAPI

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -51,6 +51,7 @@ import org.folio.rest.tools.AnnotationGrabber;
 import org.folio.rest.tools.ClientGenerator;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.RTFConsts;
+import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.codecs.PojoEventBusCodec;
 import org.folio.rest.tools.messages.MessageConsts;
@@ -769,7 +770,13 @@ public class RestVerticle extends AbstractVerticle {
    *          - request's start time, using JVM's high-resolution time source, in nanoseconds
    */
   private void sendResponse(RoutingContext rc, AsyncResult<Response> v, long start, String tenantId) {
-    Response result = ((Response) ((AsyncResult<?>) v).result());
+    Response result = v.result();
+    if (v.failed()) {
+      Throwable exception = v.cause();
+      if (exception instanceof ResponseException) {
+        result = ((ResponseException) exception).getResponse();
+      }
+    }
     if (result == null) {
       // catch all
       endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -759,6 +759,17 @@ public class RestVerticle extends AbstractVerticle {
     return false;
   }
 
+  static Response getResponse(AsyncResult<Response> asyncResult) {
+    if (asyncResult.succeeded()) {
+      return asyncResult.result();
+    }
+    Throwable exception = asyncResult.cause();
+    if (exception instanceof ResponseException) {
+      return ((ResponseException) exception).getResponse();
+    }
+    return null;
+  }
+
   /**
    * Send the result as response.
    *
@@ -770,13 +781,7 @@ public class RestVerticle extends AbstractVerticle {
    *          - request's start time, using JVM's high-resolution time source, in nanoseconds
    */
   private void sendResponse(RoutingContext rc, AsyncResult<Response> v, long start, String tenantId) {
-    Response result = v.result();
-    if (v.failed()) {
-      Throwable exception = v.cause();
-      if (exception instanceof ResponseException) {
-        result = ((ResponseException) exception).getResponse();
-      }
-    }
+    Response result = getResponse(v);
     if (result == null) {
       // catch all
       endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -759,6 +759,10 @@ public class RestVerticle extends AbstractVerticle {
     return false;
   }
 
+  /**
+   * @return a {@link Response} extracted from asyncResult, either from result(), or from
+   *         cause().getResponse() if cause() is a {@link ResponseException}, or null otherwise
+   */
   static Response getResponse(AsyncResult<Response> asyncResult) {
     if (asyncResult.succeeded()) {
       return asyncResult.result();

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -785,8 +785,8 @@ public class RestVerticle extends AbstractVerticle {
    *          - request's start time, using JVM's high-resolution time source, in nanoseconds
    */
   private void sendResponse(RoutingContext rc, AsyncResult<Response> v, long start, String tenantId) {
-    Response result = getResponse(v);
-    if (result == null) {
+    Response responseFromResult = getResponse(v);
+    if (responseFromResult == null) {
       // catch all
       endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });
       return;
@@ -794,7 +794,7 @@ public class RestVerticle extends AbstractVerticle {
     Object entity = null;
     try {
       HttpServerResponse response = rc.response();
-      int statusCode = result.getStatus();
+      int statusCode = responseFromResult.getStatus();
       // 204 means no content returned in the response, so passing
       // a chunked Transfer header is not allowed
       if (statusCode != 204) {
@@ -806,9 +806,9 @@ public class RestVerticle extends AbstractVerticle {
       // !!!!!!!!!!!!!!!!!!!!!! CORS commented OUT!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
       // response.putHeader("Access-Control-Allow-Origin", "*");
 
-      copyHeadersJoin(result.getStringHeaders(), response.headers());
+      copyHeadersJoin(responseFromResult.getStringHeaders(), response.headers());
 
-      entity = result.getEntity();
+      entity = responseFromResult.getEntity();
 
       /* entity is of type OutStream - and will be written as a string */
       if (entity instanceof OutStream) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -64,7 +64,7 @@ public class TenantAPI implements Tenant {
             if(h.succeeded()){
               exists = h.result();
               if(!exists){
-                handlers.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse.
+                handlers.handle(failedFuture(DeleteTenantResponse.
                   respond400WithTextPlain("Tenant does not exist: " + tenantId)));
                 log.error("Can not delete. Tenant does not exist: " + tenantId);
                 return;
@@ -102,7 +102,7 @@ public class TenantAPI implements Tenant {
                       if(reply.result().size() > 0){
                         log.error("Unable to run the following commands during tenant delete: ");
                         reply.result().forEach(System.out::println);
-                        handlers.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse.respond400WithTextPlain(res)));
+                        handlers.handle(failedFuture(DeleteTenantResponse.respond400WithTextPlain(res)));
                       }
                       else {
                         OutStream os = new OutStream();
@@ -112,19 +112,19 @@ public class TenantAPI implements Tenant {
                     }
                     else {
                       log.error(reply.cause().getMessage(), reply.cause());
-                      handlers.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse
+                      handlers.handle(failedFuture(DeleteTenantResponse
                         .respond500WithTextPlain(reply.cause().getMessage())));
                     }
                   } catch (Exception e) {
                     log.error(e.getMessage(), e);
-                    handlers.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse
+                    handlers.handle(failedFuture(DeleteTenantResponse
                       .respond500WithTextPlain(e.getMessage())));
                   }
                 });
           });
       } catch (Exception e) {
         log.error(e.getMessage(), e);
-        handlers.handle(io.vertx.core.Future.succeededFuture(DeleteTenantResponse
+        handlers.handle(failedFuture(DeleteTenantResponse
           .respond500WithTextPlain(e.getMessage())));
       }
     });
@@ -176,13 +176,13 @@ public class TenantAPI implements Tenant {
           }
           else{
             log.error(res.cause().getMessage(), res.cause());
-            handlers.handle(io.vertx.core.Future.succeededFuture(GetTenantResponse
+            handlers.handle(failedFuture(GetTenantResponse
               .respond500WithTextPlain(res.cause().getMessage())));
           }
         });
       } catch (Exception e) {
         log.error(e.getMessage(), e);
-        handlers.handle(io.vertx.core.Future.succeededFuture(GetTenantResponse
+        handlers.handle(failedFuture(GetTenantResponse
           .respond500WithTextPlain(e.getMessage())));
       }
     });
@@ -330,14 +330,22 @@ public class TenantAPI implements Tenant {
       log.error(e.getMessage(), e);
       String text = e.getMessage() + "\n" + ExceptionUtils.getStackTrace(e);
       Response response = PostTenantResponse.respond500WithTextPlain(text);
-      handlers.handle(Future.failedFuture(new ResponseException(response)));
+      handlers.handle(failedFuture(response));
     })
     .onSuccess(response -> {
       if (response.getStatus() >= 300) {
-        handlers.handle(Future.failedFuture(new ResponseException(response)));
+        handlers.handle(failedFuture(response));
         return;
       }
       handlers.handle(Future.succeededFuture(response));
     });
+  }
+
+  /**
+   * @return a failed {@link Future} where the failure cause is a {@link ResponseException}
+   *         containing the {@code response}
+   */
+  static Future<Response> failedFuture(Response response) {
+    return Future.failedFuture(new ResponseException(response));
   }
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/exceptions/ResponseException.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/exceptions/ResponseException.java
@@ -1,0 +1,22 @@
+package org.folio.rest.tools.client.exceptions;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Exception with a {@link javax.ws.rs.core.Response}.
+ *
+ * <p>The Response can contain an HTTP body with error details and
+ * an HTTP status.
+ */
+public class ResponseException extends RuntimeException {
+  private final Response response;
+
+  public ResponseException(Response response) {
+    super(response == null ? "null response" : response.getStatus() + " " + response.getStatusInfo());
+    this.response = response;
+  }
+
+  public Response getResponse() {
+    return response;
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -16,10 +16,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import org.folio.rest.jaxrs.model.Book;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.junit.jupiter.api.Test;
-
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import javax.ws.rs.core.Response;
 
 class RestVerticleTest {
 
@@ -180,5 +183,22 @@ class RestVerticleTest {
         is(arrayContaining("abc", "def", "ghi")));
     assertThat(RestVerticle.matchPath("/%2F%3F%2B%23/12%2334", Pattern.compile("^/([^/]+)/([^/]+)$")),
         is(arrayContaining("/?+#", "12#34")));
+  }
+
+  @Test
+  void getResponseSucceeded() {
+    Response response = ResponseDelegate.status(234).build();
+    assertThat(RestVerticle.getResponse(Future.succeededFuture(response)).getStatus(), is(234));
+  }
+
+  @Test
+  void getResponseFailed() {
+    Response response = ResponseDelegate.status(456).build();
+    assertThat(RestVerticle.getResponse(Future.failedFuture(new ResponseException(response))).getStatus(), is(456));
+  }
+
+  @Test
+  void getResponseFailedWithoutResponse() {
+    assertThat(RestVerticle.getResponse(Future.failedFuture("foo")), is(nullValue()));
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -13,12 +13,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
-
+import javax.ws.rs.core.Response;
 import org.folio.rest.jaxrs.model.Book;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.ddlgen.Schema;
+import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.folio.rest.tools.utils.VertxUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
@@ -272,8 +273,8 @@ public class TenantAPIIT {
       }
     };
     TenantAttributes tenantAttributes = new TenantAttributes();
-    tenantAPI.postTenant(tenantAttributes, okapiHeaders, context.asyncAssertSuccess(response -> {
-      assertThat(response.getStatus(), is(500));
+    tenantAPI.postTenant(tenantAttributes, okapiHeaders, context.asyncAssertFailure(exception -> {
+      assertThat(((ResponseException) exception).getResponse().getStatus(), is(500));
     }), vertx.getOrCreateContext());
   }
 
@@ -293,7 +294,8 @@ public class TenantAPIIT {
         handler.handle(Future.succeededFuture(false));
       }
     };
-    tenantAPI.postTenant(null, okapiHeaders, context.asyncAssertSuccess(result -> {
+    tenantAPI.postTenant(null, okapiHeaders, context.asyncAssertFailure(exception -> {
+      Response result = ((ResponseException) exception).getResponse();
       assertThat(result.getStatus(), is(400));
       assertThat(result.getEntity(), is("[ \"first failure\" ]"));
     }), vertx.getOrCreateContext());
@@ -324,7 +326,8 @@ public class TenantAPIIT {
         }
       }
     };
-    tenantAPI.postTenant(null, okapiHeaders, context.asyncAssertSuccess(result -> {
+    tenantAPI.postTenant(null, okapiHeaders, context.asyncAssertFailure(exception -> {
+      Response result = ((ResponseException) exception).getResponse();
       assertThat(result.getStatus(), is(500));
       assertThat(result.getEntity().toString(), is(CoreMatchers.startsWith(exceptionClass.getName())));
     }), vertx.getOrCreateContext());


### PR DESCRIPTION
Use a ResponseException that contains a javax.ws.rs.core.Response
when a TenantAPI call fails.

The TenantAPI methods use a Handler<AsyncResult<Response>> handler
to return success and failure. It is returned as a succeeded
AsyncResult where the value is the Response:
https://github.com/folio-org/raml-module-builder/blob/v30.2.4/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java

On success the Response has a 200 or 201 HTTP status code.
If installation or upgrade fails the Response has a 400 or 500
HTTP status code and a detailed error message in the body.
Note that AsyncResult is a succeeded result in all cases.

The documentation was wrong in that it only checked the
AsyncResult (succeeded, failed) and not the Response status
code.

This is how we fix this:
A success is returned using a succeeded AsyncResult as before.
A failure is returned using a failed AsyncResult. A failed AsyncResult
doesn't have a value where we can pass the Response. But it has an
Exception and we can create our custom ResponseException that contains
the Response.

RestVerticle extracts the Response from the ResponseException.