### PR TITLE
Flapdoodle 2.1.2, Commons-compress 1.18, fixing ReDoS

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -128,7 +128,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.process</artifactId>
-      <version>2.0.5</version>
+      <version>2.1.2</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>


### PR DESCRIPTION
de.flapdoodle.embed.process:2.0.5 dependes on vulnerable
org.apache.commons:commons-compress:1.10 that allows a
Denial of Service (DoS) attack when reading a
specially crafted ZIP archive.

Flapdoodle 2.1.2 depends on the fixed Commons-compress 1.18.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11771
https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-32473