### PR TITLE
FOLREL-445: Release RMB v30.2.9

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+## 30.2.9 2020-10-23
+
+ * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+   the following two patches
+ * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
+ * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
+ * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
+   can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778
+
 ## 30.2.8 2020-10-12
 
  * [RMB-732](https://issues.folio.org/browse/RMB-732) doStreamGetQuery returns only 100 records when limit>100

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <properties>

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <properties>

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -21,6 +21,38 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
   "may not be null" changed to "must not be null" (hibernate-validator)
 * [RMB-693](https://issues.folio.org/browse/RMB-693) If using
   PostgresClient#selectStream always call RowStream#close.
+* [RMB-738](https://issues.folio.org/browse/RMB-738) Since RMB 30.2.9:
+  Upgrade to Vert.x 3.9.4
+* [RMB-740](https://issues.folio.org/browse/RMB-740) Since RMB 30.2.9:
+  Use FOLIO fork of vertx-sql-client and vertx-pg-client,
+  [example pom.xml](https://github.com/folio-org/raml-module-builder/commit/1481635d291fc6191366aeb276c8e23fad038655):
+```
+  <properties>
+    <vertx.version>3.9.4</vertx.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.9.4</version>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+```
 
 ## Version 30.0
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-interface-extensions</artifactId>
 

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
   <artifactId>domain-models-interface-extensions</artifactId>
 

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>30.2.9-SNAPSHOT</version>
+  <version>30.2.9</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -400,7 +400,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v30.2.9</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>30.2.9</version>
+  <version>30.2.10-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -400,7 +400,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>v30.2.9</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9</version>
+    <version>30.2.10-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>30.2.9-SNAPSHOT</version>
+    <version>30.2.9</version>
   </parent>
 
   <artifactId>util</artifactId>


### PR DESCRIPTION
 * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
   the following two patches
 * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
 * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
 * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch
   can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778