### PR TITLE
RMB-829: Suppress "Table audit_... NOT FOUND" in loadDbSchema()

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -183,10 +183,15 @@ public class CQL2PgJSON {
   enum InitDbTableResult {
     TABLE_FOUND,
     AUDIT_TABLE_FOUND,
+    NO_PRIMARY_TABLE_NAME,
     NOT_FOUND,
   };
 
   InitDbTableResult initDbTable() {
+    if (jsonField == null) {
+      logger.log(Level.SEVERE, "loadDbSchema(): No primary table name, can not load");
+      return InitDbTableResult.NO_PRIMARY_TABLE_NAME;
+    }
     // Remove the json blob field name, usually ".jsonb", but in tests also
     // ".user_data" etc.
     String tname = this.jsonField.replaceAll("\\.[^.]+$", "");

--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -196,7 +196,6 @@ public class CQL2PgJSON {
     // ".user_data" etc.
     String tname = this.jsonField.replaceAll("\\.[^.]+$", "");
     for (Table table : dbSchema.getTables()) {
-      System.out.println(table.getTableName() + " " + table.getMode());
       if ("DELETE".equalsIgnoreCase(table.getMode())) {
         continue;
       }

--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -180,27 +180,41 @@ public class CQL2PgJSON {
     }
   }
 
-  private void initDbTable() {
-    if (dbSchema.getTables() != null) {
-      if (jsonField == null) {
-        logger.log(Level.SEVERE, "loadDbSchema(): No primary table name, can not load");
-        return;
-      }
-      // Remove the json blob field name, usually ".jsonb", but in tests also
-      // ".user_data" etc.
-      String tname = this.jsonField.replaceAll("\\.[^.]+$", "");
-      for (Table table : dbSchema.getTables()) {
-        if (tname.equalsIgnoreCase(table.getTableName())) {
-          dbTable = table;
-          break;
-        }
-      }
-      if (dbTable == null) {
-        logger.log(Level.SEVERE, "loadDbSchema loadDbSchema(): Table {0} NOT FOUND", tname);
-      }
-    } else {
+  enum InitDbTableResult {
+    TABLE_FOUND,
+    AUDIT_TABLE_FOUND,
+    NO_TABLES_SECTION,
+    NO_PRIMARY_TABLE_NAME,
+    NOT_FOUND,
+  };
+
+  InitDbTableResult initDbTable() {
+    if (dbSchema.getTables() == null) {
       logger.log(Level.SEVERE, "loadDbSchema loadDbSchema(): No 'tables' section found");
+      return InitDbTableResult.NO_TABLES_SECTION;
     }
+    if (jsonField == null) {
+      logger.log(Level.SEVERE, "loadDbSchema(): No primary table name, can not load");
+      return InitDbTableResult.NO_PRIMARY_TABLE_NAME;
+    }
+    // Remove the json blob field name, usually ".jsonb", but in tests also
+    // ".user_data" etc.
+    String tname = this.jsonField.replaceAll("\\.[^.]+$", "");
+    boolean isAuditTable = false;
+    for (Table table : dbSchema.getTables()) {
+      if (tname.equalsIgnoreCase(table.getTableName())) {
+        dbTable = table;
+        return InitDbTableResult.TABLE_FOUND;
+      }
+      if (tname.equalsIgnoreCase(table.getAuditingTableName())) {
+        isAuditTable = true;
+      }
+    }
+    if (isAuditTable) {
+      return InitDbTableResult.AUDIT_TABLE_FOUND;
+    }
+    logger.log(Level.SEVERE, "loadDbSchema loadDbSchema(): Table {0} NOT FOUND", tname);
+    return InitDbTableResult.NOT_FOUND;
   }
 
   private void doInit(String field, String dbSchemaPath) throws FieldException {

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -1173,4 +1173,11 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   public void validateFieldName() throws FieldException {
     new CQL2PgJSON("foo'bar");
   }
+
+  @Test
+  public void initDbTable() throws Throwable {
+    assertThat(new CQL2PgJSON("x").initDbTable(), is(CQL2PgJSON.InitDbTableResult.NOT_FOUND));
+    assertThat(new CQL2PgJSON("loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.TABLE_FOUND));
+    assertThat(new CQL2PgJSON("audit_loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.AUDIT_TABLE_FOUND));
+  }
 }

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -1177,6 +1177,7 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
   @Test
   public void initDbTable() throws Throwable {
     assertThat(new CQL2PgJSON("x").initDbTable(), is(CQL2PgJSON.InitDbTableResult.NOT_FOUND));
+    assertThat(new CQL2PgJSON("deleted").initDbTable(), is(CQL2PgJSON.InitDbTableResult.NOT_FOUND));
     assertThat(new CQL2PgJSON("loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.TABLE_FOUND));
     assertThat(new CQL2PgJSON("audit_loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.AUDIT_TABLE_FOUND));
   }

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -1180,5 +1180,6 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     assertThat(new CQL2PgJSON("deleted").initDbTable(), is(CQL2PgJSON.InitDbTableResult.NOT_FOUND));
     assertThat(new CQL2PgJSON("loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.TABLE_FOUND));
     assertThat(new CQL2PgJSON("audit_loan").initDbTable(), is(CQL2PgJSON.InitDbTableResult.AUDIT_TABLE_FOUND));
+    assertThat(new CQL2PgJSON(List.of("x", "y")).initDbTable(), is(CQL2PgJSON.InitDbTableResult.NO_PRIMARY_TABLE_NAME));
   }
 }

--- a/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
+++ b/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
@@ -144,6 +144,17 @@
           "statement": "jsonb = jsonb_set(jsonb, '{loan,action}', '\"deleted\"', false);"
         }
       }
+    },
+    {
+      "tableName": "deleted",
+      "mode": "DELETE",
+      "withAuditing": true,
+      "auditingTableName": "deleted"
+    },
+    {
+      "tableName": "deleted_auditing",
+      "withAuditing": false,
+      "auditingTableName": "deleted"
     }
   ]
 }

--- a/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
+++ b/cql2pgjson/src/test/resources/templates/db_scripts/schema.json
@@ -131,6 +131,19 @@
           "targetTable": "holdings"
         }
       ]
+    },
+    {
+      "tableName": "loan",
+      "fromModuleVersion": "10.1.0",
+      "withMetadata": true,
+      "withAuditing": true,
+      "auditingTableName": "audit_loan",
+      "auditingFieldName": "loan",
+      "auditingSnippet": {
+        "delete": {
+          "statement": "jsonb = jsonb_set(jsonb, '{loan,action}', '\"deleted\"', false);"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Also search a table name in the auditingTableName field
and suppress a "Table ... NOT FOUND" warning if found to
be an auditing table.