### PR TITLE
RMB-738: Upgrade to Vert.x 3.9.4

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -2662,7 +2662,8 @@ public class PostgresClient {
     ResultsHelper<T> resultsHelper, Map<String, Method> externalColumnSetters,
     boolean isAuditFlavored, Row row
   ) throws IOException, InstantiationException, IllegalAccessException, InvocationTargetException {
-    Object jo = row.getValue(DEFAULT_JSONB_FIELD_NAME);
+    int columnIndex = row.getColumnIndex(DEFAULT_JSONB_FIELD_NAME);
+    Object jo = columnIndex == -1 ? null : row.getValue(columnIndex);
     Object o = null;
     resultsHelper.facet = false;
 
@@ -2740,6 +2741,13 @@ public class PostgresClient {
     }
   }
 
+  private boolean isStringArrayType(Object value) {
+    // https://github.com/eclipse-vertx/vertx-sql-client/blob/4.0.0.Beta3/vertx-sql-client/src/main/java/io/vertx/sqlclient/Tuple.java#L737
+    return value instanceof String[] ||
+        value instanceof Enum[] ||
+        (value != null && value.getClass() == Object[].class);
+  }
+
   /**
    * populate jsonb object with values from external columns - for example:
    * if there is an update_date column in the record - try to populate a field updateDate in the
@@ -2757,11 +2765,12 @@ public class PostgresClient {
     for (Map.Entry<String, Method> entry : externalColumnSetters.entrySet()) {
       String columnName = entry.getKey();
       Method method = entry.getValue();
-      String[] stringArray = row.getStringArray(columnName);
-      if (stringArray != null) {
-        method.invoke(o, Arrays.asList(stringArray));
+      int columnIndex = row.getColumnIndex(columnName);
+      Object value = columnIndex == -1 ? null : row.getValue(columnIndex);
+      if (isStringArrayType(value)) {
+        method.invoke(o, Arrays.asList(row.getStringArray(columnIndex)));
       } else {
-        method.invoke(o, row.getValue(columnName));
+        method.invoke(o, value);
       }
     }
   }
@@ -2834,7 +2843,7 @@ public class PostgresClient {
           RowIterator<Row> iterator = explain.result().iterator();
           while (iterator.hasNext()) {
             Row row = iterator.next();
-            e.append('\n').append(row.getString(0));
+            e.append('\n').append(row.getValue(0));
           }
           log.warn(e.toString());
         });

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -243,13 +242,14 @@ public class PostgresClientTest {
   }
 
   @Test
-  public void testPopulateExternalColumns() throws InvocationTargetException, IllegalAccessException {
+  public void testPopulateExternalColumns() throws Exception {
     PostgresClient testClient = PostgresClient.testClient();
     List<String> columnNames = new ArrayList<String>(Arrays.asList(new String[] {
       "id", "foo", "bar", "biz", "baz"
     }));
     Map<String, Method> externalColumnSetters = new HashMap<>();
     testClient.collectExternalColumnSetters(columnNames, TestPojo.class, false, externalColumnSetters);
+    externalColumnSetters.put("nonExistingColumn", TestPojo.class.getMethod("setBar", String.class));
     TestPojo o = new TestPojo();
     String foo = "Hello";
     String bar = "World";

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.3</version>
+        <version>3.9.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Release notes: https://github.com/vert-x3/wiki/wiki/3.9.4-Release-Notes

Most notable fix:
* RowStream fetch can close prematurely the stream
  https://github.com/eclipse-vertx/vertx-sql-client/issues/778

SQL Row has breaking changes that require unit tests changes:

* Row getters throw a NoSuchElementException when getting non existing column
  https://github.com/eclipse-vertx/vertx-sql-client/issues/775

* Tuple/Row getters throw a ClassCastException when getting incorrect types
  https://github.com/eclipse-vertx/vertx-sql-client/issues/774