### PR TITLE
RMB-812: Make PostgresClientStreamResult public

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientStreamResult.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientStreamResult.java
@@ -9,7 +9,7 @@ import org.folio.rest.jaxrs.model.ResultInfo;
  *
  * @param <T> each item returned in stream is of this type
  */
-class PostgresClientStreamResult<T> implements ReadStream<T> {
+public class PostgresClientStreamResult<T> implements ReadStream<T> {
 
   private final ResultInfo resultInfo;
 


### PR DESCRIPTION
PostgresClient.streamGet methods have this reply parameter:

Handler<AsyncResult<PostgresClientStreamResult<T>>> replyHandler

This can only been used from all packages if the visibility of PostgresClientStreamResult is changed from package-private to public.