### PR TITLE
RMB-714: Remove unused aws-lambda-java-core dependency

### DIFF
--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -18,11 +18,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-lambda-java-core</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <version>1.3.1</version>


### PR DESCRIPTION
Remove the unused com.amazonaws:aws-lambda-java-core dependency.

Obsoletes https://github.com/folio-org/raml-module-builder/pull/762