### PR TITLE
RMB-711: Remove Java 8 and Maven 3.3 check

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -123,13 +123,6 @@ public class RestVerticle extends AbstractVerticle {
   private static final Logger       log                             = LoggerFactory.getLogger(className);
   private static final ObjectMapper MAPPER                          = ObjectMapperTool.getMapper();
 
-  /**
-   * Minimum java version used for runtime check.
-   *
-   * For compile time check see raml-module-builder/pom.xml maven-enforcer-plugin requireJavaVersion.
-   */
-  private static final String       MINIMUM_JAVA_VERSION              = "1.8.0_101";
-
   private static final String[]     DATE_PATTERNS = {
     "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
     "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
@@ -159,31 +152,6 @@ public class RestVerticle extends AbstractVerticle {
     //passed in the request body in put and post requests. The constraints validated by this factory
     //are the ones in the json schemas accompanying the raml files
     validationFactory = Validation.buildDefaultValidatorFactory();
-    checkJavaVersion(System.getProperty("java.runtime.version"));
-  }
-
-  /**
-   * Compare java version strings of the form 1.8.0_191
-   */
-  static int compareJavaVersion(String versionA, String versionB) {
-    String [] a = versionA.split("[^0-9]+");
-    String [] b = versionB.split("[^0-9]+");
-    for (int i=0; i<4; i++) {
-      int compare = Integer.compare(Integer.parseInt(a[i]), Integer.parseInt(b[i]));
-      if (compare != 0) {
-        return compare;
-      }
-    }
-    return 0;
-  }
-
-  /**
-   * @throws InternalError if javaVersion is less than {@link #MINIMUM_JAVA_VERSION}
-   */
-  static void checkJavaVersion(String javaVersion) {
-    if (compareJavaVersion(javaVersion, MINIMUM_JAVA_VERSION) < 0) {
-      throw new InternalError("Minimum java version is " + MINIMUM_JAVA_VERSION + " but found " + javaVersion);
-    }
   }
 
   // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -2,7 +2,6 @@ package org.folio.rest;
 
 import static org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit.*;
 import static org.hamcrest.collection.ArrayMatching.arrayContaining;
-import static org.hamcrest.number.OrderingComparison.lessThan;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.emptyArray;
@@ -45,17 +44,6 @@ class RestVerticleTest {
   @Test
   void parseEnumNonEnumClass() throws Exception {
     assertThat(RestVerticle.parseEnum("java.util.Vector", "foo", "bar"), is(nullValue()));
-  }
-
-  @Test
-  void javaVersion() {
-    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_4"), is(0));
-    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_5"), is(lessThan(0)));
-    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.3_10"), is(lessThan(0)));
-    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.2.10_3"), is(lessThan(0)));
-    assertThat(RestVerticle.compareJavaVersion("1.2.3_4", "1.10.2_3"), is(lessThan(0)));
-    assertThrows(InternalError.class, () -> RestVerticle.checkJavaVersion("1.8.0_99"));
-    RestVerticle.checkJavaVersion("1.8.0_1000000");  // assert no exception
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -278,35 +278,6 @@
       </plugin>
 
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-java</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                 <requireMavenVersion>
-                  <message>Maven &gt;= 3.3 required</message>
-                  <version>3.3</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <message>
-                    JDK &gt;= 1.8.0-101 required for Let's Encrypt certificate of https://repository.folio.org/ :
-                    https://dev.folio.org/guides/troubleshooting/#missing-certificate-authority-for-lets-encrypt
-                  </message>
-                  <version>1.8.0-101</version>
-                  <!-- for runtime check see domain-models-runtime RestVerticle.MINIMUM_JAVA_VERSION -->
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <version>1.0.0</version>


### PR DESCRIPTION
We no longer need to check that the Java version is >= 1.8.0-101 because
we've already switched to Java 11 and both Maven and the Java runtime fail
with a good error message when running with Java 8.

We no longer need to detect a maven version older than 3.3 because such
versions are from 2014-12-20 or before and are unlikely to be still in use.