### PR TITLE
FOLIO-2893 Use api-lint CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,9 @@
 buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
   buildNode =  'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'domain-models-api-interfaces/ramls'
 }


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop

https://dev.folio.org/guides/api-lint/