### PR TITLE
RMB-705: Refactor assertThrows lambda to have only one exception

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -146,7 +146,6 @@ public class SchemaMakerTest {
       "mod-foo-0.2.1-SNAPSHOT.2", "mod-foo-18.2.1-SNAPSHOT.2");
     IOException e = assertThrows(IOException.class, () -> {
       schemaMaker.setSchema(schema("templates/db_scripts/schemaPopulateJsonWithId.json"));
-      schemaMaker.generateDDL();
     });
     assertThat(tidy(e.getMessage()), containsString("Unrecognized field \"populateJsonWithId\""));
   }


### PR DESCRIPTION
Sonar fails the first pull request against a new branch because of two bugs:
https://github.com/folio-org/raml-module-builder/pull/755

This issue fixes the one in SchemaMakerTest.java.