### PR TITLE
Fix HttpClientFactory mock can never be unset RMB-811

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
@@ -8,53 +8,47 @@ import org.folio.rest.tools.client.test.HttpClientMock2;
  *
  */
 public class HttpClientFactory {
-
-
-  private static boolean mock = false;
-
-  static {
-    if(System.getProperty(HttpClientMock2.MOCK_MODE) != null ){
-      mock = true;
-    }
+  private static boolean isMock() {
+    return System.getProperty(HttpClientMock2.MOCK_MODE) != null;
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId, boolean keepAlive, int connTO,
       int idleTO, boolean autoCloseConnections, long cacheTO) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId, keepAlive, connTO, idleTO, autoCloseConnections, cacheTO);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId, keepAlive, connTO, idleTO, autoCloseConnections, cacheTO);
     }
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId);
     }
   }
 
   public static HttpClientInterface getHttpClient(String absHost, String tenantId) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(absHost,tenantId);
-    }else{
+    } else {
       return new HttpModuleClient2(absHost, tenantId);
     }
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId, boolean autoCloseConnections) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId, autoCloseConnections);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId, autoCloseConnections);
     }
   }
 
   public static HttpClientInterface getHttpClient(String absHost, String tenantId, boolean autoCloseConnections) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(absHost, tenantId, autoCloseConnections);
-    }else{
+    } else {
       return new HttpModuleClient2(absHost, tenantId, autoCloseConnections);
     }
   }


### PR DESCRIPTION
Not per Verticle yet, but at least the property is honored.