### PR TITLE
RMB-677: Close PostgreSQL connection after invalid CQL failure

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1861,14 +1861,12 @@ public class PostgresClient {
   <T> void doStreamGetQuery(SQLConnection connection, QueryHelper queryHelper,
                             ResultInfo resultInfo, Class<T> clazz,
                             Handler<AsyncResult<PostgresClientStreamResult<T>>> replyHandler) {
-    // decide if we need to close transaction+connection ourselves
-    final PgConnection closeConnection = connection.tx == null ? connection.conn : null;
-    if (closeConnection != null) {
-      closeConnection.begin();
-    }
+    // Start a transaction that we need to close.
+    // If a transaction is already running we don't need to close it.
+    final Transaction transaction = connection.tx == null ? connection.conn.begin() : null;
     connection.conn.prepare(queryHelper.selectQuery, prepareRes -> {
       if (prepareRes.failed()) {
-        connection.conn.close();
+        closeIfNonNull(transaction);
         log.error(prepareRes.cause().getMessage(), prepareRes.cause());
         replyHandler.handle(Future.failedFuture(prepareRes.cause()));
         return;
@@ -1877,7 +1875,7 @@ public class PostgresClient {
       RowStream<Row> rowStream = new PreparedRowStream(
           preparedStatement, STREAM_GET_DEFAULT_CHUNK_SIZE, Tuple.tuple());
       PostgresClientStreamResult<T> streamResult = new PostgresClientStreamResult<>(resultInfo);
-      doStreamRowResults(rowStream, clazz, closeConnection, queryHelper,
+      doStreamRowResults(rowStream, clazz, transaction, queryHelper,
           streamResult, replyHandler);
     });
   }
@@ -1891,14 +1889,17 @@ public class PostgresClient {
     return columnNames;
   }
 
-  private void closeIfNonNull(PgConnection pgConnection) {
-    if (pgConnection != null) {
-      pgConnection.close();
+  private void closeIfNonNull(Transaction transaction) {
+    if (transaction != null) {
+      transaction.close();
     }
   }
 
+  /**
+   * @param transaction the transaction to close, null if not to close
+   */
   <T> void doStreamRowResults(RowStream<Row> rowStream, Class<T> clazz,
-      PgConnection pgConnection, QueryHelper queryHelper,
+      Transaction transaction, QueryHelper queryHelper,
       PostgresClientStreamResult<T> streamResult,
       Handler<AsyncResult<PostgresClientStreamResult<T>>> replyHandler) {
 
@@ -1934,12 +1935,12 @@ public class PostgresClient {
           replyHandler.handle(promise.future());
         }
         rowStream.close();
-        closeIfNonNull(pgConnection);
+        closeIfNonNull(transaction);
         streamResult.fireExceptionHandler(e);
       }
     }).endHandler(v2 -> {
       rowStream.close();
-      closeIfNonNull(pgConnection);
+      closeIfNonNull(transaction);
       resultInfo.setTotalRecords(
         getTotalRecords(resultCount.get(),
           resultInfo.getTotalRecords(),
@@ -1955,7 +1956,7 @@ public class PostgresClient {
       }
     }).exceptionHandler(e -> {
       rowStream.close();
-      closeIfNonNull(pgConnection);
+      closeIfNonNull(transaction);
       if (!promise.future().isComplete()) {
         promise.complete(streamResult);
         replyHandler.handle(promise.future());

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -1765,7 +1765,7 @@ public class PostgresClient {
 
     getSQLConnection(0, conn ->
         streamGet(conn, table, clazz, fieldName, filter, returnIdField,
-            distinctOn, facets, replyHandler));
+            distinctOn, facets, closeAndHandleResult(conn, replyHandler)));
   }
 
   /**
@@ -1789,7 +1789,7 @@ public class PostgresClient {
 
     getSQLConnection(queryTimeout, conn ->
         streamGet(conn, table, clazz, fieldName, filter, returnIdField,
-            distinctOn, facets, replyHandler));
+            distinctOn, facets, closeAndHandleResult(conn, replyHandler)));
   }
 
   /**
@@ -3055,10 +3055,24 @@ public class PostgresClient {
     });
   }
 
+  /**
+   * Don't forget to close the connection!
+   *
+   * <p>Use closeAndHandleResult as replyHandler, for example:
+   *
+   * <pre>getSQLConnection(conn -> execute(conn, sql, params, closeAndHandleResult(conn, replyHandler)))</pre>
+   */
   void getSQLConnection(Handler<AsyncResult<SQLConnection>> handler) {
     getSQLConnection(0, handler);
   }
 
+  /**
+   * Don't forget to close the connection!
+   *
+   * <p>Use closeAndHandleResult as replyHandler, for example:
+   *
+   * <pre>getSQLConnection(timeout, conn -> execute(conn, sql, params, closeAndHandleResult(conn, replyHandler)))</pre>
+   */
   void getSQLConnection(int queryTimeout, Handler<AsyncResult<SQLConnection>> handler) {
     getConnection(res -> {
       if (res.failed()) {

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -83,16 +83,22 @@ public class DemoRamlRestTest {
 
     try {
       deployRestVerticle(context);
+
+      Buffer buf = Buffer.buffer("{\"module_to\":\"raml-module-builder-1.0.0\"}");
+      postData(context, "http://localhost:" + port + "/_/tenant", buf,
+        201, HttpMethod.POST, "application/json", TENANT, false);
     } catch (Exception e) {
       context.fail(e);
     }
   }
 
   private static void deployRestVerticle(TestContext context) {
+    Async async = context.async();
     DeploymentOptions deploymentOptions = new DeploymentOptions().setConfig(
         new JsonObject().put("http.port", port));
     vertx.deployVerticle(RestVerticle.class.getName(), deploymentOptions,
-            context.asyncAssertSuccess());
+        context.asyncAssertSuccess(done -> async.complete()));
+    async.await();
   }
 
   /**
@@ -173,12 +179,7 @@ public class DemoRamlRestTest {
 
   @Test
   public void getBookWithRoutingContext(TestContext context)  throws Exception {
-    Buffer buf = Buffer.buffer("{\"module_to\":\"raml-module-builder-1.0.0\"}");
-    NetClient cli = vertx.createNetClient();
-    postData(context, "http://localhost:" + port + "/_/tenant", buf,
-      201, HttpMethod.POST, "application/json", TENANT, false);
-
-    buf = checkURLs(context, "http://localhost:" + port + "/rmbtests/test?query=nullpointer%3Dtrue", 500);
+    Buffer buf = checkURLs(context, "http://localhost:" + port + "/rmbtests/test?query=nullpointer%3Dtrue", 500);
     context.assertEquals("java.lang.NullPointerException", buf.toString());
 
     Books books;
@@ -588,7 +589,8 @@ public class DemoRamlRestTest {
   /**
    * for POST
    */
-  private void postData(TestContext context, String url, Buffer buffer, int errorCode, HttpMethod method, String contenttype, String tenant, boolean userIdHeader) {
+  private static void postData(TestContext context, String url, Buffer buffer,
+      int errorCode, HttpMethod method, String contenttype, String tenant, boolean userIdHeader) {
     Exception stacktrace = new RuntimeException();  // save stacktrace for async handler
     Async async = context.async();
     HttpClient client = vertx.createHttpClient();

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -265,6 +265,18 @@ public class DemoRamlRestTest {
     postBook(context, "", 422);
   }
 
+  /**
+   * 4 calls with invalid CQL cause RMB to hang if PostgreSQL connections
+   * are not closed: https://issues.folio.org/browse/RMB-677
+   */
+  @Test
+  public void invalidCqlClosesConnection(TestContext context) {
+    for (int i=0; i<10; i++) {
+      given().spec(tenant).when().get("/rmbtests/test?query=()").then().statusCode(400);
+    }
+  }
+
+
   @Test
   public void postBookValidateAuthor(TestContext context) {
     postBook(context, "?validate_field=author", 200);

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -652,7 +652,8 @@ public class PostgresClientIT {
   public void selectWithTimeoutSuccess(TestContext context) {
       PostgresClient client = postgresClient();
       client.getSQLConnection(2000, asyncAssertTx(context, conn -> {
-        client.selectSingle(conn, "SELECT 1, pg_sleep(1);", context.asyncAssertSuccess());
+        client.selectSingle(conn, "SELECT 1, pg_sleep(1);",
+            client.closeAndHandleResult(conn, context.asyncAssertSuccess()));
       }));
   }
 
@@ -660,10 +661,11 @@ public class PostgresClientIT {
   public void selectWithTimeoutFailure(TestContext context) {
       PostgresClient client = postgresClient();
       client.getSQLConnection(500, asyncAssertTx(context, conn -> {
-        client.selectSingle(conn, "SELECT 1, pg_sleep(3);", context.asyncAssertFailure(e -> {
-          String sqlState = new PgExceptionFacade(e).getSqlState();
-          assertThat(PgExceptionUtil.getMessage(e), sqlState, is("57014"));  // query_canceled
-        }));
+        client.selectSingle(conn, "SELECT 1, pg_sleep(3);",
+            client.closeAndHandleResult(conn, context.asyncAssertFailure(e -> {
+              String sqlState = new PgExceptionFacade(e).getSqlState();
+              assertThat(PgExceptionUtil.getMessage(e), sqlState, is("57014"));  // query_canceled
+        })));
       }));
   }
 


### PR DESCRIPTION
PostgresClient.streamGet should close the PostgreSQL connection.
Otherwise an invalid CQL will not release the connection and
further requests will wait forever to get an available connection.