### PR TITLE
RMB-803: Fix URL encoding in BuildCQL preventing CQL injection

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
@@ -1,11 +1,10 @@
 package org.folio.rest.tools.client;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.folio.rest.tools.parser.JsonPathParser;
+import org.folio.util.StringUtil;
 
 /**
  * @author shale
@@ -140,7 +139,7 @@ public class BuildCQL {
   }
 
   @SuppressWarnings("unchecked")
-  public String buildCQL() throws UnsupportedEncodingException {
+  public String buildCQL() {
     StringBuilder sb = new StringBuilder();
     StringBuilder prefix = new StringBuilder();
 
@@ -172,13 +171,13 @@ public class BuildCQL {
       if(paths.get(i) == null){
         continue;
       }
-      sb.append(cqlPath).append(cqlStatementOperator).append(URLEncoder.encode(paths.get(i).toString(), "UTF-8"));
+      sb.append(cqlPath).append(cqlStatementOperator).append(paths.get(i).toString());
       if(i<size-1){
-        sb.append("+").append(operatorBetweenArgs).append("+");
+        sb.append(" ").append(operatorBetweenArgs).append(" ");
       }
     }
     if(sb.length() > 0){
-      return prefix.append(sb.toString()).toString();
+      return prefix.append(StringUtil.urlEncode(sb.toString())).toString();
     }
     return "";
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/BuildCQLTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/BuildCQLTest.java
@@ -1,12 +1,9 @@
 package org.folio.rest.tools.utils;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.net.URLDecoder;
-
 import org.folio.rest.tools.client.BuildCQL;
 import org.folio.rest.tools.client.Response;
+import org.folio.util.StringUtil;
 import org.junit.Test;
 
 import io.vertx.core.json.JsonArray;
@@ -20,9 +17,6 @@ public class BuildCQLTest {
 
   @Test
   public void check() {
-
-
-    try {
       JsonObject j = new JsonObject();
       JsonArray j22 = new JsonArray();
       JsonArray j33 = new JsonArray();
@@ -40,27 +34,23 @@ public class BuildCQLTest {
       Response r = new Response();
       r.setBody(j);
 
-      String g1 = new BuildCQL(r, "arr2[0]", "group").buildCQL();
-      assertEquals("?query=group=={\"o\":{\"bbb\":\"aaa\"}}", URLDecoder.decode(g1, "UTF-8"));
-      String g2 = new BuildCQL(r, "arr", "group").buildCQL();
-      assertEquals("?query=group==[\"librarian3\",\"librarian2\"]", URLDecoder.decode(g2, "UTF-8"));
-      String g3 = new BuildCQL(r, "arr[0]", "group").buildCQL();
-      assertEquals("?query=group==librarian3", URLDecoder.decode(g3, "UTF-8"));
-      String g4 = new BuildCQL(r, "arr[*]", "group").buildCQL();
-      assertEquals("?query=group==librarian3 or group==librarian2", URLDecoder.decode(g4, "UTF-8"));
-      String g5 = new BuildCQL(r, "arr[*]", "group", "query1").buildCQL();
-      assertEquals("?query1=group==librarian3 or group==librarian2", URLDecoder.decode(g5, "UTF-8"));
-      String g6 = new BuildCQL(r, "arr[*]", "group", "query1", false, "and").buildCQL();
-      assertEquals("&query1=group==librarian3 and group==librarian2", URLDecoder.decode(g6, "UTF-8"));
+      String g = new BuildCQL(r, "arr2[0]", "group").buildCQL();
+      assertEquals("?query=" + StringUtil.urlEncode("group=={\"o\":{\"bbb\":\"aaa\"}}"), g);
+      g = new BuildCQL(r, "arr", "group").buildCQL();
+      assertEquals("?query=" + StringUtil.urlEncode("group==[\"librarian3\",\"librarian2\"]"), g);
+      g = new BuildCQL(r, "arr[0]", "group").buildCQL();
+      assertEquals("?query=" + StringUtil.urlEncode("group==librarian3"), g);
+      g = new BuildCQL(r, "arr[*]", "group").buildCQL();
+      assertEquals("?query=" + StringUtil.urlEncode("group==librarian3 or group==librarian2"), g);
+      g = new BuildCQL(r, "arr[*]", "group", "query1").buildCQL();
+      assertEquals("?query1=" + StringUtil.urlEncode("group==librarian3 or group==librarian2"), g);
+      g = new BuildCQL(r, "arr[*]", "group", "query1", false, "and").buildCQL();
+      assertEquals("&query1=" + StringUtil.urlEncode("group==librarian3 and group==librarian2"), g);
       //build cql by requesting values from a non existent field in the json, should be an emptry string ""
-      String g7 = new BuildCQL(r, "arr3", "group").buildCQL();
-      assertEquals("", URLDecoder.decode(g7, "UTF-8"));
-      String g8 = new BuildCQL(r, "arr[*]", "group", "query1", false, "and", "=").buildCQL();
-      assertEquals("&query1=group=librarian3 and group=librarian2", URLDecoder.decode(g8, "UTF-8"));
-    } catch (Exception e) {
-      e.printStackTrace();
-      assertTrue(false);
-    }
+      g = new BuildCQL(r, "arr3", "group").buildCQL();
+      assertEquals("", g);
+      g = new BuildCQL(r, "arr[*]", "group", "query1", false, "and", "=").buildCQL();
+      assertEquals("&query1=" + StringUtil.urlEncode("group=librarian3 and group=librarian2"), g);
   }
 
 }


### PR DESCRIPTION
BuildCQL.buildCQL() doesn't URL encode cqlStatementOperator
and operatorBetweenArgs. This may result in CQL injection.

Solution:

URL encode the complete CQL query.