### PR TITLE
Fix HttpClientFactory mock can never be unset RMB-811

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -109,12 +109,6 @@ public class RestVerticle extends AbstractVerticle {
             log.error(e.getMessage(), e);
             return Future.failedFuture(e);
           }
-          //check if mock mode requested and set sys param so that http client factory
-          //can config itself accordingly
-          String mockMode = config().getString(HttpClientMock2.MOCK_MODE);
-          if (mockMode != null) {
-            System.setProperty(HttpClientMock2.MOCK_MODE, mockMode);
-          }
           runPostDeployHook(res2 -> {
             if (!res2.succeeded()) {
               log.error(res2.cause().getMessage(), res2.cause());

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
@@ -1,5 +1,6 @@
 package org.folio.rest.tools.client;
 
+import io.vertx.core.Vertx;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 
@@ -9,52 +10,47 @@ import org.folio.rest.tools.client.test.HttpClientMock2;
  */
 public class HttpClientFactory {
 
-
-  private static boolean mock = false;
-
-  static {
-    if(System.getProperty(HttpClientMock2.MOCK_MODE) != null ){
-      mock = true;
-    }
+  static boolean isMock() {
+    return Vertx.currentContext().config().containsKey(HttpClientMock2.MOCK_MODE);
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId, boolean keepAlive, int connTO,
       int idleTO, boolean autoCloseConnections, long cacheTO) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId, keepAlive, connTO, idleTO, autoCloseConnections, cacheTO);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId, keepAlive, connTO, idleTO, autoCloseConnections, cacheTO);
     }
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId);
     }
   }
 
   public static HttpClientInterface getHttpClient(String absHost, String tenantId) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(absHost,tenantId);
-    }else{
+    } else {
       return new HttpModuleClient2(absHost, tenantId);
     }
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId, boolean autoCloseConnections) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(host, port, tenantId, autoCloseConnections);
-    }else{
+    } else {
       return new HttpModuleClient2(host, port, tenantId, autoCloseConnections);
     }
   }
 
   public static HttpClientInterface getHttpClient(String absHost, String tenantId, boolean autoCloseConnections) {
-    if(mock){
+    if (isMock()) {
       return new HttpClientMock2(absHost, tenantId, autoCloseConnections);
-    }else{
+    } else {
       return new HttpModuleClient2(absHost, tenantId, autoCloseConnections);
     }
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/HTTPMockTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/HTTPMockTest.java
@@ -1,48 +1,65 @@
 package org.folio.rest.tools.utils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.CompletableFuture;
-
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-import org.junit.After;
-import org.junit.Before;
+import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.junit.Test;
-
+import org.junit.runner.RunWith;
 
 /**
  * @author shale
  *
  */
+@RunWith(VertxUnitRunner.class)
 public class HTTPMockTest {
 
-  @Before
-  public void setUp() throws Exception {
-    System.setProperty("mock.httpclient", "true");
-    System.out.println(System.getProperty("mock.httpclient"));
-  }
-
-  @After
-  public void tearDown() throws Exception {
+  @Test
+  public void testWithMock(TestContext context) {
+    int port = NetworkUtils.nextFreePort(); // most certainly a failure if mock was not in use
+    Vertx vertx = Vertx.vertx();
+    Async async = context.async();
+    vertx.runOnContext(x -> {
+      Vertx.currentContext().config().put(HttpClientMock2.MOCK_MODE, "foo");
+      HttpClientInterface client = HttpClientFactory.getHttpClient("localhost", port, "zxc");
+      try {
+        CompletableFuture<Response> cf = client.request("auth_test2");
+        Response response = cf.get(1, TimeUnit.MILLISECONDS);
+        context.assertEquals("1", response.getBody().getString("id"));
+      } catch (Exception e) {
+        context.fail(e);
+      }
+      async.complete();
+    });
+    async.await();
+    vertx.close(context.asyncAssertSuccess());
   }
 
   @Test
-  public void test() {
-    HttpClientInterface client = HttpClientFactory.getHttpClient("localhost", 8080, "zxc");
-    try {
-      CompletableFuture<Response> cf = client.request("auth_test2");
-      System.out.println("-------------------------------------->"+cf.get().getBody());
-      assertEquals("1", cf.get().getBody().getString("id"));
-    } catch (Exception e) {
-      assertTrue(false);
-      e.printStackTrace();
-    }
-
+  public void testWithNoMock(TestContext context) {
+    int port = NetworkUtils.nextFreePort(); // no mock so we expect failure
+    Vertx vertx = Vertx.vertx();
+    Async async = context.async();
+    vertx.runOnContext(x -> {
+      HttpClientInterface client = HttpClientFactory.getHttpClient("localhost", port, "zxc");
+      Class<? extends Exception> aClass = null;
+      try {
+        CompletableFuture<Response> cf = client.request("auth_test2");
+        cf.get(1, TimeUnit.MILLISECONDS);
+      } catch (Exception e) {
+        aClass = e.getClass();
+      }
+      context.assertEquals(TimeoutException.class, aClass);
+      async.complete();
+    });
+    async.await();
+    vertx.close(context.asyncAssertSuccess());
   }
-
-
 
 }


### PR DESCRIPTION
Do not use a property for in-process communication. Instead rely
on Vertx context configuration.

Will improve test coverage if this way of doing it seems better.