### PR TITLE
RMB-694: Upgrade foreign key of a sub-field like "fieldName": "foo.bar"

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -98,7 +98,10 @@ public class SchemaMaker {
 
     templateInput.put("schemaJson", this.getSchemaJson());
 
-    this.schema.setup();
+    schema.setup();
+    if (previousSchema != null) {
+      previousSchema.setup();
+    }
 
     templateInput.put("tables", tables());
 
@@ -150,7 +153,6 @@ public class SchemaMaker {
       Table newTable = tableForName.get(oldTable.getTableName());
       if (newTable == null) {
         oldTable.setMode("delete");
-        oldTable.setup();
         list.add(oldTable);
         return;
       }
@@ -169,7 +171,6 @@ public class SchemaMaker {
           return;
         }
         oldForeignKey.settOps(TableOperation.DELETE);
-        oldForeignKey.setup();
         allForeignKeys.add(oldForeignKey);
       });
       newTable.setForeignKeys(allForeignKeys);

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -330,18 +330,18 @@ public class SchemaMakerTest {
     schemaMaker.setPreviousSchema(schema("templates/db_scripts/foreignKey1.json"));
     String ddl = schemaMaker.generateDDL();
     // a, f -> b, c, d, e, f
-    assertThat(ddl, containsString("DROP COLUMN IF EXISTS refa"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS refb"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS refc"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS refd"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS refe"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS reff"));
-    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refa")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS refb")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS refc")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS refd")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS refe")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS reff")));
+    assertThat(ddl, containsString("DROP COLUMN IF EXISTS ref_a"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_b"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_c"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_d"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_e"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_f"));
+    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS ref_a")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_b")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_c")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_d")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_e")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_f")));
   }
 
   @Test
@@ -351,18 +351,18 @@ public class SchemaMakerTest {
     schemaMaker.setPreviousSchema(schema("templates/db_scripts/foreignKey2.json"));
     String ddl = schemaMaker.generateDDL();
     // b, c, d, e, f -> a, f
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS refa"));
-    assertThat(ddl, containsString("DROP COLUMN IF EXISTS refb"));
-    assertThat(ddl, containsString("DROP COLUMN IF EXISTS refc"));
-    assertThat(ddl, containsString("DROP COLUMN IF EXISTS refd"));
-    assertThat(ddl, containsString("DROP COLUMN IF EXISTS refe"));
-    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS reff"));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS refa")));
-    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refb")));
-    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refc")));
-    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refd")));
-    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS refe")));
-    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS reff")));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_a"));
+    assertThat(ddl, containsString("DROP COLUMN IF EXISTS ref_b"));
+    assertThat(ddl, containsString("DROP COLUMN IF EXISTS ref_c"));
+    assertThat(ddl, containsString("DROP COLUMN IF EXISTS ref_d"));
+    assertThat(ddl, containsString("DROP COLUMN IF EXISTS ref_e"));
+    assertThat(ddl, containsString("ADD COLUMN IF NOT EXISTS ref_f"));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_a")));
+    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS ref_b")));
+    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS ref_c")));
+    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS ref_d")));
+    assertThat(ddl, not(containsString("ADD COLUMN IF NOT EXISTS ref_e")));
+    assertThat(ddl, not(containsString("DROP COLUMN IF EXISTS ref_f")));
   }
 
   @ParameterizedTest

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey1.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey1.json
@@ -5,7 +5,7 @@
       "fromModuleVersion": "18.2.5",
       "foreignKeys": [
         {
-          "fieldName":        "refa",
+          "fieldName":        "ref.a",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"
@@ -17,7 +17,7 @@
       "fromModuleVersion": "18.2.5",
       "foreignKeys": [
         {
-          "fieldName":        "reff",
+          "fieldName":        "ref.f",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey2.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/foreignKey2.json
@@ -5,13 +5,13 @@
       "fromModuleVersion": "18.2.5",
       "foreignKeys": [
         {
-          "fieldName":        "refb",
+          "fieldName":        "ref.b",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"
         },
         {
-          "fieldName":        "refc",
+          "fieldName":        "ref.c",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"
@@ -23,19 +23,19 @@
       "fromModuleVersion": "18.2.5",
       "foreignKeys": [
         {
-          "fieldName":        "refd",
+          "fieldName":        "ref.d",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"
         },
         {
-          "fieldName":        "refe",
+          "fieldName":        "ref.e",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"
         },
         {
-          "fieldName":        "reff",
+          "fieldName":        "ref.f",
           "targetTable":      "ref",
           "targetTableAlias": "ref",
           "tableAlias":       "ref"


### PR DESCRIPTION
Upgrading a module where the fieldName of a foreign key contains
a dot like "foo.bar" fails, the field is deleted.
Example: https://issues.folio.org/browse/CIRCSTORE-224

Fix: Apply the . to _ conversion to the previousSchema including the
foreignKeys.