### PR TITLE
RMB-701: Update to Vert.x 3.9.2

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -54,6 +54,7 @@ import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
 import org.apache.commons.io.IOUtils;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
@@ -1798,6 +1799,10 @@ public class PostgresClientIT {
 
       }
 
+      @Override
+      public DatabaseMetadata databaseMetadata() {
+        throw new RuntimeException();
+      }
     };
 
     PgPool client = new PgPool() {
@@ -1918,6 +1923,11 @@ public class PostgresClientIT {
       @Override
       public void close() {
       }
+
+      @Override
+      public DatabaseMetadata databaseMetadata() {
+        return null;
+      }
     };
 
     PgPool client = new PgPool() {
@@ -2020,6 +2030,10 @@ public class PostgresClientIT {
 
       }
 
+      @Override
+      public DatabaseMetadata databaseMetadata() {
+        return null;
+      }
     };
     PgPool client = new PgPool() {
       @Override

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -38,6 +38,7 @@ import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.RowDesc;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
 import org.folio.rest.persist.facets.FacetField;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.tools.utils.Envs;
@@ -384,6 +385,11 @@ public class PostgresClientTest {
 
     @Override
     public void close() {
+    }
+
+    @Override
+    public DatabaseMetadata databaseMetadata() {
+      return null;
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.1</version>
+        <version>3.9.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release notes: https://github.com/vert-x3/wiki/wiki/3.9.2-Release-Notes

Most notable fix that may affect RMB based modules:
https://github.com/vert-x3/vertx-web/issues/1612 "WebClient request timeout races against send the request"