### PR TITLE
RMB-732: doStreamGetQuery returns only 100 records when limit>100

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -93,7 +93,9 @@ public class PostgresClient {
   /** default analyze threshold value in milliseconds */
   static final long              EXPLAIN_QUERY_THRESHOLD_DEFAULT = 1000;
 
-  static final String COUNT_FIELD = "count";
+  static final String            COUNT_FIELD = "count";
+
+  static final int               STREAM_GET_DEFAULT_CHUNK_SIZE = 100;
 
   private static final String    ID_FIELD                 = "id";
   private static final String    RETURNING_ID             = " RETURNING id ";
@@ -104,8 +106,6 @@ public class PostgresClient {
   private static final int       DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
   private static final String    POSTGRES_LOCALHOST_CONFIG = "/postgres-conf.json";
   private static final int       EMBEDDED_POSTGRES_PORT   = 6000;
-
-  private static final int       STREAM_GET_DEFAULT_CHUNK_SIZE = 100;
 
   private static final String    SELECT = "SELECT ";
   private static final String    UPDATE = "UPDATE ";
@@ -712,11 +712,7 @@ public class PostgresClient {
         handler.handle(ar);
         return;
       }
-      SQLConnection sqlConnection = conn.result();
-      if (sqlConnection.conn != null) {
-        sqlConnection.conn.close();
-      }
-      cancelConnectionTimeoutTimer(sqlConnection);
+      conn.result().close(vertx);
       handler.handle(ar);
     };
   }
@@ -1739,19 +1735,19 @@ public class PostgresClient {
       null, 0, replyHandler);
   }
 
-   /**
+  /**
    * Stream GET with CQLWrapper, no facets {@link org.folio.rest.persist.PostgresClientStreamResult}
-    * @param <T>
-    * @param table
-    * @param clazz
-    * @param fieldName
-    * @param filter
-    * @param returnIdField
-    * @param distinctOn may be null
-    * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
-    * @param replyHandler AsyncResult; on success with result {@link PostgresClientStreamResult}
-    */
-   @SuppressWarnings({"squid:S00107"})    // Method has >7 parameters
+   * @param <T>
+   * @param table
+   * @param clazz
+   * @param fieldName
+   * @param filter
+   * @param returnIdField
+   * @param distinctOn may be null
+   * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
+   * @param replyHandler AsyncResult; on success with result {@link PostgresClientStreamResult}
+   */
+  @SuppressWarnings({"squid:S00107"})    // Method has >7 parameters
   public <T> void streamGet(String table, Class<T> clazz, String fieldName,
        CQLWrapper filter, boolean returnIdField, String distinctOn,
        int queryTimeout, Handler<AsyncResult<PostgresClientStreamResult<T>>> replyHandler) {
@@ -1760,7 +1756,29 @@ public class PostgresClient {
       null, queryTimeout, replyHandler);
   }
 
-    /**
+  /**
+   * Close conn before calling {@link PostgresClientStreamResult#endHandler(Handler)} or
+   * {@link PostgresClientStreamResult#exceptionHandler(Handler)}, and on failed result.
+   * @param conn the connection to close
+   * @return a handler that ensures that the connection gets closed
+   */
+  <T> Handler<AsyncResult<PostgresClientStreamResult<T>>> closeAtEnd(
+      AsyncResult<SQLConnection> conn, Handler<AsyncResult<PostgresClientStreamResult<T>>> replyHandler) {
+    return asyncResult -> {
+      try {
+        if (asyncResult.succeeded()) {
+          asyncResult.result().setCloseHandler(close -> conn.result().close(vertx));
+        } else {
+          conn.result().close(vertx);
+        }
+        replyHandler.handle(asyncResult);
+      } catch (Exception e) {
+        replyHandler.handle(Future.failedFuture(e));
+      }
+    };
+  }
+
+  /**
    * Stream GET with CQLWrapper and facets {@link org.folio.rest.persist.PostgresClientStreamResult}
    * @param <T>
    * @param table
@@ -1779,7 +1797,7 @@ public class PostgresClient {
 
     getSQLConnection(0, conn ->
         streamGet(conn, table, clazz, fieldName, filter, returnIdField,
-            distinctOn, facets, closeAndHandleResult(conn, replyHandler)));
+            distinctOn, facets, closeAtEnd(conn, replyHandler)));
   }
 
   /**
@@ -1803,7 +1821,7 @@ public class PostgresClient {
 
     getSQLConnection(queryTimeout, conn ->
         streamGet(conn, table, clazz, fieldName, filter, returnIdField,
-            distinctOn, facets, closeAndHandleResult(conn, replyHandler)));
+            distinctOn, facets, closeAtEnd(conn, replyHandler)));
   }
 
   /**
@@ -1856,7 +1874,6 @@ public class PostgresClient {
     try {
       QueryHelper queryHelper = buildQueryHelper(table,
         fieldName, wrapper, returnIdField, facets, distinctOn);
-
       connection.conn.query(queryHelper.countQuery).execute(countQueryResult -> {
         if (countQueryResult.failed()) {
           replyHandler.handle(Future.failedFuture(countQueryResult.cause()));
@@ -2645,7 +2662,6 @@ public class PostgresClient {
     ResultsHelper<T> resultsHelper, Map<String, Method> externalColumnSetters,
     boolean isAuditFlavored, Row row
   ) throws IOException, InstantiationException, IllegalAccessException, InvocationTargetException {
-
     Object jo = row.getValue(DEFAULT_JSONB_FIELD_NAME);
     Object o = null;
     resultsHelper.facet = false;
@@ -3113,13 +3129,6 @@ public class PostgresClient {
       SQLConnection sqlConnection = new SQLConnection(pgConnection, null, timerId);
       handler.handle(Future.succeededFuture(sqlConnection));
     });
-  }
-
-  private void cancelConnectionTimeoutTimer(SQLConnection sqlConnection) {
-    Long timeId = sqlConnection.timerId;
-    if (timeId != null) {
-      vertx.cancelTimer(timeId);
-    }
   }
 
   /**

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientStreamResult.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientStreamResult.java
@@ -16,6 +16,7 @@ class PostgresClientStreamResult<T> implements ReadStream<T> {
   private Handler<T> streamHandler;
   private Handler<Void> endHandler;
   private Handler<Throwable> exceptionHandler;
+  private Handler<Void> closeHandler;
   private boolean failed = false; // to ensure exceptionHandler being called at most once
 
   /**
@@ -75,7 +76,16 @@ class PostgresClientStreamResult<T> implements ReadStream<T> {
   }
 
   /**
-   * Only to be called by PostgresCLient itself
+   * Set a handler that is called before the endHandler or the exceptionHandler is to be fired.
+   * The handler is called even if endHandler or exceptionHandler is null.
+   */
+  PostgresClientStreamResult<T> setCloseHandler(Handler<Void> closeHandler) {
+    this.closeHandler = closeHandler;
+    return this;
+  }
+
+  /**
+   * Only to be called by PostgresClient itself
    *
    * @param t
    */
@@ -89,6 +99,9 @@ class PostgresClientStreamResult<T> implements ReadStream<T> {
    * Only to be called by PostgresClient itself
    */
   void fireEndHandler() {
+    if (closeHandler != null) {
+      closeHandler.handle(null);
+    }
     if (endHandler != null) {
       endHandler.handle(null);
     }
@@ -104,6 +117,13 @@ class PostgresClientStreamResult<T> implements ReadStream<T> {
       return;
     }
     failed = true;
+    if (closeHandler != null) {
+      try {
+        closeHandler.handle(null);
+      } catch (Exception e) {
+        // ignore yet another exception, connection may have been closed before
+      }
+    }
     if (exceptionHandler != null) {
       exceptionHandler.handle(cause);
     }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/SQLConnection.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/SQLConnection.java
@@ -1,5 +1,6 @@
 package org.folio.rest.persist;
 
+import io.vertx.core.Vertx;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.sqlclient.Transaction;
 
@@ -13,5 +14,27 @@ public class SQLConnection {
     this.conn = conn;
     this.tx = tx;
     this.timerId = timerId;
+  }
+
+  /**
+   * Close the connection and cancel the timer.
+   * @param vertx The {@link Vertx} that started the timer, ignored if timerId is null.
+   */
+  public void close(Vertx vertx) {
+    RuntimeException timerException = null;
+    if (timerId != null) {
+      try {
+        vertx.cancelTimer(timerId);
+      } catch (RuntimeException e) {
+        timerException = e;
+      }
+    }
+    if (conn != null) {
+      conn.close();
+    }
+    if (timerException != null) {
+      // first close the connection, then throw the exception
+      throw timerException;
+    }
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2881,7 +2881,7 @@ public class PostgresClientIT {
     createTableWithPoLines(context, MOCK_POLINES_TABLE, tableDefiniton);
     CQLWrapper wrapper = new CQLWrapper(new CQL2PgJSON("jsonb"), "edition=Millenium edition");
     postgresClient.streamGet(MOCK_POLINES_TABLE, Object.class, "jsonb", wrapper, true, null,
-      facets, QUERY_TIMEOUT, context.asyncAssertSuccess(sr -> {
+      facets, context.asyncAssertSuccess(sr -> {
         ResultInfo resultInfo = sr.resultInto();
         context.assertEquals(0, resultInfo.getTotalRecords());
         context.assertEquals(0, resultInfo.getFacets().size());

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2705,6 +2705,60 @@ public class PostgresClientIT {
   }
 
   @Test
+  public void closeAtEndException(TestContext context) throws Exception {
+    Async async = context.async();
+    CQLWrapper cql = new CQLWrapper(new CQL2PgJSON("jsonb"), "id=*", 1, /* offset */ 0);
+    postgresClient = createTable(context, TENANT, MOCK_POLINES_TABLE, "id UUID PRIMARY KEY, jsonb JSONB NOT NULL");
+    postgresClient.streamGet(MOCK_POLINES_TABLE, Object.class, "jsonb", cql, false, null, 0,
+        asyncResult -> {
+          if (asyncResult.succeeded()) {
+            throw new RuntimeException("foo");
+          } else {
+            context.assertEquals("foo", asyncResult.cause().getMessage());
+            async.complete();
+          }
+        });
+  }
+
+  private void streamGetCursorPage(TestContext context, int limit) throws Exception {
+    Async async = context.async();
+    CQLWrapper cql = new CQLWrapper(new CQL2PgJSON("jsonb"), "id=*", limit, /* offset */ 0);
+    postgresClient.streamGet(MOCK_POLINES_TABLE, Object.class, "jsonb", cql, false, null,
+        context.asyncAssertSuccess(r -> {
+          AtomicInteger count = new AtomicInteger();
+          r.handler(streamHandler -> {
+            count.incrementAndGet();
+          });
+          r.endHandler(x -> {
+            context.assertEquals(limit, count.get());
+            async.complete();
+          });
+          r.exceptionHandler(e -> context.fail(e));
+        }));
+  }
+
+  @Test
+  public void streamGetCursorPage(TestContext context) throws Exception {
+    String schema = PostgresClient.convertToPsqlStandard(TENANT);
+    postgresClient = createTable(context, TENANT, MOCK_POLINES_TABLE, "id UUID PRIMARY KEY, jsonb JSONB NOT NULL");
+    int n = PostgresClient.STREAM_GET_DEFAULT_CHUNK_SIZE;
+    int max = 2*n+1;
+    execute(context,
+        "INSERT INTO " + schema + "." + MOCK_POLINES_TABLE +
+        " SELECT id, jsonb_build_object('id', id) as json" +
+        " FROM (SELECT md5(generate_series(1, " + max + ")::text)::uuid) x(id)");
+    // check that it works at the borders of the pages (chunks) we use for the SQL cursor
+    streamGetCursorPage(context, 0);
+    streamGetCursorPage(context, 1);
+    streamGetCursorPage(context, n-1);
+    streamGetCursorPage(context, n);
+    streamGetCursorPage(context, n+1);
+    streamGetCursorPage(context, 2*n-1);
+    streamGetCursorPage(context, 2*n);
+    streamGetCursorPage(context, 2*n+1);
+  }
+
+  @Test
   public void streamGetUnsupported(TestContext context) throws IOException, FieldException {
     final String tableDefiniton = "id UUID PRIMARY KEY , jsonb JSONB NOT NULL, distinct_test_field TEXT";
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/SQLConnectionTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/SQLConnectionTest.java
@@ -1,0 +1,16 @@
+package org.folio.rest.persist;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+import io.vertx.pgclient.PgConnection;
+import org.junit.jupiter.api.Test;
+
+public class SQLConnectionTest {
+  @Test
+  void closeConnectionAfterTimerException() {
+    PgConnection pgConnection = mock(PgConnection.class);
+    assertThrows(NullPointerException.class, () -> new SQLConnection(pgConnection, null, 5L).close(null));
+    verify(pgConnection).close();
+  }
+}


### PR DESCRIPTION
closeAndHandleResult closes the connection immediately after sending
the query preventing to get more than 100 records (cursor chunk size).

Fix it by using closeAtEnd that waits until all records of
all cursor chunks have been read.