### PR TITLE
upgrading.md: colon in timezone

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -52,6 +52,9 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
   </dependencyManagement>
 ```
 
+* A colon has been added to the timezone to comply with RFC 3339,
+  `2017-07-27T10:23:43.000+0000` becomes `2017-07-27T10:23:43.000+00:00`.
+
 ## Version 31.0
 
 * [RMB-328](https://issues.folio.org/browse/RMB-328) Update to OpenJDK 11.


### PR DESCRIPTION
Backporting from master to b31.1
(cherry picked from commit abf281fac4291db8872a154480b27330d6f4692e)