### PR TITLE
RMB-786 change OL notice level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1817,10 +1817,10 @@ RMB supports optimistic locking. By default it is disabled. Module developer can
 
     * `off` Optimistic Locking is disabled. The trigger is removed if it existed before.
     * `failOnConflict` Optimistic Locking is enabled. Version conflict will fail the transaction
-    * `logOnConflict` Optimistic Locking is enabled. Version conflict info is logged as a warning message with a customized SQL error code 23F09. A sample log entry looks like below:
+    * `logOnConflict` Optimistic Locking is enabled. Version conflict info is logged with a customized SQL error code 23F09. A sample log entry looks like below:
 
 ```
-Backend notice: severity='WARNING', code='23F09', message='Cannot update record 57db089f-18e4-7815-55d5-4cc6607e9059 because it has been changed: Stored _version is 2, _version of request is "1"' ...
+Backend notice: severity='NOTICE', code='23F09', message='Cannot update record 57db089f-18e4-7815-55d5-4cc6607e9059 because it has been changed: Stored _version is 2, _version of request is "1"' ...
 ```
 Use mod-inventory-storage `instance` table as an example, do following to enable optimistic locking
 

--- a/domain-models-runtime/src/main/resources/templates/db_scripts/optimistic_locking.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/optimistic_locking.ftl
@@ -14,7 +14,7 @@
           <#if table.withOptimisticLocking.name() == "FAIL">
             <#assign ol_notice_level = "EXCEPTION">
           <#else>
-            <#assign ol_notice_level = "WARNING">
+            <#assign ol_notice_level = "NOTICE">
           </#if>
           RAISE ${ol_notice_level} 'Cannot update record % because it has been changed: '
               'Stored ${ol_version} is %, ${ol_version} of request is %',


### PR DESCRIPTION
Change trigger notice level so https://github.com/folio-org/mod-inventory-storage/pull/570 can pass unit tests with embedded PostgreSQL. I was able to verify it locally. Let's try it on b32.0 branch first.