### PR TITLE
RestVerticle checks for implementation at startup RMB-805

### DIFF
--- a/domain-models-api-interfaces/ramls/sample.raml
+++ b/domain-models-api-interfaces/ramls/sample.raml
@@ -28,6 +28,13 @@ traits:
           description: The date released for the first time in the US
           example: 1984-07-10
           required: true
+        score:
+          displayName: Score
+          type: number
+          description: Score
+          example: 1.00
+          required: false
+          default: 0.0
         rating:
           displayName: Rating
           type: number
@@ -42,8 +49,13 @@ traits:
         isbn:
           displayName: ISBN
           type: string
-          minLength: 10
           example: 0321736079?
+        available:
+          displayName: Whether item is avaiable
+          type: boolean
+          example: false
+          required: false
+          default: true
       responses:
         200:
          body:

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -439,6 +439,12 @@
               <artifactSet />
               <filters>
                 <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/Log4j2Plugins.dat</exclude>
+                  </excludes>
+                </filter>
+                <filter>
                   <!-- exclude what domain-models-maven-plugin will recreate based on module raml data -->
                   <artifact>org.folio:domain-models-api-interfaces</artifact>
                   <excludes>

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -379,6 +379,7 @@ public final class RestRouting {
       String paramType = v.getString("param_type");
       int order = v.getInteger("order");
       Object defaultVal = v.getValue("default_value");
+      LOGGER.debug("order={} paramType={} valueType={}", order, paramType, valueType);
 
       // validation of query params (other then enums), object in body (not including drools),
       // and some header params validated by jsr311 (aspects) - the rest are handled in the code here

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -223,9 +223,6 @@ public final class RestRouting {
       }
       if (enumName.equals(defaultString)) {
         defaultEnum = anEnum;
-        if (param == null) {
-          return defaultEnum;
-        }
       }
     }
     return defaultEnum;

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -414,10 +414,8 @@ public final class RestRouting {
     try {
       parseParams1(rc, body, paramList, paramArray, pathParams, okapiHeaders);
     } catch (Exception e) {
-      if (!rc.response().ended()) {
-        withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
-        endRequestWithError(rc, 400, true, e.getMessage());
-      }
+      withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+      endRequestWithError(rc, 400, true, e.getMessage());
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -728,7 +728,7 @@ public final class RestRouting {
    * look for the boundary and return just the multipart/form-data multipart/form-data boundary=----WebKitFormBoundaryP8wZiNAoFszXOXEt if
    * boundary doesn't exist that return original string
    */
-  static String removeBoundry(String contentType) {
+  static String removeBoundary(String contentType) {
     int idx = contentType.indexOf("boundary");
     if (idx != -1) {
       return contentType.substring(0, idx - 1);
@@ -753,7 +753,7 @@ public final class RestRouting {
       // it was put there as a suffix
       String contentType = StringUtils.defaultString(request.getHeader(CONTENT_TYPE), DEFAULT_CONTENT_TYPE)
           .replaceFirst(";.*", "").trim();
-      if (!consumes.contains(removeBoundry(contentType))) {
+      if (!consumes.contains(removeBoundary(contentType))) {
         endRequestWithError(rc, 400, true, MESSAGES.getMessage("en", MessageConsts.ContentTypeError, consumes, contentType));
       }
     }

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -230,19 +230,21 @@ public final class RestRouting {
   }
 
   private static void parseParams(RoutingContext rc, Buffer body, Iterator<Map.Entry<String, Object>> paramList,
-                                  Object[] paramArray, String[] pathParams, Map<String, String> okapiHeaders) {
+                                     Object[] paramArray, String[] pathParams, Map<String, String> okapiHeaders) {
 
     HttpServerRequest request = rc.request();
     MultiMap queryParams = request.params();
     int[] pathParamsIndex = new int[]{0};
 
-    paramList.forEachRemaining(entry -> {
-      String valueName = ((JsonObject) entry.getValue()).getString("value");
-      String valueType = ((JsonObject) entry.getValue()).getString("type");
-      String paramType = ((JsonObject) entry.getValue()).getString("param_type");
-      int order = ((JsonObject) entry.getValue()).getInteger("order");
-      Object defaultVal = ((JsonObject) entry.getValue()).getValue("default_value");
+    while (paramList.hasNext()) {
+      JsonObject v = (JsonObject) paramList.next().getValue();
+      String valueName = v.getString("value");
+      String valueType = v.getString("type");
+      String paramType = v.getString("param_type");
+      int order = v.getInteger("order");
+      Object defaultVal = v.getValue("default_value");
 
+      LOGGER.info("order={} valueType={} paramType={}", order, valueType, paramType);
       boolean emptyNumericParam = false;
       // validation of query params (other then enums), object in body (not including drools),
       // and some header params validated by jsr311 (aspects) - the rest are handled in the code here
@@ -399,7 +401,7 @@ public final class RestRouting {
           endRequestWithError(rc, 400, true, e.getMessage());
         }
       }
-    });
+    }
   }
 
   static void invoke(Method method, Object[] params, Object o, RoutingContext rc,

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -444,8 +444,8 @@ public final class RestRouting {
     }
   }
 
-  private static void handleStream(Method method2Run, RoutingContext rc,
-                                   Object instance, String[] tenantId, Map<String, String> okapiHeaders,
+  private static void handleStream(Method method2Run, RoutingContext rc, Object instance,
+                                   String[] tenantId, Map<String, String> okapiHeaders,
                                    JsonObject params, Object[] paramArray, long start) {
     final int[] uploadParamPosition = new int[]{-1};
     params.forEach(param -> {

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -1,0 +1,891 @@
+package org.folio.rest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.google.common.base.Joiner;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.DateUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
+import org.folio.HttpStatus;
+import org.folio.dbschema.ObjectMapperTool;
+import org.folio.okapi.common.logging.FolioLoggingContext;
+import org.folio.rest.annotations.Stream;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.resource.DomainModelConsts;
+import org.folio.rest.tools.AnnotationGrabber;
+import org.folio.rest.tools.client.exceptions.ResponseException;
+import org.folio.rest.tools.messages.MessageConsts;
+import org.folio.rest.tools.messages.Messages;
+import org.folio.rest.tools.utils.AsyncResponseResult;
+import org.folio.rest.tools.utils.BinaryOutStream;
+import org.folio.rest.tools.utils.InterfaceToImpl;
+import org.folio.rest.tools.utils.JsonUtils;
+import org.folio.rest.tools.utils.LogUtil;
+import org.folio.rest.tools.utils.MetadataUtil;
+import org.folio.rest.tools.utils.OutStream;
+import org.folio.rest.tools.utils.ResponseImpl;
+import org.folio.rest.tools.utils.ValidationHelper;
+import org.folio.util.StringUtil;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringReader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class RestRouting {
+  private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
+  private static final String DEFAULT_CONTENT_TYPE            = "application/json";
+  private static final String SUPPORTED_CONTENT_TYPE_TEXT_DEF = "text/plain";
+  private static final String[] DATE_PATTERNS = {
+      "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "yyyy-MM-dd'T'HH:mm:ss'Z'",
+      "yyyy-MM-dd'T'HH:mm:ss",
+      "yyyy-MM-dd",
+      "yyyy-MM",
+      "yyyy"
+  };
+  private static final Logger LOGGER = LogManager.getLogger(RestRouting.class);
+  private static final Messages MESSAGES = Messages.getInstance();
+  private static final ObjectMapper MAPPER = ObjectMapperTool.getMapper();
+  private static ValidatorFactory validationFactory = Validation.buildDefaultValidatorFactory();
+
+  private RestRouting() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class.");
+  }
+
+  private static void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message) {
+    HttpServerResponse response = rc.response();
+    if (!response.closed()) {
+      response.setChunked(chunked);
+      response.setStatusCode(status);
+      if (status == 422) {
+        response.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_JSON_DEF);
+      } else {
+        response.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_TEXT_DEF);
+      }
+      if (message != null) {
+        response.write(message);
+      }
+      response.end();
+    }
+    withRequestId(rc, () ->
+        LogUtil.formatStatsLogMessage(rc, -1, null, message == null ? "" : message));
+  }
+
+  /**
+   * Copy the headers from source to destination. Join several headers of same key using "; ".
+   */
+  private static void copyHeadersJoin(MultivaluedMap<String,String> source, MultiMap destination) {
+    for (Map.Entry<String, List<String>> entry : source.entrySet()) {
+     String jointValue = Joiner.on("; ").join(entry.getValue());
+      try {
+        destination.add(entry.getKey(), jointValue);
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            e.getMessage() + ": " + entry.getKey() + " - " + jointValue, e);
+      }
+    }
+  }
+
+  /**
+   * return whether the request is valid [0] and a cleaned up version of the object [1]
+   * @param rc
+   * @param content
+   * @param errorResp
+   * @param singleField
+   * @param entityClazz
+   * @return
+   */
+  static Object[] isValidRequest(RoutingContext rc, Object content, Errors errorResp, List<String> singleField, Class<?> entityClazz) {
+    Set<? extends ConstraintViolation<?>> validationErrors = validationFactory.getValidator().validate(content);
+    boolean ret = true;
+    if (validationErrors.size() > 0) {
+      //StringBuffer sb = new StringBuffer();
+
+      for (ConstraintViolation<?> cv : validationErrors) {
+
+        if("must be null".equals(cv.getMessage())){
+          /**
+           * read only fields are marked with a 'must be null' annotation @null
+           * so the client should not pass them in, if they were passed in, remove them here
+           * so that they do not reach the implementing function
+           */
+          try {
+            if(!(content instanceof JsonObject)){
+              content = JsonObject.mapFrom(content);
+            }
+            ((JsonObject)content).remove(cv.getPropertyPath().toString());
+            continue;
+          } catch (Exception e) {
+            withRequestId(rc, () -> LOGGER.warn("Failed to remove " + cv.getPropertyPath().toString()
+                + " field from body when calling " + rc.request().absoluteURI(), e));
+          }
+        }
+        Error error = new Error();
+        Parameter p = new Parameter();
+        String field = cv.getPropertyPath().toString();
+        p.setKey(field);
+        Object val = cv.getInvalidValue();
+        if(val == null){
+          p.setValue("null");
+        }
+        else{
+          p.setValue(val.toString());
+
+        }
+        error.getParameters().add(p);
+        error.setMessage(cv.getMessage());
+        error.setCode("-1");
+        error.setType(DomainModelConsts.VALIDATION_FIELD_ERROR);
+        //return the error if the validation is requested on a specific field
+        //and that field fails validation. if another field fails validation
+        //that is ok as validation on that specific field wasnt requested
+        //or there are validation errors and this is not a per field validation request
+        if (singleField != null && (singleField.contains(field) || singleField.isEmpty())) {
+          errorResp.getErrors().add(error);
+          ret = false;
+        }
+        //sb.append("\n" + cv.getPropertyPath() + "  " + cv.getMessage() + ",");
+      }
+      if(content instanceof JsonObject){
+        //we have sanitized the passed in object by removing read-only fields
+        try {
+          content = MAPPER.readValue(((JsonObject)content).encode(), entityClazz);
+        } catch (IOException e) {
+          withRequestId(rc, () -> LOGGER.error(
+              "Failed to serialize body content after removing read-only fields when calling "
+                  + rc.request().absoluteURI(), e));
+        }
+      }
+    }
+    return new Object[]{Boolean.valueOf(ret), content};
+  }
+
+  /**
+   * @return the enum value of type valueType where value.name equals param (fall-back: equals defaultValue).
+   *         Return null if the type neither has param nor defaultValue.
+   * @throws ClassNotFoundException if valueType does not exist
+   */
+  @SuppressWarnings({
+      "squid:S1523",  // Suppress warning "Make sure that this dynamic injection or execution of code is safe."
+      // This is safe because we accept an enum class only, and do not invoke any method.
+      "squid:S3011"}) // Suppress "Make sure that this accessibility update is safe here."
+  // This is safe because we only read the field and it is a field of an enum.
+  static Object parseEnum(String valueType, String param, Object defaultValue)
+      throws ReflectiveOperationException {
+
+    Class<?> enumClass = Class.forName(valueType);
+    if (! enumClass.isEnum()) {
+      return null;
+    }
+    String defaultString = null;
+    if (defaultValue != null) {
+      defaultString = defaultValue.toString();
+    }
+    Object defaultEnum = null;
+    for (Object anEnum : enumClass.getEnumConstants()) {
+      Field nameField = anEnum.getClass().getDeclaredField("name");
+      nameField.setAccessible(true);  // access to private field
+      String enumName = nameField.get(anEnum).toString();
+      if (enumName.equals(param)) {
+        return anEnum;
+      }
+      if (enumName.equals(defaultString)) {
+        defaultEnum = anEnum;
+        if (param == null) {
+          return defaultEnum;
+        }
+      }
+    }
+    return defaultEnum;
+  }
+
+  private static void parseParams(RoutingContext rc, Buffer body, Iterator<Map.Entry<String, Object>> paramList,
+                           Object[] paramArray, String[] pathParams, Map<String, String> okapiHeaders, boolean [] useRC) {
+
+    HttpServerRequest request = rc.request();
+    MultiMap queryParams = request.params();
+    int []pathParamsIndex = new int[] { 0 };
+
+    paramList.forEachRemaining(entry -> {
+        String valueName = ((JsonObject) entry.getValue()).getString("value");
+        String valueType = ((JsonObject) entry.getValue()).getString("type");
+        String paramType = ((JsonObject) entry.getValue()).getString("param_type");
+        int order = ((JsonObject) entry.getValue()).getInteger("order");
+        Object defaultVal = ((JsonObject) entry.getValue()).getValue("default_value");
+
+        boolean emptyNumericParam = false;
+        // validation of query params (other then enums), object in body (not including drools),
+        // and some header params validated by jsr311 (aspects) - the rest are handled in the code here
+        // handle un-annotated parameters - this is assumed to be
+        // entities in HTTP BODY for post and put requests or the 3 injected params
+        // (okapi headers, vertx context and vertx handler) - file uploads are also not annotated but are not handled here due
+        // to their async upload - so explicitly skip them
+        if (AnnotationGrabber.NON_ANNOTATED_PARAM.equals(paramType)) {
+          try {
+            // this will also validate the json against the pojo created from the schema
+            Class<?> entityClazz = Class.forName(valueType);
+
+            if (valueType.equals("io.vertx.ext.web.RoutingContext")) {
+              useRC[0] = true;
+            } else if (!valueType.equals("io.vertx.core.Handler") && !valueType.equals("io.vertx.core.Context") &&
+                !valueType.equals("java.util.Map") && !valueType.equals("java.io.InputStream")) {
+              // we have special handling for the Result Handler and context, it is also assumed that
+              //an inputsteam parameter occurs when application/octet is declared in the raml
+              //in which case the content will be streamed to he function
+              String bodyContent = body == null ? null : body.toString();
+              withRequestId(rc, () -> LOGGER.debug(rc.request().path() + " -------- bodyContent -------- " + bodyContent));
+              if (bodyContent != null){
+                if ("java.io.Reader".equals(valueType)){
+                  paramArray[order] = new StringReader(bodyContent);
+                }
+                else if ("java.lang.String".equals(valueType)) {
+                  paramArray[order] = bodyContent;
+                }
+                else if (bodyContent.length() > 0) {
+                  try {
+                    paramArray[order] = MAPPER.readValue(bodyContent, entityClazz);
+                  } catch (UnrecognizedPropertyException e) {
+                    withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+                    endRequestWithError(rc, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), true, JsonUtils.entity2String(
+                        ValidationHelper.createValidationErrorMessage("", "", e.getMessage())));
+                    return;
+                  }
+                }
+              }
+
+              Errors errorResp = new Errors();
+
+              //is this request only to validate a field value and not an actual
+              //request for additional processing
+              List<String> field2validate = request.params().getAll("validate_field");
+              Object[] resp = isValidRequest(rc, paramArray[order], errorResp, field2validate, entityClazz);
+              boolean isValid = (boolean) resp[0];
+              paramArray[order] = resp[1];
+
+              if (!isValid) {
+                endRequestWithError(rc, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), true,
+                    JsonUtils.entity2String(errorResp));
+                return;
+              }
+              if (!field2validate.isEmpty()) {
+                //valid request for the field to validate request made
+                AsyncResponseResult arr = new AsyncResponseResult();
+                ResponseImpl ri = new ResponseImpl();
+                ri.setStatus(200);
+                arr.setResult(ri);
+                //right now this is the only flag available to stop
+                //any additional respones for this request. to fix
+                sendResponse(rc, arr, 0, null);
+                return;
+              }
+              MetadataUtil.populateMetadata(paramArray[order], okapiHeaders);
+            }
+          } catch (Exception e) {
+            withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+            endRequestWithError(rc, 400, true, "Json content error " + e.getMessage());
+
+          }
+        } else if (AnnotationGrabber.HEADER_PARAM.equals(paramType)) {
+          // handle header params - read the header field from the
+          // header (valueName) and get its value
+          String value = request.getHeader(valueName);
+          // set the value passed from the header as a param to the function
+          paramArray[order] = value;
+        } else if (AnnotationGrabber.PATH_PARAM.equals(paramType)) {
+          // these are placeholder values in the path - for example
+          // /patrons/{patronid} - this would be the patronid value
+          paramArray[order] = pathParams[pathParamsIndex[0]++];
+        } else if (AnnotationGrabber.QUERY_PARAM.equals(paramType)) {
+          String param = queryParams.get(valueName);
+          // support date, enum, numbers or strings as query parameters
+          try {
+            if (valueType.equals("java.lang.String")) {
+              // regular string param in query string - just push value
+              if (param == null && defaultVal != null) {
+                // no value passed - check if there is a default value
+                paramArray[order] = defaultVal;
+              } else {
+                paramArray[order] = param;
+              }
+            } else if (valueType.equals("java.util.Date")) {
+              // regular string param in query string - just push value
+              if (param == null) {
+                // no value passed - check if there is a default value
+                paramArray[order] = defaultVal;
+              } else {
+                paramArray[order] = DateUtils.parseDate(param, DATE_PATTERNS);
+              }
+            } else if (valueType.equals("int") || valueType.equals("java.lang.Integer")) {
+              // cant pass null to an int type
+              if (param == null) {
+                if (defaultVal != null) {
+                  paramArray[order] = Integer.valueOf((String) defaultVal);
+                } else {
+                  paramArray[order] = valueType.equals("int") ? 0 : null;
+                }
+              }
+              else if("".equals(param)) {
+                emptyNumericParam = true;
+              }
+              else {
+                paramArray[order] = Integer.valueOf(param);
+              }
+            } else if (valueType.equals("boolean") || valueType.equals("java.lang.Boolean")) {
+              if (param == null) {
+                if (defaultVal != null) {
+                  paramArray[order] = Boolean.valueOf((String)defaultVal);
+                }
+              } else {
+                paramArray[order] = Boolean.valueOf(param);
+              }
+            } else if (valueType.contains("List")) {
+              List<String> vals = queryParams.getAll(valueName);
+              if (vals == null) {
+                paramArray[order] = null;
+              }
+              else {
+                paramArray[order] = vals;
+              }
+            } else if (valueType.equals("java.math.BigDecimal") || valueType.equals("java.lang.Number")) {
+              if (param == null) {
+                if (defaultVal != null) {
+                  paramArray[order] = new BigDecimal((String) defaultVal);
+                } else {
+                  paramArray[order] = null;
+                }
+              }
+              else if ("".equals(param)) {
+                emptyNumericParam = true;
+              }
+              else {
+                paramArray[order] = new BigDecimal(param.replaceAll(",", "")); // big decimal can contain ","
+              }
+            } else { // enum object type
+              try {
+                paramArray[order] = parseEnum(valueType, param, defaultVal);
+              } catch (Exception ee) {
+                withRequestId(rc, () -> LOGGER.error(ee.getMessage(), ee));
+                endRequestWithError(rc, 400, true, ee.getMessage());
+              }
+            }
+            if(emptyNumericParam){
+              endRequestWithError(rc, 400, true, valueName + " does not have a default value in the RAML and has been passed empty");
+            }
+          } catch (Exception e) {
+            withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+            endRequestWithError(rc, 400, true, e.getMessage());
+          }
+        }
+    });
+  }
+
+  static void invoke(Method method, Object[] params, Object o, RoutingContext rc, boolean addRCParam,
+                     Map<String,String> headers, StreamStatus streamed, Handler<AsyncResult<Response>> resultHandler) {
+
+    //if streaming is requested the status will be 0 (streaming started)
+    //or 1 streaming data complete
+    //or 2 streaming aborted
+    //otherwise it will be -1 and flags wont be set
+    if(streamed.getStatus() == 0){
+      headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
+    }
+    else if(streamed.getStatus() == 1){
+      headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
+      headers.put(RestVerticle.STREAM_COMPLETE, String.valueOf(rc.hashCode()));
+    }
+    else if (streamed.getStatus() == 2){
+      headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
+      headers.put(RestVerticle.STREAM_ABORT, String.valueOf(rc.hashCode()));
+    }
+
+    Object[] newArray = new Object[params.length];
+    int size = 3;
+    int pos = 0;
+
+    //this endpoint indicated it wants to receive the routing context as a parameter
+    if(addRCParam){
+      //the amount of extra params added is 4 not 3
+      size = 4;
+      //the first param of the extra params is the injected RC
+      newArray[params.length - size] = rc;
+      pos = 1;
+    }
+
+    for (int i = 0; i < params.length - size; i++) {
+      newArray[i] = params[i];
+    }
+
+    //inject call back handler into each function
+    newArray[params.length - (size-(pos+1))] = resultHandler;
+
+    //inject vertx context into each function
+    newArray[params.length - (size-(pos+2))] = rc.vertx().getOrCreateContext();
+
+    newArray[params.length - (size-pos)] = headers;
+
+    headers.forEach(FolioLoggingContext::put);
+
+    try {
+      method.invoke(o, newArray);
+    } catch (Exception e) {
+      withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+      String message;
+      try {
+        // catch exception for now in case of null point and show generic
+        // message
+        message = e.getCause().getMessage();
+      } catch (Throwable ee) {
+        message = MESSAGES.getMessage("en", MessageConsts.UnableToProcessRequest);
+      }
+      endRequestWithError(rc, 400, true, message);
+    }
+  }
+
+  static private void handleStream(Method method2Run, RoutingContext rc, boolean useRoutingContext, HttpServerRequest request,
+                            Object instance, String[] tenantId, Map<String, String> okapiHeaders,
+                            int[] uploadParamPosition, Object[] paramArray, long start){
+    request.handler(buff -> {
+      try {
+        StreamStatus stat = new StreamStatus();
+        stat.setStatus(0);
+        paramArray[uploadParamPosition[0]] =
+            new ByteArrayInputStream( buff.getBytes() );
+        invoke(method2Run, paramArray, instance, rc, useRoutingContext, okapiHeaders, stat, v -> {
+          withRequestId(rc, () -> LogUtil.formatLogMessage(method2Run.getName(), "start", " invoking " + method2Run));
+        });
+      } catch (Exception e1) {
+        withRequestId(rc, () -> LOGGER.error(e1.getMessage(), e1));
+        rc.response().end();
+      }
+    });
+    request.endHandler(e -> {
+      StreamStatus stat = new StreamStatus();
+      stat.setStatus(1);
+      paramArray[uploadParamPosition[0]] = new ByteArrayInputStream(new byte [0]);
+      invoke(method2Run, paramArray, instance, rc, useRoutingContext, okapiHeaders, stat, v -> {
+        withRequestId(rc, () -> LogUtil.formatLogMessage(method2Run.getName(), "start", " invoking " + method2Run));
+        //all data has been stored in memory - not necessarily all processed
+        sendResponse(rc, v, start, tenantId[0]);
+      });
+    });
+    request.exceptionHandler(event -> {
+      StreamStatus stat = new StreamStatus();
+      stat.setStatus(2);
+      paramArray[uploadParamPosition[0]] = new ByteArrayInputStream(new byte[0]);
+      invoke(method2Run, paramArray, instance, rc, useRoutingContext, okapiHeaders, stat,
+          v -> withRequestId(rc, () ->
+              LogUtil.formatLogMessage(method2Run.getName(), "start", " invoking " + method2Run))
+      );
+      endRequestWithError(rc, 400, true, "unable to upload file " + event.getMessage());
+    });
+  }
+
+  static void getOkapiHeaders(RoutingContext rc, Map<String, String> headers, String[] tenantId) {
+    MultiMap mm = rc.request().headers();
+    Consumer<Map.Entry<String,String>> consumer = entry -> {
+      String headerKey = entry.getKey().toLowerCase();
+      if(headerKey.startsWith(RestVerticle.OKAPI_HEADER_PREFIX)){
+        if(headerKey.equalsIgnoreCase(RestVerticle.OKAPI_HEADER_TENANT)){
+          tenantId[0] = entry.getValue();
+        }
+        headers.put(headerKey, entry.getValue());
+      }
+    };
+    mm.forEach(consumer);
+  }
+
+  /**
+   * Run logCommand with request id. Take request id value from headers in routingContext
+   * and temporarily store it as reqId in ThreadContext. Run logCommand without reqId
+   * if request id value is <code>null</code>.
+   */
+  static void withRequestId(RoutingContext routingContext, Runnable logCommand) {
+    if (routingContext == null) {
+      logCommand.run();
+      return;
+    }
+    String requestId = routingContext.request().headers().get(RestVerticle.OKAPI_REQUESTID_HEADER);
+    if (requestId == null) {
+      logCommand.run();
+      return;
+    }
+    ThreadContext.put("reqId", "reqId=" + requestId);
+    logCommand.run();
+    // Multiple vertx async requests use the same thread therefore we must delete reqId afterwards.
+    // For a better implementation see
+    // https://issues.folio.org/browse/RMB-669 "Add default metrics to RMB: incoming API calls"
+    ThreadContext.remove("reqId");
+  }
+
+
+  static Response getResponse(AsyncResult<Response> asyncResult) {
+    if (asyncResult.succeeded()) {
+      return asyncResult.result();
+    }
+    Throwable exception = asyncResult.cause();
+    if (exception instanceof ResponseException) {
+      return ((ResponseException) exception).getResponse();
+    }
+    return null;
+  }
+
+  /**
+   * Send the result as response.
+   *
+   * @param rc
+   *          - where to send the result
+   * @param v
+   *          - the result to send
+   * @param start
+   *          - request's start time, using JVM's high-resolution time source, in nanoseconds
+   */
+  static void sendResponse(RoutingContext rc, AsyncResult<Response> v, long start, String tenantId) {
+    Response responseFromResult = getResponse(v);
+    if (responseFromResult == null) {
+      endRequestWithError(rc, 500, true, "null response from handler");
+      return;
+    }
+    Object entity = null;
+    try {
+      HttpServerResponse response = rc.response();
+      int statusCode = responseFromResult.getStatus();
+      // 204 means no content returned in the response, so passing
+      // a chunked Transfer header is not allowed
+      if (statusCode != 204) {
+        response.setChunked(true);
+      }
+
+      response.setStatusCode(statusCode);
+
+      copyHeadersJoin(responseFromResult.getStringHeaders(), response.headers());
+
+      entity = responseFromResult.getEntity();
+
+      /* entity is of type OutStream - and will be written as a string */
+      if (entity instanceof OutStream) {
+        response.write(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(((OutStream) entity).getData()));
+      }
+      /* entity is of type BinaryOutStream - and will be written as a buffer */
+      else if (entity instanceof BinaryOutStream){
+        response.write(Buffer.buffer(((BinaryOutStream) entity).getData()));
+      }
+      /* data is a string so just push it out, no conversion needed */
+      else if (entity instanceof String){
+        response.write(Buffer.buffer((String)entity));
+      }
+      /* catch all - anything else will be assumed to be a pojo which needs converting to json */
+      else if (entity != null) {
+        response.write(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(entity));
+      }
+    } catch (Exception e) {
+      withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
+    } finally {
+      rc.response().end();
+    }
+
+    long end = System.nanoTime();
+
+    StringBuilder sb = new StringBuilder();
+    if (LOGGER.isDebugEnabled()) {
+      try {
+        sb.append(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(entity));
+      } catch (Exception e) {
+        String name = entity == null ? "null" : entity.getClass().getName();
+        withRequestId(rc, () -> LOGGER.error("writeValueAsString(" + name + ")", e));
+      }
+    }
+    withRequestId(rc, () -> LogUtil.formatStatsLogMessage(rc, (end - start) / 1000000, tenantId, sb.toString()));
+  }
+
+  /**
+   * @param annotations
+   * @return
+   */
+  static boolean isStreamed(Annotation[] annotations) {
+    for (int i = 0; i < annotations.length; i++) {
+      if(annotations[i].annotationType().equals(Stream.class)){
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Match the path agaist pattern.
+   * @return the matching groups urldecoded, may be an empty array, or null if the pattern doesn't match
+   */
+  @SuppressWarnings("java:S1168")  // suppress "Empty arrays should be returned instead of null"
+  static String[] matchPath(String path, Pattern pattern) {
+    Matcher m = pattern.matcher(path);
+    if (! m.find()) {
+      return null;
+    }
+
+    int groups = m.groupCount();
+    // pathParams are the place holders in the raml query string
+    // for example /admin/{admin_id}/yyy/{yyy_id} - the content in between the {} are path params
+    // they are replaced with actual values and are passed to the function which the url is mapped to
+    String[] pathParams = new String[groups];
+    for (int i = 0; i < groups; i++) {
+      pathParams[i] = StringUtil.urlDecode(m.group(i + 1));
+    }
+    return pathParams;
+  }
+
+  static void handleRequest(RoutingContext rc, Class<?> aClass, JsonObject ret, Method method, Pattern pattern) {
+    Vertx vertx = rc.vertx();
+    long start = System.nanoTime();
+    Map<String, String> okapiHeaders = new CaseInsensitiveMap<>();
+    String []tenantId = new String[]{null};
+    getOkapiHeaders(rc, okapiHeaders, tenantId);
+    if (tenantId[0] == null && !rc.request().path().startsWith("/admin")) {
+      endRequestWithError(rc, 400, true,
+          MESSAGES.getMessage("en", MessageConsts.UnableToProcessRequest) + " Tenant must be set");
+      return;
+    }
+    Constructor<?> constructorWithArgs = null;
+    Constructor<?> constructorWithNoArgs = null;
+    try {
+      constructorWithArgs = aClass.getConstructor(Vertx.class, String.class);
+    } catch (NoSuchMethodException e1) {
+      try {
+        constructorWithNoArgs = aClass.getConstructor();
+      } catch (NoSuchMethodException e2) {
+        LOGGER.error(e2.getMessage(), e2);
+        endRequestWithError(rc, 500, true, "Server error");
+        return;
+      }
+    }
+    Object o;
+    try {
+      if (constructorWithArgs != null) {
+        o = constructorWithArgs.newInstance(vertx, tenantId[0]);
+      } else {
+        o = constructorWithNoArgs.newInstance();
+      }
+    } catch (Exception e) {
+      LOGGER.error(e.getMessage(), e);
+      endRequestWithError(rc, 500, true, "Server error");
+      return;
+    }
+    JsonObject params = ret.getJsonObject(AnnotationGrabber.METHOD_PARAMS);
+
+    Iterator<Map.Entry<String, Object>> paramList = params.iterator();
+    Object[] paramArray = new Object[params.size()];
+
+    // what the api will return as output (Content-Type)
+    JsonArray produces = ret.getJsonArray(AnnotationGrabber.PRODUCES);
+    // what the api expects to get (Accept)
+    JsonArray consumes = ret.getJsonArray(AnnotationGrabber.CONSUMES);
+
+    checkAcceptContentType(produces, consumes, rc);
+    if (rc.response().ended()) {
+      return;
+    }
+    final boolean[] useRoutingContext = { false };
+
+    String[] pathParams = matchPath(rc.request().path(), pattern);
+
+    boolean streamData = isStreamed(method.getAnnotations());
+    final Object instance = o;
+    if (streamData) {
+      final int[] uploadParamPosition = new int[] { -1 };
+      params.forEach(param -> {
+        if(((JsonObject) param.getValue()).getString("type").equals("java.io.InputStream")){
+          //application/octet-stream passed - this is handled in a stream like manner
+          //and the corresponding function called must annotate with a @Stream - and be able
+          //to handle the function being called repeatedly on parts of the data
+          uploadParamPosition[0] = ((JsonObject) param.getValue()).getInteger("order");
+        }
+      });
+      parseParams(rc, null, paramList, paramArray, pathParams, okapiHeaders, useRoutingContext);
+      if (rc.response().ended()) {
+        return;
+      }
+      handleStream(method, rc, useRoutingContext[0], rc.request(), instance, tenantId, okapiHeaders,
+          uploadParamPosition, paramArray, start);
+    } else {
+      // regular request (no streaming).. Read the request body before checking params + body
+      Buffer body = Buffer.buffer();
+      rc.request().handler(body::appendBuffer);
+      rc.request().endHandler(endRes -> {
+        parseParams(rc, body, paramList, paramArray, pathParams, okapiHeaders, useRoutingContext);
+        if (rc.response().ended()) {
+          return;
+        }
+        try {
+          invoke(method, paramArray, instance, rc, useRoutingContext[0], okapiHeaders, new StreamStatus(), v -> {
+            withRequestId(rc, () -> LogUtil.formatLogMessage(method.getName(), "start", " invoking " + method.getName()));
+            sendResponse(rc, v, start, tenantId[0]);
+          });
+        } catch (Exception e1) {
+          withRequestId(rc, () -> LOGGER.error(e1.getMessage(), e1));
+          rc.response().end();
+        }
+      });
+    }
+  }
+
+  // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+  // first match - no q val check
+  static String acceptCheck(JsonArray l, String h) {
+    String []hl = h.split(",");
+    String hBest = null;
+    for (int i = 0; i < hl.length; i++) {
+      String mediaRange = hl[i].split(";")[0].trim();
+      for (int j = 0; j < l.size(); j++) {
+        String c = l.getString(j);
+        if (mediaRange.compareTo("*/*") == 0 || c.equalsIgnoreCase(mediaRange)) {
+          hBest = c;
+          break;
+        }
+      }
+    }
+    return hBest;
+  }
+
+  /**
+   * look for the boundary and return just the multipart/form-data multipart/form-data boundary=----WebKitFormBoundaryP8wZiNAoFszXOXEt if
+   * boundary doesnt exist that return original string
+   */
+  static String removeBoundry(String contenttype) {
+    int idx = contenttype.indexOf("boundary");
+    if (idx != -1) {
+      return contenttype.substring(0, idx - 1);
+    }
+    return contenttype;
+  }
+
+  /**
+   * check accept and content-type headers if no - set the request asa not valid and return error to user
+   */
+  private static void checkAcceptContentType(JsonArray produces, JsonArray consumes, RoutingContext rc) {
+    /*
+     * NOTE that the content type and accept headers will accept a partial match - for example: if the raml indicates a text/plain and an
+     * application/json content-type and only one is passed - it will accept it
+     */
+    // check allowed content types in the raml for this resource + method
+    HttpServerRequest request = rc.request();
+    if (consumes != null) {
+      // get the content type passed in the request
+      // if this was left out by the client they must add for request to return
+      // clean up simple stuff from the clients header - trim the string and remove ';' in case
+      // it was put there as a suffix
+      String contentType = StringUtils.defaultString(request.getHeader("Content-type"), DEFAULT_CONTENT_TYPE)
+          .replaceFirst(";.*", "").trim();
+      if (!consumes.contains(removeBoundry(contentType))) {
+        endRequestWithError(rc, 400, true, MESSAGES.getMessage("en", MessageConsts.ContentTypeError, consumes, contentType));
+      }
+    }
+
+    // type of data expected to be returned by the server
+    if (produces != null) {
+      String accept = StringUtils.defaultString(request.getHeader("Accept"), "*/*");
+      if (acceptCheck(produces, accept) == null) {
+        // use contains because multiple values may be passed here
+        // for example json/application; text/plain mismatch of content type found
+        endRequestWithError(rc, 400, true, MESSAGES.getMessage("en", MessageConsts.AcceptHeaderError, produces, accept));
+      }
+    }
+  }
+
+  static Future<Void> populateRoutes(Router router) {
+    JsonObject jObjClasses;
+    try {
+      jObjClasses = AnnotationGrabber.generateMappings(null);
+    } catch (IOException e) {
+      LOGGER.info(e.getMessage(), e);
+      return Future.failedFuture(e);
+    }
+    for (String classURL : jObjClasses.fieldNames()) {
+      Class<?> aClass;
+      JsonObject ret = jObjClasses.getJsonObject(classURL);
+      String iClazz = ret.getString(AnnotationGrabber.CLASS_NAME);
+      // convert from interface to an actual class implementing it, which appears in the impl package
+      try {
+        aClass = InterfaceToImpl.convert2Impl(
+            DomainModelConsts.PACKAGE_OF_IMPLEMENTATIONS, iClazz, false).get(0);
+      } catch (IOException e) {
+        LOGGER.warn(e.getMessage(), e);
+        continue;
+      } catch (ClassNotFoundException e) {
+        LOGGER.info("Looks like {} is not implemented", iClazz);
+        continue;
+      }
+      // only the regular expressions are arrays (rest is other kinds of info)
+      for (String classPaths : ret.fieldNames()) {
+        Object value = ret.getValue(classPaths);
+        if (value instanceof JsonArray) {
+          JsonArray methodsForPath = (JsonArray) value;
+          for (int i = 0; i < methodsForPath.size(); i++) {
+            JsonObject methodInfo = methodsForPath.getJsonObject(i);
+            String function = methodInfo.getString(AnnotationGrabber.FUNCTION_NAME);
+            String httpMethodS = methodInfo.getString(AnnotationGrabber.HTTP_METHOD);
+            httpMethodS = httpMethodS.substring(httpMethodS.lastIndexOf('.') + 1);
+            HttpMethod httpMethod = HttpMethod.valueOf(httpMethodS);
+            String regex = methodInfo.getString(AnnotationGrabber.REGEX_URL);
+            String ramlPath = methodInfo.getString(AnnotationGrabber.METHOD_URL);
+
+            Method[] classMethods = aClass.getMethods();
+            for (Method classMethod : classMethods) {
+              if (classMethod.getName().equals(function)) {
+                LOGGER.info("Adding route {} {} -> {}", httpMethod.name(), ramlPath, function);
+                router.routeWithRegex(httpMethod, regex).handler(ctx -> handleRequest(ctx, aClass,
+                    methodInfo, classMethod, Pattern.compile(regex)));
+              }
+            }
+          }
+        }
+      }
+    }
+    return Future.succeededFuture();
+  }
+
+  static class StreamStatus {
+    private int status = -1;
+
+    public int getStatus() {
+      return status;
+    }
+    public void setStatus(int status) {
+      this.status = status;
+    }
+  }
+
+}

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -238,7 +238,7 @@ public final class RestRouting {
       parseParams1(rc, body, paramList, paramArray, pathParams, okapiHeaders);
     } catch (Exception e) {
       withRequestId(rc, () -> LOGGER.error(e.getMessage(), e));
-      if (rc.request().isEnded()) {
+      if (rc.response().ended()) {
         return;
       }
       endRequestWithError(rc, 400, true, e.getMessage());

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -450,6 +450,7 @@ public final class RestRouting {
                                    Object instance, String[] tenantId, Map<String, String> okapiHeaders,
                                    JsonObject params, Object[] paramArray, long start) {
     final int[] uploadParamPosition = new int[]{-1};
+    String invokeMessage = " invoking " + method2Run;
     params.forEach(param -> {
       if (((JsonObject) param.getValue()).getString("type").equals("java.io.InputStream")) {
         //application/octet-stream passed - this is handled in a stream like manner
@@ -465,7 +466,7 @@ public final class RestRouting {
         okapiHeaders.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
         invoke(method2Run, paramArray, instance, rc, okapiHeaders, v ->
           withRequestId(rc, () -> LogUtil.formatLogMessage(method2Run.getName(),
-              method2Run.getName(), " invoking " + method2Run))
+              method2Run.getName(), invokeMessage))
         );
       } catch (Exception e1) {
         withRequestId(rc, () -> LOGGER.error(e1.getMessage(), e1));
@@ -478,7 +479,7 @@ public final class RestRouting {
       okapiHeaders.put(RestVerticle.STREAM_COMPLETE, String.valueOf(rc.hashCode()));
       invoke(method2Run, paramArray, instance, rc, okapiHeaders, v -> {
         withRequestId(rc, () -> LogUtil.formatLogMessage(method2Run.getName(),
-            method2Run.getName(), " invoking " + method2Run));
+            method2Run.getName(), invokeMessage));
         //all data has been stored in memory - not necessarily all processed
         sendResponse(rc, v, start, tenantId[0]);
       });
@@ -490,7 +491,7 @@ public final class RestRouting {
       invoke(method2Run, paramArray, instance, rc, okapiHeaders,
           v -> withRequestId(rc, () ->
               LogUtil.formatLogMessage(method2Run.getName(),
-                  method2Run.getName(), " invoking " + method2Run))
+                  method2Run.getName(), invokeMessage))
       );
       endRequestWithError(rc, 400, true, "unable to upload file " + event.getMessage());
     });

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -146,7 +146,7 @@ public final class RestRouting {
          * so that they do not reach the implementing function
          */
         try {
-          if(!(content instanceof JsonObject)){
+          if (!(content instanceof JsonObject)){
             content = JsonObject.mapFrom(content);
           }
           ((JsonObject)content).remove(cv.getPropertyPath().toString());
@@ -161,13 +161,7 @@ public final class RestRouting {
       String field = cv.getPropertyPath().toString();
       p.setKey(field);
       Object val = cv.getInvalidValue();
-      if(val == null){
-        p.setValue("null");
-      }
-      else{
-        p.setValue(val.toString());
-
-      }
+      p.setValue(val == null ? "null" : val.toString());
       error.getParameters().add(p);
       error.setMessage(cv.getMessage());
       error.setCode("-1");
@@ -273,11 +267,9 @@ public final class RestRouting {
               if (bodyContent != null){
                 if ("java.io.Reader".equals(valueType)){
                   paramArray[order] = new StringReader(bodyContent);
-                }
-                else if ("java.lang.String".equals(valueType)) {
+                } else if ("java.lang.String".equals(valueType)) {
                   paramArray[order] = bodyContent;
-                }
-                else if (bodyContent.length() > 0) {
+                } else if (bodyContent.length() > 0) {
                   try {
                     paramArray[order] = MAPPER.readValue(bodyContent, entityClazz);
                   } catch (UnrecognizedPropertyException e) {
@@ -335,7 +327,7 @@ public final class RestRouting {
           try {
             if (valueType.equals("java.lang.String")) {
               // regular string param in query string - just push value
-              if (param == null && defaultVal != null) {
+              if (param == null) {
                 // no value passed - check if there is a default value
                 paramArray[order] = defaultVal;
               } else {
@@ -357,11 +349,9 @@ public final class RestRouting {
                 } else {
                   paramArray[order] = valueType.equals("int") ? 0 : null;
                 }
-              }
-              else if("".equals(param)) {
+              } else if ("".equals(param)) {
                 emptyNumericParam = true;
-              }
-              else {
+              } else {
                 paramArray[order] = Integer.valueOf(param);
               }
             } else if (valueType.equals("boolean") || valueType.equals("java.lang.Boolean")) {
@@ -374,12 +364,7 @@ public final class RestRouting {
               }
             } else if (valueType.contains("List")) {
               List<String> vals = queryParams.getAll(valueName);
-              if (vals == null) {
-                paramArray[order] = null;
-              }
-              else {
-                paramArray[order] = vals;
-              }
+              paramArray[order] = vals;
             } else if (valueType.equals("java.math.BigDecimal") || valueType.equals("java.lang.Number")) {
               if (param == null) {
                 if (defaultVal != null) {
@@ -390,8 +375,7 @@ public final class RestRouting {
               }
               else if ("".equals(param)) {
                 emptyNumericParam = true;
-              }
-              else {
+              } else {
                 paramArray[order] = new BigDecimal(param.replace(",", "")); // big decimal can contain ","
               }
             } else { // enum object type
@@ -402,7 +386,7 @@ public final class RestRouting {
                 endRequestWithError(rc, 400, true, ee.getMessage());
               }
             }
-            if(emptyNumericParam){
+            if (emptyNumericParam) {
               endRequestWithError(rc, 400, true, valueName + " does not have a default value in the RAML and has been passed empty");
             }
           } catch (Exception e) {
@@ -420,14 +404,12 @@ public final class RestRouting {
     //or 1 streaming data complete
     //or 2 streaming aborted
     //otherwise it will be -1 and flags wont be set
-    if(streamed.getStatus() == 0){
+    if (streamed.getStatus() == 0) {
       headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
-    }
-    else if(streamed.getStatus() == 1){
+    } else if (streamed.getStatus() == 1) {
       headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
       headers.put(RestVerticle.STREAM_COMPLETE, String.valueOf(rc.hashCode()));
-    }
-    else if (streamed.getStatus() == 2){
+    } else if (streamed.getStatus() == 2) {
       headers.put(RestVerticle.STREAM_ID, String.valueOf(rc.hashCode()));
       headers.put(RestVerticle.STREAM_ABORT, String.valueOf(rc.hashCode()));
     }
@@ -637,7 +619,7 @@ public final class RestRouting {
    */
   static boolean isStreamed(Annotation[] annotations) {
     for (int i = 0; i < annotations.length; i++) {
-      if(annotations[i].annotationType().equals(Stream.class)){
+      if (annotations[i].annotationType().equals(Stream.class)) {
         return true;
       }
     }
@@ -717,7 +699,7 @@ public final class RestRouting {
     if (streamData) {
       final int[] uploadParamPosition = new int[] { -1 };
       params.forEach(param -> {
-        if(((JsonObject) param.getValue()).getString("type").equals("java.io.InputStream")){
+        if (((JsonObject) param.getValue()).getString("type").equals("java.io.InputStream")) {
           //application/octet-stream passed - this is handled in a stream like manner
           //and the corresponding function called must annotate with a @Stream - and be able
           //to handle the function being called repeatedly on parts of the data

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -769,7 +769,7 @@ public final class RestRouting {
     }
   }
 
-  static Future<Void> populateRoutes(Router router) {
+  static Future<Void> populateRoutes(Router router, String packageOfImplementations) {
     JsonObject jObjClasses;
     try {
       jObjClasses = AnnotationGrabber.generateMappings(null);
@@ -782,7 +782,7 @@ public final class RestRouting {
       String iClazz = ret.getString(AnnotationGrabber.CLASS_NAME);
       try {
         Class<?> aClass = InterfaceToImpl.convert2Impl(
-            DomainModelConsts.PACKAGE_OF_IMPLEMENTATIONS, iClazz, false).get(0);
+            packageOfImplementations, iClazz, false).get(0);
         // there is an implementation
         for (String classPaths : ret.fieldNames()) {
           Object value = ret.getValue(classPaths);

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -597,8 +597,8 @@ public final class RestRouting {
    * @return
    */
   static boolean isStreamed(Annotation[] annotations) {
-    for (int i = 0; i < annotations.length; i++) {
-      if (annotations[i].annotationType().equals(Stream.class)) {
+    for (Annotation annotation : annotations) {
+      if (annotation.annotationType().equals(Stream.class)) {
         return true;
       }
     }
@@ -707,8 +707,8 @@ public final class RestRouting {
   static String acceptCheck(JsonArray l, String h) {
     String []hl = h.split(",");
     String hBest = null;
-    for (int i = 0; i < hl.length; i++) {
-      String mediaRange = hl[i].split(";")[0].trim();
+    for (String s : hl) {
+      String mediaRange = s.split(";")[0].trim();
       for (int j = 0; j < l.size(); j++) {
         String c = l.getString(j);
         if (mediaRange.compareTo("*/*") == 0 || c.equalsIgnoreCase(mediaRange)) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -129,7 +129,6 @@ public class RestVerticle extends AbstractVerticle {
           return Future.succeededFuture();
         })
         .onFailure(cause -> {
-          String reason = cause.getMessage();
           log.error(cause.getMessage(), cause);
           startPromise.fail(cause);
         })
@@ -182,12 +181,12 @@ public class RestVerticle extends AbstractVerticle {
     Promise<Boolean> promise = Promise.promise();
     try {
       ArrayList<Class<?>> aClass = convert2impl("InitAPI", false);
-      for (int i = 0; i < aClass.size(); i++) {
-        Class<?>[] paramArray = new Class[] { Vertx.class, Context.class, Handler.class };
-        Method method = aClass.get(i).getMethod("init", paramArray);
-        method.invoke(aClass.get(i).newInstance(), vertx, context, promise);
+      for (Class<?> value : aClass) {
+        Class<?>[] paramArray = new Class[]{Vertx.class, Context.class, Handler.class};
+        Method method = value.getMethod("init", paramArray);
+        method.invoke(value.newInstance(), vertx, context, promise);
         LogUtil.formatLogMessage(getClass().getName(), "runHook",
-          "One time hook called with implemented class " + "named " + aClass.get(i).getName());
+            "One time hook called with implemented class " + "named " + value.getName());
       }
       return promise.future();
     } catch (ClassNotFoundException|NoSuchMethodException e) {
@@ -212,7 +211,7 @@ public class RestVerticle extends AbstractVerticle {
         LogUtil.formatLogMessage(getClass().getName(), "runPeriodicHook",
             "Periodic hook called with implemented class " + "named " + aClass.get(i).getName());
         final int j = i;
-        vertx.setPeriodic(((Long) delay).longValue(), aLong -> {
+        vertx.setPeriodic((Long) delay, aLong -> {
           try {
             Class<?>[] paramArray1 = new Class[] { Vertx.class, Context.class };
             Method method1 = aClass.get(j).getMethod("run", paramArray1);
@@ -235,12 +234,12 @@ public class RestVerticle extends AbstractVerticle {
   private void runPostDeployHook(Handler<AsyncResult<Boolean>> resultHandler) throws Exception {
     try {
       ArrayList<Class<?>> aClass = convert2impl("PostDeployVerticle", true);
-      for (int i = 0; i < aClass.size(); i++) {
-        Class<?>[] paramArray = new Class[] { Vertx.class, Context.class, Handler.class };
-        Method method = aClass.get(i).getMethod("init", paramArray);
-        method.invoke(aClass.get(i).newInstance(), vertx, context, resultHandler);
+      for (Class<?> value : aClass) {
+        Class<?>[] paramArray = new Class[]{Vertx.class, Context.class, Handler.class};
+        Method method = value.getMethod("init", paramArray);
+        method.invoke(value.newInstance(), vertx, context, resultHandler);
         LogUtil.formatLogMessage(getClass().getName(), "runHook",
-          "Post Deploy Hook called with implemented class " + "named " + aClass.get(i).getName());
+            "Post Deploy Hook called with implemented class " + "named " + value.getName());
       }
     } catch (ClassNotFoundException e) {
       // no hook implemented, this is fine, just startup normally then
@@ -256,12 +255,12 @@ public class RestVerticle extends AbstractVerticle {
   private void runShutdownHook(Handler<AsyncResult<Void>> resultHandler) throws Exception {
     try {
       ArrayList<Class<?>> aClass = convert2impl("ShutdownAPI", false);
-      for (int i = 0; i < aClass.size(); i++) {
-        Class<?>[] paramArray = new Class[] { Vertx.class, Context.class, Handler.class };
-        Method method = aClass.get(i).getMethod("shutdown", paramArray);
-        method.invoke(aClass.get(i).newInstance(), vertx, context, resultHandler);
+      for (Class<?> value : aClass) {
+        Class<?>[] paramArray = new Class[]{Vertx.class, Context.class, Handler.class};
+        Method method = value.getMethod("shutdown", paramArray);
+        method.invoke(value.newInstance(), vertx, context, resultHandler);
         LogUtil.formatLogMessage(getClass().getName(), "runShutdownHook",
-          "shutdown hook called with implemented class " + "named " + aClass.get(i).getName());
+            "shutdown hook called with implemented class " + "named " + value.getName());
       }
     } catch (ClassNotFoundException e) {
       // no hook implemented, this is fine, just startup normally then
@@ -270,7 +269,7 @@ public class RestVerticle extends AbstractVerticle {
     }
   }
 
-  private void cmdProcessing() throws IOException {
+  private void cmdProcessing() {
     // TODO need to add a normal command line parser
     List<String> cmdParams = processArgs();
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -44,7 +44,7 @@ public class RestVerticle extends AbstractVerticle {
   public static final Map<String, String> MODULE_SPECIFIC_ARGS  = new HashMap<>(); //NOSONAR
 
   private static final String       HTTP_PORT_SETTING               = "http.port";
-  private static String             className                       = RestVerticle.class.getName();
+  private static final String       className                       = RestVerticle.class.getName();
   private static final Logger       log                             = LogManager.getLogger(RestVerticle.class);
   private static String             deploymentId                     = "";
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -1,85 +1,37 @@
 package org.folio.rest;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringReader;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.ValidatorFactory;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.google.common.base.Joiner;
 
 import io.vertx.core.Future;
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.time.DateUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.ThreadContext;
-import org.folio.okapi.common.logging.FolioLoggingContext;
-import org.folio.rest.annotations.Stream;
-import org.folio.rest.jaxrs.model.Error;
-import org.folio.rest.jaxrs.model.Errors;
-import org.folio.rest.jaxrs.model.Parameter;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.resource.DomainModelConsts;
-import org.folio.rest.tools.AnnotationGrabber;
-import org.folio.rest.tools.client.exceptions.ResponseException;
-import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.rest.tools.messages.MessageConsts;
-import org.folio.rest.tools.messages.Messages;
-import org.folio.rest.tools.utils.AsyncResponseResult;
-import org.folio.rest.tools.utils.BinaryOutStream;
-import org.folio.rest.tools.utils.InterfaceToImpl;
-import org.folio.rest.tools.utils.JsonUtils;
-import org.folio.rest.tools.utils.LogUtil;
-import org.folio.rest.tools.utils.MetadataUtil;
-import org.folio.HttpStatus;
-import org.folio.dbschema.ObjectMapperTool;
-import org.folio.rest.tools.utils.OutStream;
-import org.folio.rest.tools.utils.ResponseImpl;
-import org.folio.rest.tools.utils.ValidationHelper;
-import org.folio.util.StringUtil;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.Router;
-import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.StaticHandler;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.resource.DomainModelConsts;
+import org.folio.rest.tools.client.test.HttpClientMock2;
+import org.folio.rest.tools.messages.MessageConsts;
+import org.folio.rest.tools.messages.Messages;
+import org.folio.rest.tools.utils.InterfaceToImpl;
+import org.folio.rest.tools.utils.LogUtil;
 
 public class RestVerticle extends AbstractVerticle {
 
@@ -94,54 +46,11 @@ public class RestVerticle extends AbstractVerticle {
 
   public static final Map<String, String> MODULE_SPECIFIC_ARGS  = new HashMap<>(); //NOSONAR
 
-  private static final String       SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
-  private static final String       DEFAULT_CONTENT_TYPE            = "application/json";
-  private static final String       SUPPORTED_CONTENT_TYPE_TEXT_DEF = "text/plain";
-  private static final String       FILE_UPLOAD_PARAM               = "javax.mail.internet.MimeMultipart";
   private static final String       HTTP_PORT_SETTING               = "http.port";
   private static String             className                       = RestVerticle.class.getName();
   private static final Logger       log                             = LogManager.getLogger(RestVerticle.class);
-  private static final ObjectMapper MAPPER                          = ObjectMapperTool.getMapper();
-
-  private static final String[]     DATE_PATTERNS = {
-    "yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
-    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-    "yyyy-MM-dd'T'HH:mm:ss'Z'",
-    "yyyy-MM-dd'T'HH:mm:ss",
-    "yyyy-MM-dd",
-    "yyyy-MM",
-    "yyyy"
-  };
-
-  private static ValidatorFactory   validationFactory;
   private static String             deploymentId                     = "";
-
   private final Messages            messages                        = Messages.getInstance();
-
-  static {
-    //validationFactory used to validate the pojos which are created from the json
-    //passed in the request body in put and post requests. The constraints validated by this factory
-    //are the ones in the json schemas accompanying the raml files
-    validationFactory = Validation.buildDefaultValidatorFactory();
-  }
-
-  // https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-  // first match - no q val check
-  static String acceptCheck(JsonArray l, String h) {
-    String []hl = h.split(",");
-    String hBest = null;
-    for (int i = 0; i < hl.length; i++) {
-      String mediaRange = hl[i].split(";")[0].trim();
-      for (int j = 0; j < l.size(); j++) {
-        String c = l.getString(j);
-        if (mediaRange.compareTo("*/*") == 0 || c.equalsIgnoreCase(mediaRange)) {
-          hBest = c;
-          break;
-        }
-      }
-    }
-    return hBest;
-  }
 
   @Override
   public void start(Promise<Void> startPromise) throws Exception {
@@ -155,338 +64,73 @@ public class RestVerticle extends AbstractVerticle {
 
     LogUtil.formatLogMessage(className, "start", "metrics enabled: " + vertx.isMetricsEnabled());
 
-    // maps paths found in raml to the generated functions to route to when the paths are requested
-    MappedClasses mappedURLs = populateConfig();
-
-    // set of exposed urls as declared in the raml
-    Set<String> urlPaths = mappedURLs.getAvailURLs();
-
-    // create a map of regular expression to url path
-    Map<String, Pattern> regex2Pattern = mappedURLs.buildURLRegex();
-
     // Create a router object.
     Router router = Router.router(vertx);
 
-    log.info(context.getInstanceCount() + " verticles deployed ");
+    //single handler for all url calls other then documentation
+    //which is handled separately
+    //router.routeWithRegex("^(?!.*apidocs).*$").handler(rc -> route(mappedURLs, urlPaths, regex2Pattern, rc));
+    // routes requests on “/assets/*” to resources stored in the “assets”
+    // directory.
+    router.route("/assets/*").handler(StaticHandler.create("assets"));
 
-    // run pluggable startup code in a class implementing the InitAPI interface
-    // in the "org.folio.rest.impl" package
-    runHook(vv -> {
-      if (((Future<?>) vv).failed()) {
-        String reason = ((Future<?>) vv).cause().getMessage();
-        log.error( messages.getMessage("en", MessageConsts.InitializeVerticleFail, reason));
-        startPromise.fail(reason);
-        vertx.close();
-        System.exit(-1);
-      } else {
-        log.info("init succeeded.......");
-        try {
-          // startup periodic impl if exists
-          runPeriodicHook();
-        } catch (Exception e2) {
-          log.error(e2.getMessage(), e2);
-        }
-        //single handler for all url calls other then documentation
-        //which is handled separately
-        router.routeWithRegex("^(?!.*apidocs).*$").handler(rc -> route(mappedURLs, urlPaths, regex2Pattern, rc));
-        // routes requests on “/assets/*” to resources stored in the “assets”
-        // directory.
-        router.route("/assets/*").handler(StaticHandler.create("assets"));
+    // In the following example all requests to paths starting with
+    // /apidocs/ will get served from the directory resources/apidocs:
+    // example:
+    // http://localhost:8181/apidocs/index.html?raml=raml/_patrons.raml
+    router.route("/apidocs/*").handler(StaticHandler.create("apidocs"));
+    // startup http server on port 8181 to serve documentation
 
-        // In the following example all requests to paths starting with
-        // /apidocs/ will get served from the directory resources/apidocs:
-        // example:
-        // http://localhost:8181/apidocs/index.html?raml=raml/_patrons.raml
-        router.route("/apidocs/*").handler(StaticHandler.create("apidocs"));
-        // startup http server on port 8181 to serve documentation
+    //if client includes an Accept-Encoding header which includes
+    //the supported compressions - deflate or gzip.
+    HttpServerOptions serverOptions = new HttpServerOptions();
+    serverOptions.setCompressionSupported(true);
 
-        String portS = System.getProperty(HTTP_PORT_SETTING);
-        int port;
-        if (portS != null) {
-          port = Integer.parseInt(portS);
-          config().put(HTTP_PORT_SETTING, port);
-        } else {
-          // we are here if port was not passed via cmd line
-          port = config().getInteger(HTTP_PORT_SETTING, 8081);
-        }
-
-        //check if mock mode requested and set sys param so that http client factory
-        //can config itself accordingly
-        String mockMode = config().getString(HttpClientMock2.MOCK_MODE);
-        if(mockMode != null){
-          System.setProperty(HttpClientMock2.MOCK_MODE, mockMode);
-        }
-
-        //if client includes an Accept-Encoding header which includes
-        //the supported compressions - deflate or gzip.
-        HttpServerOptions serverOptions = new HttpServerOptions();
-        serverOptions.setCompressionSupported(true);
-
-        HttpServer server = vertx.createHttpServer(serverOptions);
-        server.requestHandler(router)
-        // router object (declared in the beginning of the atrt function accepts request and will pass to next handler for
-        // specified path
-
-        .listen(port,
-          // Retrieve the port from the configuration file - file needs to
-          // be passed as arg to command line,
-          // for example: -conf src/main/conf/my-application-conf.json
-          // default to 8181.
-          result -> {
-            if (result.failed()) {
-              startPromise.fail(new RuntimeException("Listening on port " + port, result.cause()));
-            } else {
-              try {
-                runPostDeployHook( res2 -> {
-                  if(!res2.succeeded()){
-                    log.error(res2.cause().getMessage(), res2.cause());
-                  }
-                });
-              } catch (Exception e) {
-                log.error(e.getMessage(), e);
-              }
-              LogUtil.formatLogMessage(className, "start", "http server for apis and docs started on port " + port + ".");
-              LogUtil.formatLogMessage(className, "start", "Documentation available at: " + "http://localhost:" + port + "/apidocs/");
-              startPromise.complete();
-            }
-          });
-      }
-    });
-  }
-
-  /**
-   * Match the path agaist pattern.
-   * @return the matching groups urldecoded, may be an empty array, or null if the pattern doesn't match
-   */
-  @SuppressWarnings("java:S1168")  // suppress "Empty arrays should be returned instead of null"
-  static String[] matchPath(String path, Pattern pattern) {
-    Matcher m = pattern.matcher(path);
-    if (! m.find()) {
-      return null;
+    HttpServer server = vertx.createHttpServer(serverOptions);
+    String portS = System.getProperty(HTTP_PORT_SETTING);
+    int port;
+    if (portS != null) {
+      port = Integer.parseInt(portS);
+      config().put(HTTP_PORT_SETTING, port);
+    } else {
+      // we are here if port was not passed via cmd line
+      port = config().getInteger(HTTP_PORT_SETTING, 8081);
     }
-
-    int groups = m.groupCount();
-    // pathParams are the place holders in the raml query string
-    // for example /admin/{admin_id}/yyy/{yyy_id} - the content in between the {} are path params
-    // they are replaced with actual values and are passed to the function which the url is mapped to
-    String[] pathParams = new String[groups];
-    for (int i = 0; i < groups; i++) {
-      pathParams[i] = StringUtil.urlDecode(m.group(i + 1));
-    }
-    return pathParams;
-  }
-
-  /**
-   * Handler for all url calls other then documentation.
-   * @param mappedURLs  maps paths found in raml to the generated functions to route to when the paths are requested
-   * @param urlPaths  set of exposed urls as declared in the raml
-   * @param regex2Pattern  create a map of regular expression to url path
-   * @param rc  RoutingContext of this URL
-   */
-  void route(MappedClasses mappedURLs, Set<String> urlPaths, Map<String, Pattern> regex2Pattern,
-      RoutingContext rc) {
-    long start = System.nanoTime();
-    try {
-      boolean validPath = false;
-      boolean[] validRequest = { true };
-      // urlPaths = list of regex urls created from urls declared in the raml.
-      // loop over regex patterns and try to match them against the requested
-      // URL if no match is found, then the requested url is not supported by
-      // the ramls and we return an error - this has positive security implications as well
-      for (String urlPath : urlPaths) {
-        String[] pathParams = matchPath(rc.request().path(), regex2Pattern.get(urlPath));
-        if (pathParams != null) {  // if matched
-          validPath = true;
-
-          // get the function that should be invoked for the requested
-          // path + requested http_method pair
-          JsonObject ret = mappedURLs.getMethodbyPath(urlPath, rc.request().method().toString());
-          // if a valid path was requested but no function was found
-          if (ret == null) {
-
-            // if the path is valid and the http method is options
-            // assume a cors request
-            if (rc.request().method() == HttpMethod.OPTIONS) {
-              rc.response().end();
-              return;
-            }
-
-            // the url exists but the http method requested does not match a function
-            // meaning url+http method != a function
-            endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.HTTPMethodNotSupported),
-              validRequest);
-            return;
-          }
-          Class<?> aClass;
+    RestRouting.populateRoutes(router)
+        .compose(x -> runHook())
+        .compose(x -> server.requestHandler(router).listen(port))
+        .compose(ret -> {
           try {
-            if (validRequest[0]) {
-              //create okapi headers map and inject into function
-              Map<String, String> okapiHeaders = new CaseInsensitiveMap<>();
-              String []tenantId = new String[]{null};
-              getOkapiHeaders(rc, okapiHeaders, tenantId);
-              if(tenantId[0] == null && !rc.request().path().startsWith("/admin")){
-                //if tenant id is not passed in and this is not an /admin request, return error
-                endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.UnableToProcessRequest)
-                  + " Tenant must be set", validRequest);
-              }
-
-              if (validRequest[0]) {
-                //get interface mapped to this url
-                String iClazz = ret.getString(AnnotationGrabber.CLASS_NAME);
-                // convert from interface to an actual class implementing it, which appears in the impl package
-                aClass = InterfaceToImpl.convert2Impl(
-                    DomainModelConsts.PACKAGE_OF_IMPLEMENTATIONS, iClazz, false).get(0);
-                Object o = null;
-                // call back the constructor of the class - gives a hook into the class not based on the apis
-                // passing the vertx and context objects in to it.
-                try {
-                  o = aClass.getConstructor(Vertx.class, String.class).newInstance(vertx, tenantId[0]);
-                } catch (Exception e) {
-                  // if no such constructor was implemented call the
-                  // default no param constructor to create the object to be used to call functions on
-                  o = aClass.newInstance();
-                }
-                final Object instance = o;
-                // function to invoke for the requested url
-                String function = ret.getString(AnnotationGrabber.FUNCTION_NAME);
-                // parameters for the function to invoke
-                JsonObject params = ret.getJsonObject(AnnotationGrabber.METHOD_PARAMS);
-                // all methods in the class whose function is mapped to the called url
-                // needed so that we can get a reference to the Method object and call it via reflection
-                Method[] methods = aClass.getMethods();
-                // what the api will return as output (Content-Type)
-                JsonArray produces = ret.getJsonArray(AnnotationGrabber.PRODUCES);
-                // what the api expects to get (Accept)
-                JsonArray consumes = ret.getJsonArray(AnnotationGrabber.CONSUMES);
-
-                HttpServerRequest request = rc.request();
-
-                //check that the accept and content-types passed in the header of the request
-                //are as described in the raml
-                checkAcceptContentType(produces, consumes, rc, validRequest);
-
-                //Get method in class to be run for this requested API endpoint
-                Method[] method2Run = new Method[]{null};
-                for (int i = 0; i < methods.length; i++) {
-                  if (methods[i].getName().equals(function)) {
-                    method2Run[0] = methods[i];
-                    break;
-                  }
-                }
-                //is function annotated to receive data in chunks as they come in.
-                //Note that the function controls the logic to this if this is the case
-                boolean streamData = isStreamed(method2Run[0].getAnnotations());
-                // check if we are dealing with a file upload , currently only multipart/form-data and application/octet
-                //in the raml definition for such a function
-                final boolean[] isContentUpload = new boolean[] { false };
-                final boolean[] useRoutingContext = { false };
-                final int[] uploadParamPosition = new int[] { -1 };
-                params.forEach(param -> {
-                  if(((JsonObject) param.getValue()).getString("type").equals("java.io.InputStream")){
-                    //application/octet-stream passed - this is handled in a stream like manner
-                    //and the corresponding function called must annotate with a @Stream - and be able
-                    //to handle the function being called repeatedly on parts of the data
-                    uploadParamPosition[0] = ((JsonObject) param.getValue()).getInteger("order");
-                    isContentUpload[0] = true;
-                  }
-                });
-
-                // create the array and then populate it by parsing the url parameters which are needed to invoke the function mapped
-                //to the requested URL - array will be populated by parseParams() function
-                Iterator<Map.Entry<String, Object>> paramList = params.iterator();
-                Object[] paramArray = new Object[params.size()];
-
-                if (streamData) {
-                  parseParams(rc, null, paramList, validRequest, consumes, paramArray, pathParams, okapiHeaders, useRoutingContext);
-                  handleStream(method2Run[0], rc, useRoutingContext[0], request, instance, tenantId, okapiHeaders,
-                    uploadParamPosition, paramArray, validRequest, start);
-                } else {
-                  // regular request (no streaming).. Read the request body before checking params + body
-                  Buffer body = Buffer.buffer();
-                  rc.request().handler(body::appendBuffer);
-                  rc.request().endHandler(endRes -> {
-                    parseParams(rc, body, paramList, validRequest, consumes, paramArray, pathParams, okapiHeaders, useRoutingContext);
-                    if (validRequest[0]) {
-                      //if request is valid - invoke it
-                      try {
-                        invoke(method2Run[0], paramArray, instance, rc, useRoutingContext[0], tenantId, okapiHeaders, new StreamStatus(), v -> {
-                          withRequestId(rc, () -> LogUtil.formatLogMessage(className, "start", " invoking " + function));
-                          sendResponse(rc, v, start, tenantId[0]);
-                        });
-                      } catch (Exception e1) {
-                        withRequestId(rc, () -> log.error(e1.getMessage(), e1));
-                        rc.response().end();
-                      }
-                    } else {
-                      endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.UnableToProcessRequest),
-                          validRequest);
-                    }
-                  });
-                }
-              }
-            }
+            // startup periodic impl if exists
+            runPeriodicHook();
           } catch (Exception e) {
-            withRequestId(rc, () -> log.error(e.getMessage(), e));
-            endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.UnableToProcessRequest) + e.getMessage(),
-              validRequest);
-            return;
+            log.error(e.getMessage(), e);
+            return Future.failedFuture(e);
           }
-        }
-      }
-      if (!validPath) {
-        // invalid path
-        endRequestWithError(rc, 400, true,
-          messages.getMessage("en", MessageConsts.InvalidURLPath, rc.request().path()), validRequest);
-      }
-    } catch (Exception e) {
-      withRequestId(rc, () -> log.error(e.getMessage(), e));
-      endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });
-    }
-  }
-
-  private void handleStream(Method method2Run, RoutingContext rc, boolean useRoutingContext, HttpServerRequest request,
-      Object instance, String[] tenantId, Map<String, String> okapiHeaders,
-      int[] uploadParamPosition, Object[] paramArray, boolean[] validRequest, long start){
-    request.handler(new Handler<Buffer>() {
-      @Override
-      public void handle(Buffer buff) {
-        try {
-          StreamStatus stat = new StreamStatus();
-          stat.setStatus(0);
-          paramArray[uploadParamPosition[0]] =
-              new ByteArrayInputStream( buff.getBytes() );
-          invoke(method2Run, paramArray, instance, rc, useRoutingContext, tenantId, okapiHeaders, stat, v -> {
-            withRequestId(rc, () -> LogUtil.formatLogMessage(className, "start", " invoking " + method2Run));
-          });
-        } catch (Exception e1) {
-          withRequestId(rc, () -> log.error(e1.getMessage(), e1));
-          rc.response().end();
-        }
-      }
-    });
-    request.endHandler( e -> {
-      StreamStatus stat = new StreamStatus();
-      stat.setStatus(1);
-      paramArray[uploadParamPosition[0]] = new ByteArrayInputStream(new byte [0]);
-      invoke(method2Run, paramArray, instance, rc, useRoutingContext, tenantId, okapiHeaders, stat, v -> {
-        withRequestId(rc, () -> LogUtil.formatLogMessage(className, "start", " invoking " + method2Run));
-        //all data has been stored in memory - not necessarily all processed
-        sendResponse(rc, v, start, tenantId[0]);
-      });
-    });
-    request.exceptionHandler(new Handler<Throwable>() {
-      @Override
-      public void handle(Throwable event) {
-        StreamStatus stat = new StreamStatus();
-        stat.setStatus(2);
-        paramArray[uploadParamPosition[0]] = new ByteArrayInputStream(new byte[0]);
-        invoke(method2Run, paramArray, instance, rc, useRoutingContext, tenantId, okapiHeaders, stat,
-            v -> withRequestId(rc, () ->
-              LogUtil.formatLogMessage(className, "start", " invoking " + method2Run))
-        );
-        endRequestWithError(rc, 400, true, "unable to upload file " + event.getMessage(), validRequest);
-      }
-    });
+          //check if mock mode requested and set sys param so that http client factory
+          //can config itself accordingly
+          String mockMode = config().getString(HttpClientMock2.MOCK_MODE);
+          if (mockMode != null) {
+            System.setProperty(HttpClientMock2.MOCK_MODE, mockMode);
+          }
+          try {
+            runPostDeployHook(res2 -> {
+              if (!res2.succeeded()) {
+                log.error(res2.cause().getMessage(), res2.cause());
+              }
+            });
+          } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            return Future.failedFuture(e);
+          }
+          return Future.succeededFuture();
+        })
+        .onFailure(cause -> {
+          String reason = cause.getMessage();
+          log.error(cause.getMessage(), cause);
+          startPromise.fail(cause);
+        })
+        .onSuccess(x -> startPromise.complete());
   }
 
   private void readInGitProps(){
@@ -502,253 +146,6 @@ public class RestVerticle extends AbstractVerticle {
         log.warn(e.getMessage());
       }
     }
-  }
-
-  /**
-   * @param annotations
-   * @return
-   */
-  private boolean isStreamed(Annotation[] annotations) {
-    for (int i = 0; i < annotations.length; i++) {
-      if(annotations[i].annotationType().equals(Stream.class)){
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * @return a {@link Response} extracted from asyncResult, either from result(), or from
-   *         cause().getResponse() if cause() is a {@link ResponseException}, or null otherwise
-   */
-  static Response getResponse(AsyncResult<Response> asyncResult) {
-    if (asyncResult.succeeded()) {
-      return asyncResult.result();
-    }
-    Throwable exception = asyncResult.cause();
-    if (exception instanceof ResponseException) {
-      return ((ResponseException) exception).getResponse();
-    }
-    return null;
-  }
-
-  /**
-   * Send the result as response.
-   *
-   * @param rc
-   *          - where to send the result
-   * @param v
-   *          - the result to send
-   * @param start
-   *          - request's start time, using JVM's high-resolution time source, in nanoseconds
-   */
-  private void sendResponse(RoutingContext rc, AsyncResult<Response> v, long start, String tenantId) {
-    Response responseFromResult = getResponse(v);
-    if (responseFromResult == null) {
-      // catch all
-      endRequestWithError(rc, 500, true, "Server error", new boolean[] { true });
-      return;
-    }
-    Object entity = null;
-    try {
-      HttpServerResponse response = rc.response();
-      int statusCode = responseFromResult.getStatus();
-      // 204 means no content returned in the response, so passing
-      // a chunked Transfer header is not allowed
-      if (statusCode != 204) {
-        response.setChunked(true);
-      }
-
-      response.setStatusCode(statusCode);
-
-      // !!!!!!!!!!!!!!!!!!!!!! CORS commented OUT!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      // response.putHeader("Access-Control-Allow-Origin", "*");
-
-      copyHeadersJoin(responseFromResult.getStringHeaders(), response.headers());
-
-      entity = responseFromResult.getEntity();
-
-      /* entity is of type OutStream - and will be written as a string */
-      if (entity instanceof OutStream) {
-        response.write(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(((OutStream) entity).getData()));
-      }
-      /* entity is of type BinaryOutStream - and will be written as a buffer */
-      else if(entity instanceof BinaryOutStream){
-        response.write(Buffer.buffer(((BinaryOutStream) entity).getData()));
-      }
-      /* data is a string so just push it out, no conversion needed */
-      else if(entity instanceof String){
-        response.write(Buffer.buffer((String)entity));
-      }
-      /* catch all - anything else will be assumed to be a pojo which needs converting to json */
-      else if (entity != null) {
-        response.write(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(entity));
-      }
-    } catch (Exception e) {
-      withRequestId(rc, () -> log.error(e.getMessage(), e));
-    } finally {
-      rc.response().end();
-    }
-
-    long end = System.nanoTime();
-
-    StringBuilder sb = new StringBuilder();
-    if (log.isDebugEnabled()) {
-      try {
-        sb.append(MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(entity));
-      } catch (Exception e) {
-        String name = entity == null ? "null" : entity.getClass().getName();
-        withRequestId(rc, () -> log.error("writeValueAsString(" + name + ")", e));
-      }
-    }
-
-    withRequestId(rc, () -> LogUtil.formatStatsLogMessage(rc, (end - start) / 1000000, tenantId, sb.toString()));
-  }
-
-  /**
-   * Copy the headers from source to destination. Join several headers of same key using "; ".
-   */
-  private void copyHeadersJoin(MultivaluedMap<String,String> source, MultiMap destination) {
-    for (Entry<String, List<String>> entry : source.entrySet()) {
-      String jointValue = Joiner.on("; ").join(entry.getValue());
-      try {
-        destination.add(entry.getKey(), jointValue);
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(
-            e.getMessage() + ": " + entry.getKey() + " - " + jointValue, e);
-      }
-    }
-  }
-
-  void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message, boolean[] isValid) {
-    if (isValid[0]) {
-      HttpServerResponse response = rc.response();
-      if (!response.closed()) {
-        response.setChunked(chunked);
-        response.setStatusCode(status);
-        if (status == 422) {
-          response.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_JSON_DEF);
-        } else {
-          response.putHeader("Content-type", SUPPORTED_CONTENT_TYPE_TEXT_DEF);
-        }
-        if (message != null) {
-          response.write(message);
-        }
-        response.end();
-      }
-      withRequestId(rc, () ->
-        LogUtil.formatStatsLogMessage(rc, -1, null, message == null ? "" : message));
-    }
-    // once we are here the call is not valid
-    isValid[0] = false;
-  }
-
-  private void getOkapiHeaders(RoutingContext rc, Map<String, String> headers, String[] tenantId){
-    MultiMap mm = rc.request().headers();
-    Consumer<Map.Entry<String,String>> consumer = entry -> {
-      String headerKey = entry.getKey().toLowerCase();
-      if(headerKey.startsWith(OKAPI_HEADER_PREFIX)){
-        if(headerKey.equalsIgnoreCase(OKAPI_HEADER_TENANT)){
-          tenantId[0] = entry.getValue();
-        }
-        headers.put(headerKey, entry.getValue());
-      }
-    };
-    mm.forEach(consumer);
-  }
-
-  private void invoke(Method method, Object[] params, Object o, RoutingContext rc, boolean addRCParam, String[] tenantId,
-      Map<String,String> headers, StreamStatus streamed, Handler<AsyncResult<Response>> resultHandler) {
-
-    //if streaming is requested the status will be 0 (streaming started)
-    //or 1 streaming data complete
-    //or 2 streaming aborted
-    //otherwise it will be -1 and flags wont be set
-    if(streamed.status == 0){
-      headers.put(STREAM_ID, String.valueOf(rc.hashCode()));
-    }
-    else if(streamed.status == 1){
-      headers.put(STREAM_ID, String.valueOf(rc.hashCode()));
-      headers.put(STREAM_COMPLETE, String.valueOf(rc.hashCode()));
-    }
-    else if (streamed.status == 2){
-      headers.put(STREAM_ID, String.valueOf(rc.hashCode()));
-      headers.put(STREAM_ABORT, String.valueOf(rc.hashCode()));
-    }
-
-    Object[] newArray = new Object[params.length];
-    int size = 3;
-    int pos = 0;
-
-    //this endpoint indicated it wants to receive the routing context as a parameter
-    if(addRCParam){
-      //the amount of extra params added is 4 not 3
-      size = 4;
-      //the first param of the extra params is the injected RC
-      newArray[params.length - size] = rc;
-      pos = 1;
-    }
-
-    for (int i = 0; i < params.length - size; i++) {
-      newArray[i] = params[i];
-    }
-
-    //inject call back handler into each function
-    newArray[params.length - (size-(pos+1))] = resultHandler;
-
-    //inject vertx context into each function
-    newArray[params.length - (size-(pos+2))] = context;
-
-    newArray[params.length - (size-pos)] = headers;
-
-    headers.forEach(FolioLoggingContext::put);
-
-    try {
-      method.invoke(o, newArray);
-      // response.setChunked(true);
-      // response.setStatusCode(((Response)result).getStatus());
-    } catch (Exception e) {
-      withRequestId(rc, () -> log.error(e.getMessage(), e));
-      String message;
-      try {
-        // catch exception for now in case of null point and show generic
-        // message
-        message = e.getCause().getMessage();
-      } catch (Throwable ee) {
-        message = messages.getMessage("en", MessageConsts.UnableToProcessRequest);
-      }
-      endRequestWithError(rc, 400, true, message, new boolean[]{true});
-    }
-  }
-
-  private MappedClasses populateConfig() {
-    MappedClasses mappedURLs = new MappedClasses();
-    JsonObject jObjClasses = new JsonObject();
-    try {
-      jObjClasses.mergeIn(AnnotationGrabber.generateMappings(null));
-    } catch (Exception e) {
-      log.error(e.getMessage(), e);
-    }
-    // loadConfig(JSON_URL_MAPPINGS);
-    Set<String> classURLs = jObjClasses.fieldNames();
-    classURLs.forEach(classURL -> {
-      log.info(classURL);
-      JsonObject jObjMethods = jObjClasses.getJsonObject(classURL);
-      Set<String> methodURLs = jObjMethods.fieldNames();
-      jObjMethods.fieldNames();
-      methodURLs.forEach(methodURL -> {
-        Object val = jObjMethods.getValue(methodURL);
-        if (val instanceof JsonArray) {
-          ((JsonArray) val).forEach(entry -> {
-            String pathRegex = ((JsonObject) entry).getString("regex2method");
-            ((JsonObject) entry).put(AnnotationGrabber.CLASS_NAME, jObjMethods.getString(AnnotationGrabber.CLASS_NAME));
-            ((JsonObject) entry).put(AnnotationGrabber.INTERFACE_NAME, jObjMethods.getString(AnnotationGrabber.INTERFACE_NAME));
-            mappedURLs.addPath(pathRegex, (JsonObject) entry);
-          });
-        }
-      });
-    });
-    return mappedURLs;
   }
 
   @Override
@@ -778,19 +175,23 @@ public class RestVerticle extends AbstractVerticle {
    * implementors of the InitAPI interface must call back the handler in there init() implementation like this:
    * resultHandler.handle(io.vertx.core.Future.succeededFuture(true)); or this will hang
    */
-  private void runHook(Handler<AsyncResult<Boolean>> resultHandler) throws Exception {
+  private Future<Boolean> runHook() {
+    Promise<Boolean> promise = Promise.promise();
     try {
       ArrayList<Class<?>> aClass = convert2impl("InitAPI", false);
       for (int i = 0; i < aClass.size(); i++) {
         Class<?>[] paramArray = new Class[] { Vertx.class, Context.class, Handler.class };
         Method method = aClass.get(i).getMethod("init", paramArray);
-        method.invoke(aClass.get(i).newInstance(), vertx, context, resultHandler);
+        method.invoke(aClass.get(i).newInstance(), vertx, context, promise);
         LogUtil.formatLogMessage(getClass().getName(), "runHook",
           "One time hook called with implemented class " + "named " + aClass.get(i).getName());
       }
-    } catch (ClassNotFoundException e) {
+      return promise.future();
+    } catch (ClassNotFoundException|NoSuchMethodException e) {
       // no hook implemented, this is fine, just startup normally then
-      resultHandler.handle(io.vertx.core.Future.succeededFuture(true));
+      return Future.succeededFuture(Boolean.TRUE);
+    } catch (Exception e) {
+      return Future.failedFuture(e);
     }
   }
 
@@ -806,18 +207,15 @@ public class RestVerticle extends AbstractVerticle {
         Method method = aClass.get(i).getMethod("runEvery", paramArray);
         Object delay = method.invoke(aClass.get(i).newInstance());
         LogUtil.formatLogMessage(getClass().getName(), "runPeriodicHook",
-          "Periodic hook called with implemented class " + "named " + aClass.get(i).getName());
+            "Periodic hook called with implemented class " + "named " + aClass.get(i).getName());
         final int j = i;
-        vertx.setPeriodic(((Long) delay).longValue(), new Handler<Long>() {
-          @Override
-          public void handle(Long aLong) {
-            try {
-              Class<?>[] paramArray1 = new Class[] { Vertx.class, Context.class };
-              Method method1 = aClass.get(j).getMethod("run", paramArray1);
-              method1.invoke(aClass.get(j).newInstance(), vertx, context);
-            } catch (Exception e) {
-              log.error(e.getMessage(), e);
-            }
+        vertx.setPeriodic(((Long) delay).longValue(), aLong -> {
+          try {
+            Class<?>[] paramArray1 = new Class[] { Vertx.class, Context.class };
+            Method method1 = aClass.get(j).getMethod("run", paramArray1);
+            method1.invoke(aClass.get(j).newInstance(), vertx, context);
+          } catch (Exception e) {
+            log.error(e.getMessage(), e);
           }
         });
       }
@@ -911,387 +309,6 @@ public class RestVerticle extends AbstractVerticle {
           }
         }
       }
-    }
-  }
-
-  /**
-   * look for the boundary and return just the multipart/form-data multipart/form-data boundary=----WebKitFormBoundaryP8wZiNAoFszXOXEt if
-   * boundary doesnt exist that return original string
-   */
-  private String removeBoundry(String contenttype) {
-    int idx = contenttype.indexOf("boundary");
-    if (idx != -1) {
-      return contenttype.substring(0, idx - 1);
-    }
-    return contenttype;
-  }
-
-  /**
-   * check accept and content-type headers if no - set the request asa not valid and return error to user
-   */
-  private void checkAcceptContentType(JsonArray produces, JsonArray consumes, RoutingContext rc, boolean[] validRequest) {
-    /*
-     * NOTE that the content type and accept headers will accept a partial match - for example: if the raml indicates a text/plain and an
-     * application/json content-type and only one is passed - it will accept it
-     */
-    // check allowed content types in the raml for this resource + method
-    HttpServerRequest request = rc.request();
-    if (consumes != null && validRequest[0]) {
-      // get the content type passed in the request
-      // if this was left out by the client they must add for request to return
-      // clean up simple stuff from the clients header - trim the string and remove ';' in case
-      // it was put there as a suffix
-      String contentType = StringUtils.defaultString(request.getHeader("Content-type"), DEFAULT_CONTENT_TYPE)
-          .replaceFirst(";.*", "").trim();
-      if (!consumes.contains(removeBoundry(contentType))) {
-        endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.ContentTypeError, consumes, contentType),
-          validRequest);
-      }
-    }
-
-    // type of data expected to be returned by the server
-    if (produces != null && validRequest[0]) {
-      String accept = StringUtils.defaultString(request.getHeader("Accept"), "*/*");
-      if (acceptCheck(produces, accept) == null) {
-        // use contains because multiple values may be passed here
-        // for example json/application; text/plain mismatch of content type found
-        endRequestWithError(rc, 400, true, messages.getMessage("en", MessageConsts.AcceptHeaderError, produces, accept),
-          validRequest);
-      }
-    }
-  }
-
-  private void parseParams(RoutingContext rc, Buffer body, Iterator<Map.Entry<String, Object>> paramList, boolean[] validRequest, JsonArray consumes,
-      Object[] paramArray, String[] pathParams, Map<String, String> okapiHeaders, boolean [] useRC) {
-
-    HttpServerRequest request = rc.request();
-    MultiMap queryParams = request.params();
-    int []pathParamsIndex = new int[] { 0 };
-
-    paramList.forEachRemaining(entry -> {
-      if (validRequest[0]) {
-        String valueName = ((JsonObject) entry.getValue()).getString("value");
-        String valueType = ((JsonObject) entry.getValue()).getString("type");
-        String paramType = ((JsonObject) entry.getValue()).getString("param_type");
-        int order = ((JsonObject) entry.getValue()).getInteger("order");
-        Object defaultVal = ((JsonObject) entry.getValue()).getValue("default_value");
-
-        boolean emptyNumericParam = false;
-        // validation of query params (other then enums), object in body (not including drools),
-        // and some header params validated by jsr311 (aspects) - the rest are handled in the code here
-        // handle un-annotated parameters - this is assumed to be
-        // entities in HTTP BODY for post and put requests or the 3 injected params
-        // (okapi headers, vertx context and vertx handler) - file uploads are also not annotated but are not handled here due
-        // to their async upload - so explicitly skip them
-        if (AnnotationGrabber.NON_ANNOTATED_PARAM.equals(paramType) && !FILE_UPLOAD_PARAM.equals(valueType)) {
-          try {
-            // this will also validate the json against the pojo created from the schema
-            Class<?> entityClazz = Class.forName(valueType);
-
-            if (valueType.equals("io.vertx.ext.web.RoutingContext")) {
-              useRC[0] = true;
-            } else if (!valueType.equals("io.vertx.core.Handler") && !valueType.equals("io.vertx.core.Context") &&
-                !valueType.equals("java.util.Map") && !valueType.equals("java.io.InputStream")) {
-              // we have special handling for the Result Handler and context, it is also assumed that
-              //an inputsteam parameter occurs when application/octet is declared in the raml
-              //in which case the content will be streamed to he function
-              String bodyContent = body == null ? null : body.toString();
-              withRequestId(rc, () -> log.debug(rc.request().path() + " -------- bodyContent -------- " + bodyContent));
-              if(bodyContent != null){
-                if("java.io.Reader".equals(valueType)){
-                  paramArray[order] = new StringReader(bodyContent);
-                }
-                else if ("java.lang.String".equals(valueType)) {
-                  paramArray[order] = bodyContent;
-                }
-                else if(bodyContent.length() > 0) {
-                  try {
-                    paramArray[order] = MAPPER.readValue(bodyContent, entityClazz);
-                  } catch (UnrecognizedPropertyException e) {
-                    withRequestId(rc, () -> log.error(e.getMessage(), e));
-                    endRequestWithError(rc, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), true, JsonUtils.entity2String(
-                      ValidationHelper.createValidationErrorMessage("", "", e.getMessage())) , validRequest);
-                    return;
-                  }
-                }
-              }
-
-              Errors errorResp = new Errors();
-
-              //is this request only to validate a field value and not an actual
-              //request for additional processing
-              List<String> field2validate = request.params().getAll("validate_field");
-              Object[] resp = isValidRequest(rc, paramArray[order], errorResp, validRequest, field2validate, entityClazz);
-              boolean isValid = (boolean) resp[0];
-              paramArray[order] = resp[1];
-
-              if (!isValid) {
-                endRequestWithError(rc, HttpStatus.HTTP_UNPROCESSABLE_ENTITY.toInt(), true,
-                    JsonUtils.entity2String(errorResp), validRequest);
-                return;
-              }
-              if (!field2validate.isEmpty()) {
-                //valid request for the field to validate request made
-                AsyncResponseResult arr = new AsyncResponseResult();
-                ResponseImpl ri = new ResponseImpl();
-                ri.setStatus(200);
-                arr.setResult(ri);
-                //right now this is the only flag available to stop
-                //any additional respones for this request. to fix
-                validRequest[0] = false;
-                sendResponse(rc, arr, 0, null);
-                return;
-              }
-              MetadataUtil.populateMetadata(paramArray[order], okapiHeaders);
-            }
-          } catch (Exception e) {
-            withRequestId(rc, () -> log.error(e.getMessage(), e));
-            endRequestWithError(rc, 400, true, "Json content error " + e.getMessage(), validRequest);
-
-          }
-        } else if (AnnotationGrabber.HEADER_PARAM.equals(paramType)) {
-          // handle header params - read the header field from the
-          // header (valueName) and get its value
-          String value = request.getHeader(valueName);
-          // set the value passed from the header as a param to the function
-          paramArray[order] = value;
-        } else if (AnnotationGrabber.PATH_PARAM.equals(paramType)) {
-          // these are placeholder values in the path - for example
-          // /patrons/{patronid} - this would be the patronid value
-          paramArray[order] = pathParams[pathParamsIndex[0]++];
-        } else if (AnnotationGrabber.QUERY_PARAM.equals(paramType)) {
-          String param = queryParams.get(valueName);
-          // support date, enum, numbers or strings as query parameters
-          try {
-            if (valueType.equals("java.lang.String")) {
-              // regular string param in query string - just push value
-              if (param == null && defaultVal != null) {
-                // no value passed - check if there is a default value
-                paramArray[order] = defaultVal;
-              } else {
-                paramArray[order] = param;
-              }
-            } else if (valueType.equals("java.util.Date")) {
-              // regular string param in query string - just push value
-              if (param == null) {
-                // no value passed - check if there is a default value
-                paramArray[order] = defaultVal;
-              } else {
-                paramArray[order] = DateUtils.parseDate(param, DATE_PATTERNS);
-              }
-            } else if (valueType.equals("int") || valueType.equals("java.lang.Integer")) {
-              // cant pass null to an int type
-              if (param == null) {
-                if (defaultVal != null) {
-                  paramArray[order] = Integer.valueOf((String) defaultVal);
-                } else {
-                  paramArray[order] = valueType.equals("int") ? 0 : null;
-                }
-              }
-              else if("".equals(param)) {
-                emptyNumericParam = true;
-              }
-              else {
-                paramArray[order] = Integer.valueOf(param);
-              }
-            } else if (valueType.equals("boolean") || valueType.equals("java.lang.Boolean")) {
-              if (param == null) {
-                if (defaultVal != null) {
-                  paramArray[order] = Boolean.valueOf((String)defaultVal);
-                }
-              } else {
-                paramArray[order] = Boolean.valueOf(param);
-              }
-            } else if (valueType.contains("List")) {
-              List<String> vals = queryParams.getAll(valueName);
-              if (vals == null) {
-                paramArray[order] = null;
-              }
-              else {
-                paramArray[order] = vals;
-              }
-            } else if (valueType.equals("java.math.BigDecimal") || valueType.equals("java.lang.Number")) {
-              if (param == null) {
-                if (defaultVal != null) {
-                  paramArray[order] = new BigDecimal((String) defaultVal);
-                } else {
-                  paramArray[order] = null;
-                }
-              }
-              else if ("".equals(param)) {
-                emptyNumericParam = true;
-              }
-              else {
-                paramArray[order] = new BigDecimal(param.replaceAll(",", "")); // big decimal can contain ","
-              }
-            } else { // enum object type
-              try {
-                paramArray[order] = parseEnum(valueType, param, defaultVal);
-              } catch (Exception ee) {
-                withRequestId(rc, () -> log.error(ee.getMessage(), ee));
-                endRequestWithError(rc, 400, true, ee.getMessage(), validRequest);
-              }
-            }
-            if(emptyNumericParam){
-              endRequestWithError(rc, 400, true, valueName + " does not have a default value in the RAML and has been passed empty",
-                validRequest);
-            }
-          } catch (Exception e) {
-            withRequestId(rc, () -> log.error(e.getMessage(), e));
-            endRequestWithError(rc, 400, true, e.getMessage(), validRequest);
-          }
-        }
-      }
-    });
-  }
-
-  /**
-   * @return the enum value of type valueType where value.name equals param (fall-back: equals defaultValue).
-   *         Return null if the type neither has param nor defaultValue.
-   * @throws ClassNotFoundException if valueType does not exist
-   */
-  @SuppressWarnings({
-    "squid:S1523",  // Suppress warning "Make sure that this dynamic injection or execution of code is safe."
-                    // This is safe because we accept an enum class only, and do not invoke any method.
-    "squid:S3011"}) // Suppress "Make sure that this accessibility update is safe here."
-                    // This is safe because we only read the field and it is a field of an enum.
-  static Object parseEnum(String valueType, String param, Object defaultValue)
-      throws ReflectiveOperationException {
-
-    Class<?> enumClass = Class.forName(valueType);
-    if (! enumClass.isEnum()) {
-      return null;
-    }
-    String defaultString = null;
-    if (defaultValue != null) {
-      defaultString = defaultValue.toString();
-    }
-    Object defaultEnum = null;
-    for (Object anEnum : enumClass.getEnumConstants()) {
-      Field nameField = anEnum.getClass().getDeclaredField("name");
-      nameField.setAccessible(true);  // access to private field
-      String enumName = nameField.get(anEnum).toString();
-      if (enumName.equals(param)) {
-        return anEnum;
-      }
-      if (enumName.equals(defaultString)) {
-        defaultEnum = anEnum;
-        if (param == null) {
-          return defaultEnum;
-        }
-      }
-    }
-    return defaultEnum;
-  }
-
-  /**
-   * return whether the request is valid [0] and a cleaned up version of the object [1]
-   * @param rc
-   * @param content
-   * @param errorResp
-   * @param validRequest
-   * @param singleField
-   * @param entityClazz
-   * @return
-   */
-  private Object[] isValidRequest(RoutingContext rc, Object content, Errors errorResp, boolean[] validRequest, List<String> singleField, Class<?> entityClazz) {
-    Set<? extends ConstraintViolation<?>> validationErrors = validationFactory.getValidator().validate(content);
-    boolean ret = true;
-    if (validationErrors.size() > 0) {
-      //StringBuffer sb = new StringBuffer();
-
-      for (ConstraintViolation<?> cv : validationErrors) {
-
-        if("must be null".equals(cv.getMessage())){
-          /**
-           * read only fields are marked with a 'must be null' annotation @null
-           * so the client should not pass them in, if they were passed in, remove them here
-           * so that they do not reach the implementing function
-           */
-          try {
-            if(!(content instanceof JsonObject)){
-              content = JsonObject.mapFrom(content);
-            }
-            ((JsonObject)content).remove(cv.getPropertyPath().toString());
-            continue;
-          } catch (Exception e) {
-            withRequestId(rc, () -> log.warn("Failed to remove " + cv.getPropertyPath().toString()
-                + " field from body when calling " + rc.request().absoluteURI(), e));
-          }
-        }
-        Error error = new Error();
-        Parameter p = new Parameter();
-        String field = cv.getPropertyPath().toString();
-        p.setKey(field);
-        Object val = cv.getInvalidValue();
-        if(val == null){
-          p.setValue("null");
-        }
-        else{
-          p.setValue(val.toString());
-
-        }
-        error.getParameters().add(p);
-        error.setMessage(cv.getMessage());
-        error.setCode("-1");
-        error.setType(DomainModelConsts.VALIDATION_FIELD_ERROR);
-        //return the error if the validation is requested on a specific field
-        //and that field fails validation. if another field fails validation
-        //that is ok as validation on that specific field wasnt requested
-        //or there are validation errors and this is not a per field validation request
-        if (singleField != null && (singleField.contains(field) || singleField.isEmpty())) {
-          errorResp.getErrors().add(error);
-          ret = false;
-        }
-        //sb.append("\n" + cv.getPropertyPath() + "  " + cv.getMessage() + ",");
-      }
-      if(content instanceof JsonObject){
-        //we have sanitized the passed in object by removing read-only fields
-        try {
-          content = MAPPER.readValue(((JsonObject)content).encode(), entityClazz);
-        } catch (IOException e) {
-          withRequestId(rc, () -> log.error(
-              "Failed to serialize body content after removing read-only fields when calling "
-                  + rc.request().absoluteURI(), e));
-        }
-      }
-    }
-
-    return new Object[]{Boolean.valueOf(ret), content};
-  }
-
-  /**
-   * Run logCommand with request id. Take request id value from headers in routingContext
-   * and temporarily store it as reqId in ThreadContext. Run logCommand without reqId
-   * if request id value is <code>null</code>.
-   */
-  private static void withRequestId(RoutingContext routingContext, Runnable logCommand) {
-    if (routingContext == null) {
-      logCommand.run();
-      return;
-    }
-    String requestId = routingContext.request().headers().get(RestVerticle.OKAPI_REQUESTID_HEADER);
-    if (requestId == null) {
-      logCommand.run();
-      return;
-    }
-    ThreadContext.put("reqId", "reqId=" + requestId);
-    logCommand.run();
-    // Multiple vertx async requests use the same thread therefore we must delete reqId afterwards.
-    // For a better implementation see
-    // https://issues.folio.org/browse/RMB-669 "Add default metrics to RMB: incoming API calls"
-    ThreadContext.remove("reqId");
-  }
-
-  class StreamStatus {
-
-    private int status = -1;
-
-    public int getStatus() {
-      return status;
-    }
-    public void setStatus(int status) {
-      this.status = status;
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -2,7 +2,6 @@ package org.folio.rest;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -28,8 +27,6 @@ import org.apache.logging.log4j.Logger;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.resource.DomainModelConsts;
 import org.folio.rest.tools.client.test.HttpClientMock2;
-import org.folio.rest.tools.messages.MessageConsts;
-import org.folio.rest.tools.messages.Messages;
 import org.folio.rest.tools.utils.InterfaceToImpl;
 import org.folio.rest.tools.utils.LogUtil;
 
@@ -50,7 +47,6 @@ public class RestVerticle extends AbstractVerticle {
   private static String             className                       = RestVerticle.class.getName();
   private static final Logger       log                             = LogManager.getLogger(RestVerticle.class);
   private static String             deploymentId                     = "";
-  private final Messages            messages                        = Messages.getInstance();
 
   @Override
   public void start(Promise<Void> startPromise) throws Exception {

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -160,6 +160,44 @@ public class DemoRamlRestTest {
   }
 
   @Test
+  public void getEmptyRating(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&rating=", 400);
+  }
+
+  // produces error, but shouldn't as there is a default value (an old error)
+  @Test
+  public void getEmptyScore(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&score=", 400);
+  }
+
+  @Test
+  public void getEmptyEdition(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&edition=", 400);
+  }
+
+  // note that isbn is size 15, 20 in /domain-models-maven-plugin/src/main/resources/overrides/raml_overrides.json
+  @Test
+  public void getWithIsbnS10(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&rating=1.2&isbn=1234567890", 400);
+  }
+
+  @Test
+  public void getWithIsbnS15(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&rating=1.2&isbn=123456789012345", 200);
+  }
+
+  @Test
+  public void getWithAvailableFalse(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&rating=1.2&available=false", 200);
+  }
+
+  // Boolean.valueOf turns any value to false , except "true" (ignoring case)
+  @Test
+  public void getWithAvailableBadValue(TestContext context) {
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/books?publicationDate=1900-01-01&author=me&rating=1.2&available=xx", 200);
+  }
+
+  @Test
   public void history(TestContext context) {
     checkURLs(context, "http://localhost:" + port + "/admin/memory?history=true", 200, "text/html");
   }

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -163,7 +163,7 @@ public class DemoRamlRestTest {
 
   @Test
   public void wrongPath(TestContext context) {
-    checkURLs(context, "http://localhost:" + port + "/rmbtests/x/books", 400); // should be 404
+    checkURLs(context, "http://localhost:" + port + "/rmbtests/x/books", 404);
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.collection.ArrayMatching.arrayContaining;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+import org.folio.rest.testing.UtilityClassTester;
 import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.junit.jupiter.api.Test;
 import io.vertx.core.Future;
@@ -15,6 +16,11 @@ import javax.ws.rs.core.Response;
 import java.util.regex.Pattern;
 
 public class RestRoutingTest {
+  @Test
+  public void utilityClass() {
+    UtilityClassTester.assertUtilityClass(RestRouting.class);
+  }
+
   Object parseEnum(String value, String defaultValue) throws Exception {
     return RestRouting.parseEnum(
         "org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit",

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
@@ -1,0 +1,78 @@
+package org.folio.rest;
+
+import static org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.collection.ArrayMatching.arrayContaining;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
+import org.folio.rest.tools.client.exceptions.ResponseException;
+import org.junit.jupiter.api.Test;
+import io.vertx.core.Future;
+import javax.ws.rs.core.Response;
+import java.util.regex.Pattern;
+
+public class RestRoutingTest {
+  Object parseEnum(String value, String defaultValue) throws Exception {
+    return RestRouting.parseEnum(
+        "org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit",
+        value, defaultValue);
+  }
+
+  @Test
+  void parseEnum() throws Exception {
+    assertThat(parseEnum(null,           null  ), is(nullValue()));
+    assertThat(parseEnum("",             ""    ), is(nullValue()));
+    assertThat(parseEnum("day",          "hour"), is(DAY));
+    assertThat(parseEnum("hour",         "day" ), is(HOUR));
+    assertThat(parseEnum("foo",          "day" ), is(DAY));
+    assertThat(parseEnum(null,           "day" ), is(DAY));
+    assertThat(parseEnum("foo",          "hour"), is(HOUR));
+    assertThat(parseEnum(null,           "hour"), is(HOUR));
+    assertThat(parseEnum("bee interval", ""    ), is(BEEINTERVAL));
+  }
+
+  @Test
+  void parseEnumUnknownType() {
+    assertThrows(ClassNotFoundException.class, () -> RestRouting.parseEnum("foo.bar", "foo", "bar"));
+  }
+
+  @Test
+  void parseEnumNonEnumClass() throws Exception {
+    assertThat(RestRouting.parseEnum("java.util.Vector", "foo", "bar"), is(nullValue()));
+  }
+
+  @Test
+  void getResponseSucceeded() {
+    Response response = ResponseDelegate.status(234).build();
+    assertThat(RestRouting.getResponse(Future.succeededFuture(response)).getStatus(), is(234));
+  }
+
+  @Test
+  void getResponseFailed() {
+    Response response = ResponseDelegate.status(456).build();
+    assertThat(RestRouting.getResponse(Future.failedFuture(new ResponseException(response))).getStatus(), is(456));
+  }
+
+  @Test
+  void getResponseFailedWithoutResponse() {
+    assertThat(RestRouting.getResponse(Future.failedFuture("foo")), is(nullValue()));
+  }
+
+  @Test
+  void matchUrl() {
+    assertThat(RestRouting.matchPath("/", Pattern.compile("^/x$")), is(nullValue()));
+    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/$")), is(nullValue()));
+    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/y$")), is(nullValue()));
+    assertThat(RestRouting.matchPath("/", Pattern.compile("^/$")), is(emptyArray()));
+    assertThat(RestRouting.matchPath("/x/yy", Pattern.compile("^/x/yy$")), is(emptyArray()));
+    assertThat(RestRouting.matchPath("/x/yy", Pattern.compile("^/x/([^/]+)$")),
+        is(arrayContaining("yy")));
+    assertThat(RestRouting.matchPath("/abc/def/ghi", Pattern.compile("^/([^/]+)/([^/]+)/([^/]+)$")),
+        is(arrayContaining("abc", "def", "ghi")));
+    assertThat(RestRouting.matchPath("/%2F%3F%2B%23/12%2334", Pattern.compile("^/([^/]+)/([^/]+)$")),
+        is(arrayContaining("/?+#", "12#34")));
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestRoutingTest.java
@@ -63,9 +63,9 @@ public class RestRoutingTest {
 
   @Test
   void matchUrl() {
-    assertThat(RestRouting.matchPath("/", Pattern.compile("^/x$")), is(nullValue()));
-    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/$")), is(nullValue()));
-    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/y$")), is(nullValue()));
+    assertThat(RestRouting.matchPath("/", Pattern.compile("^/x$")), is(emptyArray()));
+    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/$")), is(emptyArray()));
+    assertThat(RestRouting.matchPath("/x", Pattern.compile("^/y$")), is(emptyArray()));
     assertThat(RestRouting.matchPath("/", Pattern.compile("^/$")), is(emptyArray()));
     assertThat(RestRouting.matchPath("/x/yy", Pattern.compile("^/x/yy$")), is(emptyArray()));
     assertThat(RestRouting.matchPath("/x/yy", Pattern.compile("^/x/([^/]+)$")),

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1,94 +1,12 @@
 package org.folio.rest;
 
-import static org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit.*;
-import static org.hamcrest.collection.ArrayMatching.arrayContaining;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import java.util.regex.Pattern;
-import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
-import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.junit.jupiter.api.Test;
-import io.vertx.core.Future;
-import io.vertx.ext.web.RoutingContext;
-import javax.ws.rs.core.Response;
 
 class RestVerticleTest {
-
-  Object parseEnum(String value, String defaultValue) throws Exception {
-    return RestVerticle.parseEnum(
-          "org.folio.rest.jaxrs.model.CalendarPeriodsServicePointIdCalculateopeningGetUnit",
-          value, defaultValue);
-  }
-
   @Test
-  void parseEnum() throws Exception {
-    assertThat(parseEnum(null,           null  ), is(nullValue()));
-    assertThat(parseEnum("",             ""    ), is(nullValue()));
-    assertThat(parseEnum("day",          "hour"), is(DAY));
-    assertThat(parseEnum("hour",         "day" ), is(HOUR));
-    assertThat(parseEnum("foo",          "day" ), is(DAY));
-    assertThat(parseEnum(null,           "day" ), is(DAY));
-    assertThat(parseEnum("foo",          "hour"), is(HOUR));
-    assertThat(parseEnum(null,           "hour"), is(HOUR));
-    assertThat(parseEnum("bee interval", ""    ), is(BEEINTERVAL));
-  }
-
-  @Test
-  void parseEnumUnknownType() {
-    assertThrows(ClassNotFoundException.class, () -> RestVerticle.parseEnum("foo.bar", "foo", "bar"));
-  }
-
-  @Test
-  void parseEnumNonEnumClass() throws Exception {
-    assertThat(RestVerticle.parseEnum("java.util.Vector", "foo", "bar"), is(nullValue()));
-  }
-
-  @Test
-  void routeExceptionReturns500() {
-    class MyRestVerticle extends RestVerticle {
-      public int status = -1;
-      @Override
-      void endRequestWithError(RoutingContext rc, int status, boolean chunked, String message, boolean[] isValid) {
-        this.status = status;
-      }
-    };
-    MyRestVerticle myRestVerticle = new MyRestVerticle();
-    myRestVerticle.route(null, null, null, null);
-    assertThat(myRestVerticle.status, is(500));
-  }
-
-  @Test
-  void matchUrl() {
-    assertThat(RestVerticle.matchPath("/", Pattern.compile("^/x$")), is(nullValue()));
-    assertThat(RestVerticle.matchPath("/x", Pattern.compile("^/$")), is(nullValue()));
-    assertThat(RestVerticle.matchPath("/x", Pattern.compile("^/y$")), is(nullValue()));
-    assertThat(RestVerticle.matchPath("/", Pattern.compile("^/$")), is(emptyArray()));
-    assertThat(RestVerticle.matchPath("/x/yy", Pattern.compile("^/x/yy$")), is(emptyArray()));
-    assertThat(RestVerticle.matchPath("/x/yy", Pattern.compile("^/x/([^/]+)$")),
-        is(arrayContaining("yy")));
-    assertThat(RestVerticle.matchPath("/abc/def/ghi", Pattern.compile("^/([^/]+)/([^/]+)/([^/]+)$")),
-        is(arrayContaining("abc", "def", "ghi")));
-    assertThat(RestVerticle.matchPath("/%2F%3F%2B%23/12%2334", Pattern.compile("^/([^/]+)/([^/]+)$")),
-        is(arrayContaining("/?+#", "12#34")));
-  }
-
-  @Test
-  void getResponseSucceeded() {
-    Response response = ResponseDelegate.status(234).build();
-    assertThat(RestVerticle.getResponse(Future.succeededFuture(response)).getStatus(), is(234));
-  }
-
-  @Test
-  void getResponseFailed() {
-    Response response = ResponseDelegate.status(456).build();
-    assertThat(RestVerticle.getResponse(Future.failedFuture(new ResponseException(response))).getStatus(), is(456));
-  }
-
-  @Test
-  void getResponseFailedWithoutResponse() {
-    assertThat(RestVerticle.getResponse(Future.failedFuture("foo")), is(nullValue()));
+  void getDeploymentId() {
+    assertThat(RestVerticle.getDeploymentId(), is(""));
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -1,12 +1,116 @@
 package org.folio.rest;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import org.junit.jupiter.api.Test;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.resource.interfaces.InitAPI;
+import org.folio.rest.resource.interfaces.PostDeployVerticle;
+import org.folio.rest.resource.interfaces.ShutdownAPI;
+import org.folio.rest.tools.utils.NetworkUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-class RestVerticleTest {
-  @Test
-  void getDeploymentId() {
-    assertThat(RestVerticle.getDeploymentId(), is(""));
+@RunWith(VertxUnitRunner.class)
+public class RestVerticleTest implements InitAPI, PostDeployVerticle, ShutdownAPI {
+  private static final Logger LOGGER = LogManager.getLogger(RestVerticleTest.class);
+
+  private static Vertx vertx;
+  private static int port;
+  private static Boolean initResult = null;
+  private static int initCalls;
+  private static int shutdownCalls;
+
+  @BeforeClass
+  public static void setUp(TestContext context) {
+    vertx = Vertx.vertx();
+    port = NetworkUtils.nextFreePort();
   }
+
+  @AfterClass
+  public static void afterClass(TestContext context) {
+    vertx.close(context.asyncAssertSuccess());
+  }
+
+  @Override
+  public void init(Vertx vertx, Context context, Handler<AsyncResult<Boolean>> resultHandler) {
+    LOGGER.info("Init handler called");
+    initCalls++;
+    if (initResult == null) {
+      throw new RuntimeException("init exception");
+    } else if (initResult == false) {
+      resultHandler.handle(Future.failedFuture("init failed"));
+    } else {
+      resultHandler.handle(Future.succeededFuture(initResult));
+    }
+  }
+
+  @Override
+  public void shutdown(Vertx vertx, Context context, Handler<AsyncResult<Void>> handler) {
+    LOGGER.info("shutdown handler called");
+    shutdownCalls++;
+    handler.handle(Future.succeededFuture());
+  }
+
+  @Test
+  public void initHookTrue(TestContext context) {
+    shutdownCalls = 0;
+    initCalls = 0;
+    initResult = true;
+    JsonObject config = new JsonObject();
+    config.put("packageOfImplementations", "org.folio.rest");
+    config.put("http.port", port);
+    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+        .onComplete(context.asyncAssertSuccess(res -> {
+          context.assertEquals(2, initCalls);
+          context.assertEquals(0, shutdownCalls);
+          vertx.undeploy(res).onComplete(context.asyncAssertSuccess(x -> {
+            context.assertEquals(2, initCalls);
+            context.assertEquals(1, shutdownCalls);
+          }));
+        }));
+  }
+
+  @Test
+  public void initHookFail(TestContext context) {
+    shutdownCalls = 0;
+    initCalls = 0;
+    initResult = false;
+    JsonObject config = new JsonObject();
+    config.put("packageOfImplementations", "org.folio.rest");
+    config.put("http.port", port);
+    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+        .onComplete(context.asyncAssertFailure(cause -> {
+          context.assertEquals("init failed", cause.getMessage());
+          context.assertEquals(1, initCalls);
+          context.assertEquals(0, shutdownCalls);
+        }));
+  }
+
+  @Test
+  public void initHookException(TestContext context) {
+    shutdownCalls = 0;
+    initCalls = 0;
+    initResult = null;
+    JsonObject config = new JsonObject();
+    config.put("packageOfImplementations", "org.folio.rest");
+    config.put("http.port", port);
+    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+        .onComplete(context.asyncAssertFailure(cause -> {
+          context.assertNull(cause.getMessage());
+          context.assertEquals(1, initCalls);
+          context.assertEquals(0, shutdownCalls);
+        }));
+  }
+
+
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/RestVerticleTest.java
@@ -54,6 +54,15 @@ public class RestVerticleTest implements InitAPI, PostDeployVerticle, ShutdownAP
     }
   }
 
+  Future<String> deploy() {
+    shutdownCalls = 0;
+    initCalls = 0;
+    JsonObject config = new JsonObject();
+    config.put("packageOfImplementations", "org.folio.rest");
+    config.put("http.port", port);
+    return vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config));
+  }
+
   @Override
   public void shutdown(Vertx vertx, Context context, Handler<AsyncResult<Void>> handler) {
     LOGGER.info("shutdown handler called");
@@ -63,13 +72,8 @@ public class RestVerticleTest implements InitAPI, PostDeployVerticle, ShutdownAP
 
   @Test
   public void initHookTrue(TestContext context) {
-    shutdownCalls = 0;
-    initCalls = 0;
     initResult = true;
-    JsonObject config = new JsonObject();
-    config.put("packageOfImplementations", "org.folio.rest");
-    config.put("http.port", port);
-    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+    deploy()
         .onComplete(context.asyncAssertSuccess(res -> {
           context.assertEquals(2, initCalls);
           context.assertEquals(0, shutdownCalls);
@@ -82,13 +86,9 @@ public class RestVerticleTest implements InitAPI, PostDeployVerticle, ShutdownAP
 
   @Test
   public void initHookFail(TestContext context) {
-    shutdownCalls = 0;
-    initCalls = 0;
     initResult = false;
     JsonObject config = new JsonObject();
-    config.put("packageOfImplementations", "org.folio.rest");
-    config.put("http.port", port);
-    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+    deploy()
         .onComplete(context.asyncAssertFailure(cause -> {
           context.assertEquals("init failed", cause.getMessage());
           context.assertEquals(1, initCalls);
@@ -98,13 +98,8 @@ public class RestVerticleTest implements InitAPI, PostDeployVerticle, ShutdownAP
 
   @Test
   public void initHookException(TestContext context) {
-    shutdownCalls = 0;
-    initCalls = 0;
     initResult = null;
-    JsonObject config = new JsonObject();
-    config.put("packageOfImplementations", "org.folio.rest");
-    config.put("http.port", port);
-    vertx.deployVerticle(RestVerticle.class, new DeploymentOptions().setConfig(config))
+    deploy()
         .onComplete(context.asyncAssertFailure(cause -> {
           context.assertNull(cause.getMessage());
           context.assertEquals(1, initCalls);

--- a/domain-models-runtime/src/test/java/org/folio/rest/client/RmbtestsClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/client/RmbtestsClientTest.java
@@ -40,7 +40,7 @@ class RmbtestsClientTest {
     })).listen(8888, server -> {
       Date date = new Date(24 * 60 * 60 * 1000);  // 1 day (in milliseconds) after 1970-01-01T00:00:00
       new RmbtestsClient("http://localhost:8888", "test_tenant", "token")
-          .getRmbtestsBooks("author", date, 1, 1, "isbn", null, response -> {});
+          .getRmbtestsBooks("author", date,  0,1, 1, "isbn", false, null, response -> {});
     });
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
@@ -72,14 +72,14 @@ public class BooksDemoAPI implements Rmbtests {
     switch (query == null ? "null" : query) {
       case "badclass=true":
         PgUtil.streamGet(TABLE, /* can not be deserialized */ StringBuilder.class,
-          null, 0, 10, new LinkedList<String>(), "books", routingContext, okapiHeaders, vertxContext);
+          null, 0, 10, new LinkedList<>(), "books", routingContext, okapiHeaders, vertxContext);
         break;
       case "nullpointer=true":
         PgUtil.streamGet(TABLE, Book.class, null, 0, 10, null, "books",
           routingContext, /* okapiHeaders is null which results in exception */ null, vertxContext);
         break;
       case "slim=true":
-        PgUtil.streamGet(TABLE, SlimBook.class, null, 0, 10, new LinkedList<String>(), "books",
+        PgUtil.streamGet(TABLE, SlimBook.class, null, 0, 10, new LinkedList<>(), "books",
           routingContext, okapiHeaders, vertxContext);
         break;
       case "wrapper=true":
@@ -91,7 +91,7 @@ public class BooksDemoAPI implements Rmbtests {
         }
         break;
       default:
-        PgUtil.streamGet(TABLE, Book.class, query, 0, 10, new LinkedList<String>(), "books",
+        PgUtil.streamGet(TABLE, Book.class, query, 0, 10, new LinkedList<>(), "books",
           routingContext, okapiHeaders, vertxContext);
     }
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/BooksDemoAPI.java
@@ -35,8 +35,8 @@ public class BooksDemoAPI implements Rmbtests {
    */
   @Validate
   @Override
-  public void getRmbtestsBooks(String author, Date publicationDate, Number rating, int edition, String isbn,
-      List<String> facets, Map<String, String> okapiHeaders,
+  public void getRmbtestsBooks(String author, Date publicationDate, Number score, Number rating, int edition, String isbn,
+      boolean available, List<String> facets, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     asyncResultHandler.handle(Future.succeededFuture(GetRmbtestsBooksResponse.respond200WithApplicationJson(new


### PR DESCRIPTION
Big refactor; all user requests handled in static class RestRouting.
Use Vert.x route for each of the routes offered, instead of
one big fat route function that does everything (slow and big).
This has been tested with mod-inventory-storage and all tests pass.
RMB returns 404 on path/method not found (actually this is thrown by Vert.x
itself now that only supported routes are registered).