### PR TITLE
RMB-723: Close database connection after dropping schema and role

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -98,7 +98,7 @@ public class TenantAPI implements Tenant {
                   try {
                     // close clients because they still use the old oid of the dropped schema/role name,
                     // they will fail when the same schema/role is recreated with a new oid.
-                    PostgresClient.closeAllClients();
+                    PostgresClient.closeAllClients(tenantId);
                     String res = "";
                     if(reply.succeeded()){
                       res = new JsonArray(reply.result()).encodePrettily();

--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -96,12 +96,15 @@ public class TenantAPI implements Tenant {
             postgresClient(context).runSQLFile(sqlFile, true,
                 reply -> {
                   try {
+                    // close clients because they still use the old oid of the dropped schema/role name,
+                    // they will fail when the same schema/role is recreated with a new oid.
+                    PostgresClient.closeAllClients();
                     String res = "";
                     if(reply.succeeded()){
                       res = new JsonArray(reply.result()).encodePrettily();
                       if(reply.result().size() > 0){
                         log.error("Unable to run the following commands during tenant delete: ");
-                        reply.result().forEach(System.out::println);
+                        reply.result().forEach(log::error);
                         handlers.handle(failedFuture(DeleteTenantResponse.respond400WithTextPlain(res)));
                       }
                       else {

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -2028,7 +2028,7 @@ public class PostgresClient {
       queryHelper.countQuery = SELECT + "count(*) FROM (" + query + ") x";
     } else if (!wrapper.getWhereClause().isEmpty()) {
       // only do estimation when filter is in use (such as CQL).
-      queryHelper.countQuery = SELECT + "count_estimate('"
+      queryHelper.countQuery = SELECT + schemaName + DOT + "count_estimate('"
         + org.apache.commons.lang.StringEscapeUtils.escapeSql(query)
         + "')";
     }

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/delete.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/delete.ftl
@@ -1,6 +1,5 @@
 -- This is run for any module, a removal of the schema and user for a specific tenant
 -- There is no per module configuration here so a delete of tenant will always run the below
 
-REVOKE ALL PRIVILEGES ON DATABASE postgres from ${myuniversity}_${mymodule};
 DROP SCHEMA IF EXISTS ${myuniversity}_${mymodule} CASCADE;
-DROP USER IF EXISTS ${myuniversity}_${mymodule};
+DROP ROLE IF EXISTS ${myuniversity}_${mymodule};

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -356,6 +356,14 @@ public class TenantAPIIT {
     tenantDelete(context);  // delete existing tenant
     assertThat(tenantGet(context), is(false));
     tenantDelete(context);  // delete non existing tenant
+    assertThat(tenantGet(context), is(false));
+    tenantPost(context);    // create tenant
+    assertThat(tenantGet(context), is(true));
+
+    String sql = "SELECT count(*) FROM " + PostgresClient.convertToPsqlStandard(tenantId) + ".test_tenantapi";
+    PostgresClient.getInstance(vertx, tenantId).selectSingle(sql, context.asyncAssertSuccess(result -> {
+      assertThat(result.getInteger(0), is(0));
+    }));
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -3,6 +3,7 @@ package org.folio.rest.persist;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -228,7 +229,24 @@ public class PostgresClientIT {
   public void closeAllClients(TestContext context) {
     PostgresClient c = PostgresClient.getInstance(vertx);
     context.assertNotNull(PostgresClientHelper.getClient(c), "getClient()");
+    assertThat(PostgresClient.getConnectionPoolSize(), is(not(0)));
     PostgresClient.closeAllClients();
+    assertThat(PostgresClient.getConnectionPoolSize(), is(0));
+  }
+
+  @Test
+  public void closeAllClientsTenant(TestContext context) {
+    PostgresClient.closeAllClients();
+    PostgresClient.getInstance(vertx, "a");
+    PostgresClient.getInstance(Vertx.vertx(), "a");
+    PostgresClient.getInstance(vertx, "b");
+    assertThat(PostgresClient.getConnectionPoolSize(), is(3));
+    PostgresClient.closeAllClients("c");
+    assertThat(PostgresClient.getConnectionPoolSize(), is(3));
+    PostgresClient.closeAllClients("b");
+    assertThat(PostgresClient.getConnectionPoolSize(), is(2));
+    PostgresClient.closeAllClients("a");
+    assertThat(PostgresClient.getConnectionPoolSize(), is(0));
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -224,13 +224,13 @@ public class SchemaMakerTest {
   }
 
   @Test
-  public void delete() throws IOException, TemplateException {
+  public void deleteSchema() throws IOException, TemplateException {
 
     SchemaMaker schemaMaker = schemaMaker("harvard", "circ", TenantOperation.DELETE,
       "mod-foo-18.2.3", "mod-foo-18.2.4", "templates/db_scripts/scriptexists.json");
 
-    assertThat(tidy(schemaMaker.generateDDL()), containsString(
-        "REVOKE ALL PRIVILEGES ON DATABASE"));
+    assertThat(tidy(schemaMaker.generateDDL()), allOf(
+        containsString("DROP SCHEMA "), containsString("DROP ROLE ")));
   }
 
   @Test


### PR DESCRIPTION
After dropping schema and role the database connection still uses
the old oid. This will fail when schema and role are recreated
with the same name but a different oid.

Solution:

Close all database connections when dropping schema and role.

Other changes:
* Fix error logging (switch from System.out to log.error).
* Use schema name when calling count_estimate; this results in
  a better error message: "permission problem" instead of "not found"
  when permissions are missing.
* Remove "REVOKE ALL PRIVILEGES ON DATABASE postgres". This is
  not needed. Even if it were needed the hard-coded database
  name "postgres" may be wrong, can be "folio".
* Use "DROP ROLE" (= SQL standard) and not the PostgreSQL synonym
  "DROP USER"; this parallels "CREATE ROLE".