### PR TITLE
Use okapi-common 4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.3.0</version>
+        <version>4.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Because Okapi 4.5.0 is also using Vert.x 4.0.0.