### PR TITLE
FOLREL-446: Release RMB 31.1.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## 31.1.3 2020-10-23
+
+ * [RMB-737](https://issues.folio.org/browse/RMB-737): Update to Junit and jupiter to 4.13.1
+ * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+   the following two patches
+ * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
+ * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
+ * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fixed bug: RowStream fetch
+   can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778
+
 ## 31.1.2 2020-10-12
 
  * [RMB-732](https://issues.folio.org/browse/RMB-732) doStreamGetQuery returns only 100 records when limit>100

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <properties>

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -4,6 +4,7 @@ These are notes to assist upgrading to newer versions.
 See the [NEWS](../NEWS.md) summary of changes for each version.
 
 <!-- ../../okapi/doc/md2toc -l 2 -h 3 upgrading.md -->
+* [Version 31.1](#version-311)
 * [Version 31.0](#version-310)
 * [Version 30.2](#version-302)
 * [Version 30.0](#version-300)
@@ -16,6 +17,41 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 * [Version 26](#version-26)
 * [Version 25](#version-25)
 * [Version 20](#version-20)
+
+## Version 31.1
+
+* [RMB-738](https://issues.folio.org/browse/RMB-738) Since RMB 30.2.9 and 31.1.3:
+  Upgrade to Vert.x 3.9.4
+* [RMB-740](https://issues.folio.org/browse/RMB-740) Since RMB 30.2.9 and 31.1.3:
+  Use FOLIO fork of vertx-sql-client and vertx-pg-client,
+  [example pom.xml](https://github.com/folio-org/raml-module-builder/commit/1481635d291fc6191366aeb276c8e23fad038655):
+```
+  <properties>
+    <vertx.version>3.9.4</vertx.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>3.9.4</version>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+```
 
 ## Version 31.0
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
   <artifactId>domain-models-interface-extensions</artifactId>
 

--- a/domain-models-interface-extensions/pom.xml
+++ b/domain-models-interface-extensions/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-interface-extensions</artifactId>
 

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -243,13 +242,14 @@ public class PostgresClientTest {
   }
 
   @Test
-  public void testPopulateExternalColumns() throws InvocationTargetException, IllegalAccessException {
+  public void testPopulateExternalColumns() throws Exception {
     PostgresClient testClient = PostgresClient.testClient();
     List<String> columnNames = new ArrayList<String>(Arrays.asList(new String[] {
       "id", "foo", "bar", "biz", "baz"
     }));
     Map<String, Method> externalColumnSetters = new HashMap<>();
     testClient.collectExternalColumnSetters(columnNames, TestPojo.class, false, externalColumnSetters);
+    externalColumnSetters.put("nonExistingColumn", TestPojo.class.getMethod("setBar", String.class));
     TestPojo o = new TestPojo();
     String foo = "Hello";
     String bar = "World";

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.3</version>
+        <version>3.9.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <aspectj.version>1.9.6</aspectj.version>
     <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <postgresql-embedded-version>2.10</postgresql-embedded-version>
+    <vertx.version>3.9.4</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -51,9 +52,19 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>3.9.4</version>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-sql-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-pg-client</artifactId>
+        <version>${vertx.version}-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>io.rest-assured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <aspectj.version>1.9.6</aspectj.version>
-    <junit-jupiter-version>5.6.0</junit-jupiter-version>
+    <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <postgresql-embedded-version>2.10</postgresql-embedded-version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13</version>
+        <version>4.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>31.1.3</version>
+  <version>31.1.4-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -385,7 +385,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>v31.1.3</tag>
+    <tag>v31.1.0</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>31.1.3-SNAPSHOT</version>
+  <version>31.1.3</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -385,7 +385,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>v31.1.0</tag>
+    <tag>v31.1.3</tag>
   </scm>
 
   <distributionManagement>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3-SNAPSHOT</version>
+    <version>31.1.3</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>31.1.3</version>
+    <version>31.1.4-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>


### PR DESCRIPTION
 * [RMB-737](https://issues.folio.org/browse/RMB-737): Update to Junit and jupiter to 4.13.1
 * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
   the following two patches
 * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
 * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
 * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fixed bug: RowStream fetch
   can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778