### PR TITLE
Netty 4.1.59.Final (CVE-2021-21290)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,16 @@
         <artifactId>guava</artifactId>
         <version>30.0-jre</version>
       </dependency>
+      <!-- https://nvd.nist.gov/vuln/detail/CVE-2021-21290
+           https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2
+      -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>4.1.59.Final</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>


### PR DESCRIPTION
Update Netty version, fixing
Local Information Disclosure Vulnerability in Netty on Unix-Like systems due temporary files.

https://nvd.nist.gov/vuln/detail/CVE-2021-21290
https://github.com/netty/netty/security/advisories/GHSA-5mcr-gq6c-3hq2