### PR TITLE
RMB-693: Close prepared statements in PostgresClient stream get

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -19,6 +19,8 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 * [RMB-652](https://issues.folio.org/browse/RMB-652) error message
   "may not be null" changed to "must not be null" (hibernate-validator)
+* [RMB-693](https://issues.folio.org/browse/RMB-693) If using
+  PostgresClient#selectStream always call RowStream#close.
 
 ## Version 30.0
 

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -181,6 +181,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
@@ -76,21 +76,17 @@ public class PreparedRowStream implements RowStream<Row> {
 
   @Override
   public void close() {
-    preparedStatement.close(close -> {
-      rowStream.close();
-    });
+    preparedStatement.close(close -> rowStream.close());
   }
 
   @Override
   public void close(Handler<AsyncResult<Void>> completionHandler) {
-    preparedStatement.close(close1 -> {
-      rowStream.close(close2 -> {
-        if (close1.failed()) {
-          completionHandler.handle(close1);
-          return;
-        }
-        completionHandler.handle(close2);
-      });
-    });
+    preparedStatement.close(close1 -> rowStream.close(close2 -> {
+      if (close1.failed()) {
+        completionHandler.handle(close1);
+        return;
+      }
+      completionHandler.handle(close2);
+    }));
   }
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
@@ -76,12 +76,12 @@ public class PreparedRowStream implements RowStream<Row> {
 
   @Override
   public void close() {
-    preparedStatement.close(close -> rowStream.close());
+    rowStream.close(close -> preparedStatement.close());
   }
 
   @Override
   public void close(Handler<AsyncResult<Void>> completionHandler) {
-    preparedStatement.close(close1 -> rowStream.close(close2 -> {
+    rowStream.close(close1 -> preparedStatement.close(close2 -> {
       if (close1.failed()) {
         completionHandler.handle(close1);
         return;

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
@@ -1,0 +1,96 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
+import io.vertx.sqlclient.Tuple;
+
+/**
+ * Extend a RowStream<Row> by adding a {@link PreparedStatement#close} call
+ * to any {@link RowStream#close} call. This will release the resources allocated
+ * by the prepared statement.
+ */
+public class PreparedRowStream implements RowStream<Row> {
+  private final PreparedStatement preparedStatement;
+  private final RowStream<Row> rowStream;
+
+  /**
+   * Extend rowStream by adding a preparedStatement.close call
+   * to any {@link PreparedRowStream#close} call. This will release the resources
+   * allocated by the prepared statement.
+   */
+  public PreparedRowStream(PreparedStatement preparedStatement, RowStream<Row> rowStream) {
+    this.preparedStatement = preparedStatement;
+    this.rowStream = rowStream;
+  }
+
+  /**
+   * Create a RowStream<Row> using the preparedStatement, fetch and tuple.
+   * A call to PreparedRowStream#close will close the preparedStatement to
+   * release the resources that it allocates.
+   * @param preparedStatement the query to execute
+   * @param fetch the cursor fetch size
+   * @param tuple the arguments for preparedStatement
+   */
+  public PreparedRowStream(PreparedStatement preparedStatement, int fetch, Tuple tuple) {
+    this(preparedStatement, preparedStatement.createStream(fetch, tuple));
+  }
+
+  @Override
+  public ReadStream<Row> fetch(long amount) {
+    return rowStream.fetch(amount);
+  }
+
+  @Override
+  public RowStream<Row> exceptionHandler(Handler<Throwable> handler) {
+    rowStream.exceptionHandler(handler);
+    return this;
+  }
+
+  @Override
+  public RowStream<Row> handler(Handler<Row> handler) {
+    rowStream.handler(handler);
+    return this;
+  }
+
+  @Override
+  public RowStream<Row> pause() {
+    rowStream.pause();
+    return this;
+  }
+
+  @Override
+  public RowStream<Row> resume() {
+    rowStream.resume();
+    return this;
+  }
+
+  @Override
+  public RowStream<Row> endHandler(Handler<Void> endHandler) {
+    rowStream.endHandler(endHandler);
+    return this;
+  }
+
+  @Override
+  public void close() {
+    preparedStatement.close(close -> {
+      rowStream.close();
+    });
+  }
+
+  @Override
+  public void close(Handler<AsyncResult<Void>> completionHandler) {
+    preparedStatement.close(close1 -> {
+      rowStream.close(close2 -> {
+        if (close1.failed()) {
+          completionHandler.handle(close1);
+          return;
+        }
+        completionHandler.handle(close2);
+      });
+    });
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2838,12 +2838,12 @@ public class PostgresClientIT {
           events.append("[handler]");
           throw new NullPointerException("null");
         });
+        sr.exceptionHandler(x -> {
+          events.append("[exception]");
+        });
         sr.endHandler(x -> {
           events.append("[endHandler]");
           async.complete();
-        });
-        sr.exceptionHandler(x -> {
-          events.append("[exception]");
         });
       }));
     async.await(1000);
@@ -3046,12 +3046,12 @@ public class PostgresClientIT {
             events.append("[handler]");
             throw new NullPointerException("null");
           });
+          sr.exceptionHandler(x -> {
+            events.append("[exception]");
+          });
           sr.endHandler(x -> {
             events.append("[endHandler]");
             async.complete();
-          });
-          sr.exceptionHandler(x -> {
-            events.append("[exception]");
           });
         }));
     async.await(1000);

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2840,14 +2840,14 @@ public class PostgresClientIT {
         });
         sr.endHandler(x -> {
           events.append("[endHandler]");
+          async.complete();
         });
         sr.exceptionHandler(x -> {
           events.append("[exception]");
-          async.complete();
         });
       }));
     async.await(1000);
-    context.assertEquals("[handler][exception]", events.toString());
+    context.assertEquals("[handler][exception][endHandler]", events.toString());
   }
 
   @Test
@@ -3006,10 +3006,9 @@ public class PostgresClientIT {
           async.complete();
         });
         // no exceptionHandler defined
-        vertx.setTimer(100, x -> async.complete());
       }));
     async.await(1000);
-    context.assertEquals("[handler]", events.toString());
+    context.assertEquals("[handler][endHandler]", events.toString());
   }
 
   @Test
@@ -3053,11 +3052,10 @@ public class PostgresClientIT {
           });
           sr.exceptionHandler(x -> {
             events.append("[exception]");
-            async.complete();
           });
         }));
     async.await(1000);
-    context.assertEquals("[handler][exception]", events.toString());
+    context.assertEquals("[handler][exception][endHandler]", events.toString());
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2840,14 +2840,14 @@ public class PostgresClientIT {
         });
         sr.exceptionHandler(x -> {
           events.append("[exception]");
+          vertx.runOnContext(run -> async.complete());
         });
         sr.endHandler(x -> {
           events.append("[endHandler]");
-          async.complete();
         });
       }));
     async.await(1000);
-    context.assertEquals("[handler][exception][endHandler]", events.toString());
+    context.assertEquals("[handler][exception]", events.toString());
   }
 
   @Test
@@ -2999,16 +2999,16 @@ public class PostgresClientIT {
       context.asyncAssertSuccess(sr -> {
         sr.handler(streamHandler -> {
           events.append("[handler]");
+          vertx.runOnContext(run -> async.complete());
           throw new NullPointerException("null");
         });
         sr.endHandler(x -> {
           events.append("[endHandler]");
-          async.complete();
         });
         // no exceptionHandler defined
       }));
     async.await(1000);
-    context.assertEquals("[handler][endHandler]", events.toString());
+    context.assertEquals("[handler]", events.toString());
   }
 
   @Test
@@ -3026,7 +3026,7 @@ public class PostgresClientIT {
           events.append("[endHandler]");
         }).exceptionHandler(x -> {
           events.append("[exception]");
-          async.complete();
+          vertx.runOnContext(run -> async.complete());
         });
       }));
     async.await(1000);
@@ -3048,14 +3048,14 @@ public class PostgresClientIT {
           });
           sr.exceptionHandler(x -> {
             events.append("[exception]");
+            vertx.runOnContext(run -> async.complete());
           });
           sr.endHandler(x -> {
             events.append("[endHandler]");
-            async.complete();
           });
         }));
     async.await(1000);
-    context.assertEquals("[handler][exception][endHandler]", events.toString());
+    context.assertEquals("[handler][exception]", events.toString());
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PreparedRowStreamTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PreparedRowStreamTest.java
@@ -70,7 +70,7 @@ class PreparedRowStreamTest {
     PreparedRowStream preparedRowStream = new PreparedRowStream(mockedPreparedStatement, mockedRowStream);
     StringBuilder s = new StringBuilder();
     preparedRowStream.close(handler -> s.append(handler.cause().getMessage()));
-    assertThat(s.toString(), is("fail1"));
+    assertThat(s.toString(), is("fail2"));
     verify(mockedPreparedStatement).close(any());
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PreparedRowStreamTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PreparedRowStreamTest.java
@@ -1,0 +1,76 @@
+package org.folio.rest.persist;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+class PreparedRowStreamTest {
+  @Mock
+  PreparedStatement mockedPreparedStatement;
+  @Mock
+  RowStream<Row> mockedRowStream;
+
+  @Test
+  void fetch() {
+    PreparedRowStream preparedRowStream = new PreparedRowStream(null, mockedRowStream);
+    preparedRowStream.fetch(234);
+    verify(mockedRowStream).fetch(234);
+  }
+
+  @Test
+  void pauseResume() {
+    PreparedRowStream preparedRowStream = new PreparedRowStream(null, mockedRowStream);
+    preparedRowStream.pause();
+    verify(mockedRowStream, times(1)).pause();
+    verify(mockedRowStream, never()).resume();
+    preparedRowStream.resume();
+    verify(mockedRowStream, times(1)).pause();
+    verify(mockedRowStream, times(1)).resume();
+  }
+
+  @Test
+  void closeHandlerOneFailure() {
+    doAnswer(AdditionalAnswers.answerVoid((Handler<AsyncResult<Void>> handler)
+        -> handler.handle(Future.succeededFuture())))
+        .when(mockedPreparedStatement).close(any());
+    doAnswer(AdditionalAnswers.answerVoid((Handler<AsyncResult<Void>> handler)
+        -> handler.handle(Future.failedFuture("fail"))))
+        .when(mockedRowStream).close(any());
+    PreparedRowStream preparedRowStream = new PreparedRowStream(mockedPreparedStatement, mockedRowStream);
+    StringBuilder s = new StringBuilder();
+    preparedRowStream.close(handler -> s.append(handler.cause().getMessage()));
+    assertThat(s.toString(), is("fail"));
+    verify(mockedPreparedStatement).close(any());
+  }
+
+  @Test
+  void closeHandlerTwoFailures() {
+    doAnswer(AdditionalAnswers.answerVoid((Handler<AsyncResult<Void>> handler)
+        -> handler.handle(Future.failedFuture("fail1"))))
+        .when(mockedPreparedStatement).close(any());
+    doAnswer(AdditionalAnswers.answerVoid((Handler<AsyncResult<Void>> handler)
+        -> handler.handle(Future.failedFuture("fail2"))))
+        .when(mockedRowStream).close(any());
+    PreparedRowStream preparedRowStream = new PreparedRowStream(mockedPreparedStatement, mockedRowStream);
+    StringBuilder s = new StringBuilder();
+    preparedRowStream.close(handler -> s.append(handler.cause().getMessage()));
+    assertThat(s.toString(), is("fail1"));
+    verify(mockedPreparedStatement).close(any());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.3.3</version>
+        <version>3.4.6</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>3.4.6</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
Closing the prepared statement releases the resources allocated
by PostgreSQL for them and also releases the name of the prepared
statement for reuse. The latter will reduce the likelihood
of failures caused by duplicate prepared statement names reported
in https://issues.folio.org/browse/MODINVSTOR-540 :
"ERROR: prepared statement "XYZ" already exists"