### PR TITLE
RMB-799: Update Vert.x from 4.0.0 to 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.6</aspectj.version>
     <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <postgresql-embedded-version>2.10</postgresql-embedded-version>
-    <vertx.version>4.0.0</vertx.version>
+    <vertx.version>4.0.2</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->


### PR DESCRIPTION
Vertx 4.0.2 has many bug fixes, see release notes:

https://github.com/vert-x3/wiki/wiki/4.0.2-Release-Notes