### PR TITLE
Deprecate HttpClientInterface, HttpModuleClient2, HttpClientMock2 RMB…

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -21,6 +21,14 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 ## Version 33.0
 
+#### [RMB-717](https://issues.folio.org/browse/RMB-717) Deprecate HttpClientInterface, HttpModuleClient2, HttpClientMock2
+
+All classes in org.folio.rest.tools.client are deprecated. HTTP client
+functionality should use WebClient or HttpClient as factory of clients
+and combine with generated client(s) or use WebClient directly. Tests
+can create HTTP servers with Vertx.createHttpServer or use other mocking
+facility.
+
 #### [RMB-789](https://issues.folio.org/browse/RMB-789) Remove support of Embedded PostgreSQL Server
 
 Removed support for embedded Postgres for testing. Testing is now with

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -23,11 +23,10 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 #### [RMB-717](https://issues.folio.org/browse/RMB-717) Deprecate HttpClientInterface, HttpModuleClient2, HttpClientMock2
 
-All classes in org.folio.rest.tools.client are deprecated. HTTP client
-functionality should use WebClient or HttpClient as factory of clients
-and combine with generated client(s) or use WebClient directly. Tests
-can create HTTP servers with Vertx.createHttpServer or use other mocking
-facility.
+All classes in org.folio.rest.tools.client are deprecated. Instead
+use the generated client provided by RMB or use WebClient directly.
+Tests can create HTTP servers with Vertx.createHttpServer or use other
+mocking facility.
 
 #### [RMB-789](https://issues.folio.org/browse/RMB-789) Remove support of Embedded PostgreSQL Server
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
@@ -7,9 +7,10 @@ import org.folio.rest.tools.parser.JsonPathParser;
 import org.folio.util.StringUtil;
 
 /**
- * @author shale
- *
+ * Build CQL string by parsing response JSON
+ * @deprecated All material in org.folio.rest.tools.client is deprecated
  */
+@Deprecated
 public class BuildCQL {
 
   private Response r;

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HTTPJsonResponseHandler.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HTTPJsonResponseHandler.java
@@ -11,8 +11,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * @author shale
+ * HTTP JSON response handling.
+ * @deprecated All material in org.folio.rest.tools.client is deprecated
  */
+@Deprecated
 class HTTPJsonResponseHandler implements Handler<AsyncResult<HttpResponse<Buffer>>> {
 
   private static final Logger log = LogManager.getLogger(HTTPJsonResponseHandler.class);

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
@@ -4,9 +4,11 @@ import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 
 /**
- * @author shale
- *
+ * Factory of HTTP clients with interface {@link HttpClientInterface}
+ * @deprecated Use {@link io.vertx.ext.web.client.WebClient} for generic HTTP client or generated client and
+ * mock server with {@link io.vertx.core.Vertx#createHttpServer()} or use a mocking utility.
  */
+@Deprecated
 public class HttpClientFactory {
 
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient2.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient2.java
@@ -36,9 +36,10 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
 
 /**
- * @author shale
- *
+ * Http Module client.
+ * @deprecated Use {@link io.vertx.ext.web.client.WebClient} for generic HTTP client or generated client.
  */
+@Deprecated
 public class HttpModuleClient2 implements HttpClientInterface {
 
   static LoadingCache<String, Response> cache = null;

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/Response.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/Response.java
@@ -17,9 +17,10 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 /**
- * @author shale
- *
+ * Http client response handling.
+ * @deprecated All material in org.folio.rest.tools.client is deprecated.
  */
+@Deprecated
 public class Response {
 
   private static final ObjectMapper MAPPER = ObjectMapperTool.getMapper();

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/RollBackURL.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/RollBackURL.java
@@ -3,9 +3,10 @@ package org.folio.rest.tools.client;
 import io.vertx.core.http.HttpMethod;
 
 /**
- * @author shale
- *
+ * Implementation incomplete.
+ * @deprecated All material in org.folio.rest.tools.client is deprecated.
  */
+@Deprecated
 public class RollBackURL {
 
   String endpoint;

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/test/HttpClientMock2.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/test/HttpClientMock2.java
@@ -23,6 +23,11 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * Mock HTTP client.
+ * @deprecated Use {@link io.vertx.core.Vertx#createHttpServer()} for mocking a server or use mocking utility.
+ */
+@Deprecated
 public class HttpClientMock2 implements HttpClientInterface {
 
   public static final String MOCK_MODE = "mock.httpclient";


### PR DESCRIPTION
Deprecate HttpClientInterface and implementations of it RMB-717

These classes and the helper classes are now deprected which constitutes
to all material in org.folio.rest.tools.client.