### PR TITLE
Remove jdbc driver from runtime RMB-642

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -22,7 +22,6 @@
     <filebeat_log_path>${basedir}/logs/filebeat</filebeat_log_path>
     <filebeat_registry_file>${basedir}/logs/filebeat/registry</filebeat_registry_file>
     <logstash_instance>ec2-52-27-98-246.us-west-2.compute.amazonaws.com:5044</logstash_instance>
-    <postgresql.version>9.4.1209</postgresql.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <generate_routing_context>/rmbtests/test</generate_routing_context>
   </properties>
@@ -126,12 +125,6 @@
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.process</artifactId>
       <version>2.0.5</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>${postgresql.version}</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3673,7 +3673,7 @@ public class PostgresClient {
   }
 
   /**
-   * Execute multiple SQL commands ine one transaction as superuser.
+   * Execute multiple SQL commands in a transaction as superuser.
    *<p>
    *   Currently this function always succeeds. Failure is indicated by
    *   the lines returned (empty on no errors).

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -22,20 +22,15 @@ import io.vertx.sqlclient.RowStream;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.Tuple;
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.StringReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,8 +42,6 @@ import java.util.regex.Pattern;
 import javax.crypto.SecretKey;
 import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.collections4.map.MultiKeyMap;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dbschema.util.SqlUtil;
@@ -64,16 +57,12 @@ import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.persist.interfaces.Results;
 import org.folio.rest.security.AES;
 import org.folio.rest.tools.PomReader;
-import org.folio.rest.tools.messages.MessageConsts;
 import org.folio.rest.tools.messages.Messages;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.LogUtil;
 import org.folio.rest.tools.utils.MetadataUtil;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.dbschema.ObjectMapperTool;
-import org.folio.rest.tools.utils.ResourceUtils;
-import org.postgresql.copy.CopyManager;
-import org.postgresql.core.BaseConnection;
 import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
 import ru.yandex.qatools.embed.postgresql.PostgresProcess;
 import ru.yandex.qatools.embed.postgresql.distribution.Version;
@@ -3582,25 +3571,6 @@ public class PostgresClient {
   }
 
   /**
-   * Drop the database if it exists.
-   * @param database  database name
-   * @throws SQLException  on database error
-   * @throws IllegalArgumentException  if database name is too long, contains
-   *          illegal characters or letters with diacritical marks or non-Latin letters
-   */
-  public void dropCreateDatabase(String database) throws SQLException {
-    if (! isValidPostgresIdentifier(database)) {
-      throw new IllegalArgumentException("Illegal character in database name: " + database);
-    }
-
-    try (Connection connection = getStandaloneConnection("postgres", true);
-        Statement statement = connection.createStatement()) {
-      statement.executeUpdate("DROP DATABASE IF EXISTS " + database); //NOSONAR
-      statement.executeUpdate("CREATE DATABASE " + database); //NOSONAR
-    }
-  }
-
-  /**
    * Split string into lines.
    */
   private static List<String> lines(String string) {
@@ -3702,155 +3672,56 @@ public class PostgresClient {
     }
   }
 
-  private Connection getStandaloneConnection(String newDB, boolean superUser) throws SQLException {
-    String host = postgreSQLClientConfig.getString(HOST);
-    int port = postgreSQLClientConfig.getInteger(PORT);
-    String user = postgreSQLClientConfig.getString(USERNAME);
-    String pass = postgreSQLClientConfig.getString(PASSWORD);
-    String db = postgreSQLClientConfig.getString(DATABASE);
-
-    if(newDB != null){
-      db = newDB;
-      if(!superUser){
-        pass = newDB;
-        user = newDB;
-      }
-    }
-    return DriverManager.getConnection(
-      "jdbc:postgresql://"+host+":"+port+"/"+db, user , pass);
-  }
-
   /**
-   * Copy files via the COPY FROM postgres syntax
-   * Support 3 modes
-   * 1. In line (STDIN) Notice the mandatory \. at the end of all entries to import
-   * COPY config_data (jsonb) FROM STDIN ENCODING 'UTF8';
-   * {"module":"SETTINGS","config_name":"locale","update_date":"1.1.2017","code":"system.currency_symbol.dk","description":"currency code","default": false,"enabled": true,"value": "kr"}
-   * \.
-   * 2. Copy from a data file packaged in the jar
-   * COPY config_data (jsonb) FROM 'data/locales.data' ENCODING 'UTF8';
-   * 3. Copy from a file on disk (absolute path)
-   * COPY config_data (jsonb) FROM 'C:\\Git\\configuration\\mod-configuration-server\\src\\main\\resources\\data\\locales.data' ENCODING 'UTF8';
-
-   * @param copyInStatement
-   * @param connection
-   * @throws Exception
+   * Execute multiple SQL commands ine one transaction as superuser.
+   *<p>
+   *   Currently this function always succeeds. Failure is indicated by
+   *   the lines returned (empty on no errors).
+   *</p>
+   * @param sql SQL lines
+   * @param stopOnError whether to ignore errors
+   * @param replyHandler result with lines that failed.
    */
-  private void copyIn(String copyInStatement, Connection connection) throws Exception {
-    long totalInsertedRecords = 0;
-    CopyManager copyManager = new CopyManager((BaseConnection) connection);
-    if(copyInStatement.contains("STDIN")){
-      //run as is
-      int sep = copyInStatement.indexOf("\n");
-      String copyIn = copyInStatement.substring(0, sep);
-      String data = copyInStatement.substring(sep+1);
-      totalInsertedRecords = copyManager.copyIn(copyIn, new StringReader(data));
-    }
-    else{
-      //copy from a file,
-      String[] valuesInQuotes = StringUtils.substringsBetween(copyInStatement , "'", "'");
-      if(valuesInQuotes.length == 0){
-        log.warn("SQL statement: COPY FROM, has no STDIN and no file path wrapped in ''");
-        throw new Exception("SQL statement: COPY FROM, has no STDIN and no file path wrapped in ''");
-      }
-      //do not read from the file system for now as this needs to support data files packaged in
-      //the jar, read files into memory and load - consider improvements to this
-      String filePath = valuesInQuotes[0];
-      String data;
-      if(new File(filePath).isAbsolute()){
-        data = FileUtils.readFileToString(new File(filePath), "UTF8");
-      }
-      else{
-        try {
-          //assume running from within a jar,
-          data = ResourceUtils.resource2String(filePath);
-        } catch (Exception e) {
-          //from IDE
-          data = ResourceUtils.resource2String("/"+filePath);
-        }
-      }
-      copyInStatement = copyInStatement.replace("'"+filePath+"'", "STDIN");
-      totalInsertedRecords = copyManager.copyIn(copyInStatement, new StringReader(data));
-    }
-    log.info("Inserted " + totalInsertedRecords + " via COPY IN. Tenant: " + tenantId);
-  }
-
   private void execute(String[] sql, boolean stopOnError,
-      Handler<AsyncResult<List<String>>> replyHandler){
+                       Handler<AsyncResult<List<String>>> replyHandler) {
 
     long s = System.nanoTime();
     log.info("Executing multiple statements with id " + Arrays.hashCode(sql));
-    List<String> results = new ArrayList<>();
-    vertx.executeBlocking(dothis -> {
-      Connection connection = null;
-      Statement statement = null;
-      boolean error = false;
-      try {
+    List<String> results = new LinkedList<>();
 
-        /* this should be  super user account that is in the config file */
-        connection = getStandaloneConnection(null, false);
-        connection.setAutoCommit(false);
-        statement = connection.createStatement();
-
-        for (int j = 0; j < sql.length; j++) {
-          try {
-            log.info("trying to execute: " + sql[j].substring(0, Math.min(sql[j].length()-1, 1000)));
-            if(sql[j].trim().toUpperCase().startsWith("COPY ")){
-              copyIn(sql[j], connection);
-            }
-            else{
-              statement.executeUpdate(sql[j]); //NOSONAR
-            }
-            log.info("Successfully executed: " + sql[j].substring(0, Math.min(sql[j].length()-1, 400)));
-          } catch (Exception e) {
-            results.add(sql[j]);
-            error = true;
-            log.error(e.getMessage(),e);
-            if(stopOnError){
-              break;
-            }
+    getInstance(vertx).getClient().getConnection()
+        .compose(conn -> conn.begin()
+            .compose(tx -> {
+              Future<Void> future = Future.succeededFuture();
+              for (int i = 0; i < sql.length; i++) {
+                String stmt = sql[i];
+                int fi = i;
+                future = future.compose(x -> {
+                  log.info("trying to execute: {}" + stmt);
+                  return conn.query(stmt).execute()
+                      .compose(good -> {
+                        log.info("Successfully executed {}", stmt);
+                        return Future.succeededFuture();
+                      }, res -> {
+                        results.add(stmt);
+                        if (stopOnError) {
+                          return Future.failedFuture(stmt);
+                        } else {
+                          log.error(res.getMessage(), res);
+                          return Future.succeededFuture();
+                        }
+                      }).mapEmpty();
+                });
+              }
+              return future.compose(x -> tx.commit()).eventually(y -> conn.close());
+            }))
+        .onComplete(x -> {
+          if (x.failed()) {
+            log.error(x.cause().getMessage(), x.cause());
           }
-        }
-        try {
-          if(error){
-            connection.rollback();
-            log.error("Rollback for: " + Arrays.hashCode(sql));
-          }
-          else{
-            connection.commit();
-            log.info("Successfully committed: " + Arrays.hashCode(sql));
-          }
-        } catch (Exception e) {
-          error = true;
-          log.error("Commit failed " + Arrays.hashCode(sql) + SPACE + e.getMessage(), e);
-        }
-      }
-      catch(Exception e){
-        log.error(e.getMessage(), e);
-        error = true;
-      }
-      finally {
-        try {
-          if(statement != null) statement.close();
-        } catch (Exception e) {
-          log.error(e.getMessage(), e);
-        }
-        try {
-          if(connection != null) connection.close();
-        } catch (Exception e) {
-          log.error(e.getMessage(), e);
-        }
-        if(error){
-          dothis.fail("error");
-        }
-        else{
-          dothis.complete();
-        }
-      }
-    }, done -> {
-      logTimer(EXECUTE_STAT_METHOD, "" + Arrays.hashCode(sql), s);
-      replyHandler.handle(Future.succeededFuture(results));
-    });
+          logTimer(EXECUTE_STAT_METHOD, "" + Arrays.hashCode(sql), s);
+          replyHandler.handle(Future.succeededFuture(results));
+        });
   }
 
   private static void rememberEmbeddedPostgres() {
@@ -3909,55 +3780,6 @@ public class PostgresClient {
         log.info("embedded postgress not enabled");
       }
     }
-  }
-
-  /**
-   * This is a blocking call - run in an execBlocking statement
-   * import data in a tab delimited file into columns of an existing table
-   * Using only default values of the COPY FROM STDIN Postgres command
-   * @param path - path to the file
-   * @param tableName - name of the table to import the content into
-   */
-  public void importFile(String path, String tableName) {
-
-    long recordsImported[] = new long[]{-1};
-    vertx.<String>executeBlocking(dothis -> {
-      try {
-        String host = postgreSQLClientConfig.getString(HOST);
-        int port = postgreSQLClientConfig.getInteger(PORT);
-        String user = postgreSQLClientConfig.getString(USERNAME);
-        String pass = postgreSQLClientConfig.getString(PASSWORD);
-        String db = postgreSQLClientConfig.getString(DATABASE);
-
-        log.info("Connecting to " + db);
-
-        Connection con = DriverManager.getConnection(
-          "jdbc:postgresql://"+host+":"+port+"/"+db, user , pass);
-
-        log.info("Copying text data rows from stdin");
-
-        CopyManager copyManager = new CopyManager((BaseConnection) con);
-
-        FileReader fileReader = new FileReader(path);
-        recordsImported[0] = copyManager.copyIn("COPY "+tableName+" FROM STDIN", fileReader );
-
-      } catch (Exception e) {
-        log.error(messages.getMessage("en", MessageConsts.ImportFailed), e);
-        dothis.fail(e);
-      }
-      dothis.complete("Done.");
-
-    }, whendone -> {
-
-      if(whendone.succeeded()){
-        log.info("Done importing file: " + path + ". Number of records imported: " + recordsImported[0]);
-      }
-      else{
-        log.info("Failed importing file: " + path);
-      }
-
-    });
-
   }
 
   public static void stopEmbeddedPostgres() {

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3695,7 +3695,6 @@ public class PostgresClient {
               Future<Void> future = Future.succeededFuture();
               for (int i = 0; i < sql.length; i++) {
                 String stmt = sql[i];
-                int fi = i;
                 future = future.compose(x -> {
                   log.info("trying to execute: {}" + stmt);
                   return conn.query(stmt).execute()

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -86,7 +86,7 @@ public class DemoRamlRestTest {
       Buffer buf = Buffer.buffer("{\"module_to\":\"raml-module-builder-1.0.0\"}");
       String location = postData(context, "http://localhost:" + port + "/_/tenant", buf,
         201, HttpMethod.POST, "application/json", TENANT, false);
-      checkURLs(context, "http://localhost:" + port + location, 200);
+      checkURLs(context, "http://localhost:" + port + location + "?wait=10000", 200);
 
     } catch (Exception e) {
       context.fail(e);

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -270,12 +270,16 @@ public class TenantAPIIT {
   public void previousSchemaSqlExistsTrue2(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI();
     String tenantId = TenantTool.tenantId(okapiHeaders);
-
+    Async async = context.async();
     // only run create.ftl .. This makes previousSchema to find nothing on 2nd invocation
     tenantAPI.sqlFile(vertx.getOrCreateContext(), tenantId, null, false)
         .compose(files -> tenantAPI.postgresClient(vertx.getOrCreateContext()).runSQLFile(files[0], true))
         .compose(x -> tenantAPI.previousSchema(vertx.getOrCreateContext(), tenantId, true)
-        .onComplete(context.asyncAssertSuccess(schema -> context.assertNull(schema))));
+        .onComplete(context.asyncAssertSuccess(schema -> {
+          context.assertNull(schema);
+          async.complete();
+        })));
+    async.await();
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/RunSQLIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/RunSQLIT.java
@@ -22,23 +22,26 @@ public class RunSQLIT {
   @Parameter(0)
   public int expectedResultSize;
   @Parameter(1)
+  public int expectedResult2;
+  @Parameter(2)
   public String sql;
 
   private Vertx vertx;
   private PostgresClient client;
 
-  @Parameterized.Parameters(name = "{0} {1}")
+  @Parameterized.Parameters(name = "{0} {1} {2}")
   static public Iterable<Object []> data() {
     return Arrays.asList(new Object [][] {
-      { 0, "update pg_database set datname=null where false" },
-      { 0, "update pg_database set datname=null where false;" },
-      { 0, "update pg_database set datname=null where false\n" },
-      { 1, "syntaxerror" },
-      { 1, "syntaxerror;" },
-      { 1, "syntaxerror\n" },
-      { 2, "syntaxerror1;\nsyntaxerror2" },
-      { 2, "syntaxerror1;\nsyntaxerror2;" },
-      { 2, "syntaxerror1;\nsyntaxerror2\n" }
+        { 0, 0, "update pg_database set datname=null where false" },
+        { 0, 0, "update pg_database set datname=null where false;" },
+        { 0, 0, "update pg_database set datname=null where false\n" },
+        { 1, 1, "update pg_database set datname=null where false\nsyntax error" },
+        { 1, 1, "syntaxerror" },
+        { 1, 1, "syntaxerror;" },
+        { 1, 1, "syntaxerror\n" },
+        { 2, 1, "syntaxerror1;\nsyntaxerror2" },
+        { 2, 1, "syntaxerror1;\nsyntaxerror2;" },
+        { 2, 1, "syntaxerror1;\nsyntaxerror2\n" }
     });
   }
 
@@ -62,4 +65,14 @@ public class RunSQLIT {
             "runSQL result.size()=" + result.size() + " [" + results + "]");
     }));
   }
+
+  @Test
+  public void sqlStopOnError(TestContext context) {
+    client.runSQLFile(sql, true, context.asyncAssertSuccess(result -> {
+      String results = result.stream().collect(Collectors.joining("\n"));
+      context.assertEquals(expectedResult2, result.size(),
+          "runSQL result.size()=" + result.size() + " [" + results + "]");
+    }));
+  }
+
 }


### PR DESCRIPTION
The driver is used for testing in cql2pgjson but that's not a problem.

These public methods were removed from PostgresClient: importFile and dropCreateDatabase

dropCreateDatabase is used by mod-vendors in a number of places, but that module is archived and deprecated.

importFile is also only used by deprecated-mod-acquisitions-postgres