### PR TITLE
RMB-735: Reject unsupported sort modifiers in getWithOptimizedSql

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -34,6 +34,7 @@ import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
 import org.folio.util.UuidUtil;
 import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.CQLFeatureUnsupportedException;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.cql2pgjson.exception.QueryValidationException;
 import org.folio.rest.persist.cql.CQLWrapper;
@@ -1083,7 +1084,7 @@ public final class PgUtil {
     }
   }
 
-  private static String getAscDesc(ModifierSet modifierSet) {
+  private static String getAscDesc(ModifierSet modifierSet) throws CQLFeatureUnsupportedException {
     String ascDesc = "";
     for (Modifier modifier : modifierSet.getModifiers()) {
       switch (modifier.getType()) {
@@ -1094,7 +1095,7 @@ public final class PgUtil {
         ascDesc = "DESC";
         break;
       default:
-        // ignore
+        throw new CQLFeatureUnsupportedException("CQL: Unsupported modifier " + modifier.getType());
       }
     }
     return ascDesc;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
@@ -1072,7 +1072,7 @@ public class PgUtilIT {
   @Test
   public void optimizedSQLwithNo500(TestContext testContext) {
     PgUtil.getWithOptimizedSql("users", User.class, UserdataCollection.class,
-        "title", "username=a sortBy title", 0, 10,
+        "title", "username=a sortBy username", 0, 10,
         okapiHeaders, vertx.getOrCreateContext(), ResponseWithout500.class, testContext.asyncAssertFailure(e -> {
           assertThat(e, is(instanceOf(NullPointerException.class)));
         }));
@@ -1090,14 +1090,14 @@ public class PgUtilIT {
 
   @Test
   public void optimizedSqlInvalidSortModifier(TestContext testContext) {
-    String cql = "username=a sortBy title/sort.ignoreCase";
+    String cql = "username=a sortBy username/sort.ignoreCase";
     String msg = searchForDataExpectFailure(cql, 0, 10, testContext);
     assertThat(msg, containsString("Unsupported modifier sort.ignorecase"));
   }
 
   @Test
   public void optimizedSqlInvalidSortModifier2(TestContext testContext) {
-    String cql = "username=a sortBy title/sort.ascending/sort.respectAccents";
+    String cql = "username=a sortBy username/sort.ascending/sort.respectAccents";
     String msg = searchForDataExpectFailure(cql, 0, 10, testContext);
     assertThat(msg, containsString("Unsupported modifier sort.respectaccents"));
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
@@ -1071,11 +1071,11 @@ public class PgUtilIT {
 
   @Test
   public void optimizedSQLwithNo500(TestContext testContext) {
-    PgUtil.getWithOptimizedSql("users", User.class, UserdataCollection.class, "title", "username=a sortBy title",
-        0, 10, okapiHeaders, vertx.getOrCreateContext(), ResponseWithout500.class, response -> {
-
-          testContext.assertTrue( response.cause() instanceof NullPointerException);
-        });
+    PgUtil.getWithOptimizedSql("users", User.class, UserdataCollection.class,
+        "title", "username=a sortBy title", 0, 10,
+        okapiHeaders, vertx.getOrCreateContext(), ResponseWithout500.class, testContext.asyncAssertFailure(e -> {
+          assertThat(e, is(instanceOf(NullPointerException.class)));
+        }));
   }
 
   @Test
@@ -1086,6 +1086,20 @@ public class PgUtilIT {
     assertThat(PgUtil.getOptimizedSqlSize(), is(newSize));
     PgUtil.setOptimizedSqlSize(oldSize);
     assertThat(PgUtil.getOptimizedSqlSize(), is(oldSize));
+  }
+
+  @Test
+  public void optimizedSqlInvalidSortModifier(TestContext testContext) {
+    String cql = "username=a sortBy title/sort.ignoreCase";
+    String msg = searchForDataExpectFailure(cql, 0, 10, testContext);
+    assertThat(msg, containsString("Unsupported modifier sort.ignorecase"));
+  }
+
+  @Test
+  public void optimizedSqlInvalidSortModifier2(TestContext testContext) {
+    String cql = "username=a sortBy title/sort.ascending/sort.respectAccents";
+    String msg = searchForDataExpectFailure(cql, 0, 10, testContext);
+    assertThat(msg, containsString("Unsupported modifier sort.respectaccents"));
   }
 
   private void setUpUserDBForTest(TestContext testContext, PostgresClient pg) {
@@ -1241,7 +1255,7 @@ public class PgUtilIT {
     return userdataCollection;
   }
   private String searchForDataExpectFailure(String cql, int offset, int limit, TestContext testContext) {
-    String responseString = new String();
+    StringBuilder responseString = new StringBuilder();
     Async async = testContext.async();
     PgUtil.getWithOptimizedSql(
         "users", User.class, UserdataCollection.class, "username", cql, offset, limit,
@@ -1254,11 +1268,11 @@ public class PgUtilIT {
             return;
           }
           String c = (String) response.getEntity();
-          responseString.concat(c);
+          responseString.append(c);
           async.complete();
     }));
     async.awaitSuccess(10000 /* ms */);
-    return responseString;
+    return responseString.toString();
   }
   private String searchForDataNullHeadersExpectFailure(String cql, int offset, int limit, TestContext testContext) {
     String responseString = new String();


### PR DESCRIPTION
Sorting in CQL is expessed using the sortby keyword followed by
a list of sort-keys, each expressed as a CQL index data optionally
followed by one or more index modifiers — see
http://zing.z3950.org/cql/sorting.html#6.
For example, title/sort.descending/sort.ignorecase.

RMB handles the sort.ascending and sort.descending modifiers.
It rejects all other sort modifiers with a
CQLFeatureUnsupportedException:
https://github.com/folio-org/raml-module-builder/blob/v31.1.0/cql2pgjson/src/main/java/org/folio/cql2pgjson/model/CqlModifiers.java#L71

For optimized queries (that we use for instance.title only)
we have some lazy code that doesn't reject other sort modifiers:
https://github.com/folio-org/raml-module-builder/blob/v31.1.0/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java#L1097

This pull request fixes this inconsistency: Reject unsupported sort
modifiers in optimized queries (PgUtil.getWithOptimizedSql) as well.

Example that demonstrates the inconsistency:

((keyword=water) and (source=marc)) sortby title/sort.missingLow/sort.ascending/sort.respectCase

is accepted; but if I add another sort-key, hrid/sort.descending
— which you will note does not include a "missing-value" modified — yielding

((keyword=water) and (source=marc)) sortby title/sort.missingLow/sort.ascending/sort.respectCase hrid/sort.descending

then that sort is rejected with "Unsupported modifier sort.missinglow".
That can't be right.

Note that RMB uses schema.json to determine whether the index is
case sensitive or accents sensitive. See https://issues.folio.org/browse/RMB-734
for the feature request to allow those sort modifiers that match
the index definition in schema.json.