### PR TITLE
RMB-740: Use FOLIO fork of vertx-sql-client and vertx-pg-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <aspectj.version>1.9.6</aspectj.version>
     <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <postgresql-embedded-version>2.10</postgresql-embedded-version>
+    <vertx.version>3.9.4</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -51,9 +52,19 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.4</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
The FOLIO fork https://github.com/folio-org/vertx-sql-client of the
upstream vertx-sql-client and vertx-pg-client driver contains these patches:

* https://issues.folio.org/browse/RMB-739 patch idle connection release in the forked vertx-sql-client driver
* https://issues.folio.org/browse/FOLIO-2840 Unsigned long HexSequence for name of PgPreparedStatement

Change RMB dependencies to use the forked version instead of the upstream version.