### PR TITLE
FOLIO-2898 Use api-doc CI facility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 
 buildMvn {
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
   buildNode =  'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'domain-models-api-interfaces/ramls'
 }


### PR DESCRIPTION
The doApiDoc facility replaces publishAPI

https://dev.folio.org/guides/api-doc/