### PR TITLE
raml plugin no generated clients RMB-831

### DIFF
--- a/README.md
+++ b/README.md
@@ -2193,13 +2193,22 @@ public class CustomHealthCheck extends AdminAPI {
 
 The framework can generate a Client class for every RAML file with a function for every API endpoint in the RAML.
 
-To generate a client API from your RAML use the `generateClients` option of the domain-models-maven-plugin in your pom.xml:
+To generate a client API from your RAML use the `generateClients` option of
+the domain-models-maven-plugin in your pom.xml as well as depend on the
+artifact that includes interfaces.
 
 ```xml
       <plugin>
         <groupId>org.folio</groupId>
         <artifactId>domain-models-maven-plugin</artifactId>
         <version>${raml-module-builder-version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.folio</groupId>
+            <artifactId>mod-my-server</artifactId>
+            <version>${project.parent.version}</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>generate_interfaces</id>

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -63,8 +63,7 @@ Remove `<groupId>ru.yandex.qatools.embed</groupId>`
 #### [RMB-785](https://issues.folio.org/browse/RMB-785) domain-models-maven-plugin
 
 In pom.xml replace the exec-maven-plugin sections that call
-`<mainClass>org.folio.rest.tools.GenerateRunner</mainClass>` or
-`<mainClass>org.folio.rest.tools.ClientGenerator</mainClass>` by
+`<mainClass>org.folio.rest.tools.GenerateRunner</mainClass>` by :
 
 ```xml
       <plugin>
@@ -82,14 +81,35 @@ In pom.xml replace the exec-maven-plugin sections that call
       </plugin>
 ```
 
-Add configuration if you need to disable generating interfaces or to
-enable generating clients:
+Replace `<mainClass>org.folio.rest.tools.ClientGenerator</mainClass>` by
+a call to the same plugin. It must be used in a separate project depending
+on the artifact with generated interfaces.
 
 ```xml
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>domain-models-maven-plugin</artifactId>
+        <version>${raml-module-builder-version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.folio</groupId>
+            <artifactId>mod-my-server</artifactId>
+            <version>${project.parent.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>generate_interfaces</id>
+            <goals>
+              <goal>java</goal>
+            </goals>
             <configuration>
-              <generateInterfaces>false</generateInterfaces>
               <generateClients>true</generateClients>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
 ```
 
 Add FOLIO Maven repository for plugins after existing `<repositories>` section:

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ClientGenerator.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ClientGenerator.java
@@ -87,24 +87,14 @@ public class ClientGenerator implements ClientGrabber {
   private JFieldVar okapiUrl;
   private JFieldVar webClient;
 
-  public static void main(String[] args) throws Exception {
-    boolean generateClient = System.getProperty("client.generate") != null;
-
-    if ("mongo".equals(System.getProperty("json.type"))) {
-      mappingType = "mongo";
-    }
-
-    generate(System.getProperty("project.basedir"), generateClient);
-  }
-
-  public static void generate(String basedir, boolean generateClient) throws IOException {
+  public static int generate(String basedir) throws IOException {
     ClientGenerator.basedir = basedir;
     String packageDir = basedir
         + ClientGenerator.PATH_TO_GENERATE_TO
         + AnnotationGrabber.CLIENT_GEN_PACKAGE.replace('.', '/');
     makeCleanDir(packageDir);
     ClientGrabber clientGrabber = new ClientGenerator();
-    AnnotationGrabber.generateMappings(clientGrabber);
+    return AnnotationGrabber.generateMappings(clientGrabber).size();
   }
 
   /**

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
@@ -100,14 +100,13 @@ public class DomainModelsMojo extends AbstractMojo {
     setRootLogLevel(Level.WARNING);
     try {
       if (generateInterfaces) {
-        System.err.println("generate interfaces");
         generateInterfaces();
         ModuleNameWriter.writeModuleNameClass(project);
       }
-      System.err.println("generate clients " + generateClients);
-      ClientGenerator.generate(project.getBasedir().getAbsolutePath(), generateClients);
-      System.err.println("generate clients done");
-
+      if (generateClients) {
+        int sz = ClientGenerator.generate(project.getBasedir().getAbsolutePath());
+        System.err.println("Client classes generated: " + sz);
+      }
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
@@ -100,10 +100,14 @@ public class DomainModelsMojo extends AbstractMojo {
     setRootLogLevel(Level.WARNING);
     try {
       if (generateInterfaces) {
+        System.err.println("generate interfaces");
         generateInterfaces();
         ModuleNameWriter.writeModuleNameClass(project);
       }
+      System.err.println("generate clients " + generateClients);
       ClientGenerator.generate(project.getBasedir().getAbsolutePath(), generateClients);
+      System.err.println("generate clients done");
+
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -127,7 +131,7 @@ public class DomainModelsMojo extends AbstractMojo {
       ramlDirs = new File[] { file };
     }
 
-    Path inputPath = ramlDirs[0].toPath().toAbsolutePath();
+    Path inputPath = GenerateRunner.rebase(ramlDirs[0]).toPath();
     Path outputPath = project.getBasedir().toPath()
         .resolve(GenerateRunner.RESOURCE_DEFAULT)
         .resolve(GenerateRunner.SOURCES_DEFAULT)

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
@@ -74,26 +74,26 @@ public class DomainModelsMojo extends AbstractMojo {
 
   @Override
   public void execute() {
-    System.err.println("DomainModelsMojo.execute()");
-    System.err.println("generateInterfaces=" + generateInterfaces);
-    System.err.println("generateClients=" + generateClients);
-    System.err.println("project.baseDir = " + (project == null ? "" : project.getBasedir()));
-    System.err.println("project.name = " + (project == null ? "" : project.getName()));
-    System.err.println("project.actifactId = " + (project == null ? "" : project.getArtifactId()));
-    System.err.println("Artifacts: " + project.getArtifacts());
-    System.err.println("Artifacts: " + project.getArtifactMap());
+    System.out.println("DomainModelsMojo.execute()");
+    System.out.println("generateInterfaces=" + generateInterfaces);
+    System.out.println("generateClients=" + generateClients);
+    System.out.println("project.baseDir = " + (project == null ? "" : project.getBasedir()));
+    System.out.println("project.name = " + (project == null ? "" : project.getName()));
+    System.out.println("project.actifactId = " + (project == null ? "" : project.getArtifactId()));
+    System.out.println("Artifacts: " + project.getArtifacts());
+    System.out.println("Artifacts: " + project.getArtifactMap());
 
     if (ramlDirs != null) {
       System.out.println("ramlDirs.size=" + ramlDirs.length);
       for (File ramlDir : ramlDirs) {
-        System.err.println("ramlDir = " + ramlDir);
+        System.out.println("ramlDir = " + ramlDir);
       }
     }
 
     if (schemaPaths != null) {
       System.out.println("schemaPaths.size=" + schemaPaths.length);
       for (File schemaPath : schemaPaths) {
-        System.err.println("schemaPath = " + schemaPath);
+        System.out.println("schemaPath = " + schemaPath);
       }
     }
 
@@ -105,7 +105,7 @@ public class DomainModelsMojo extends AbstractMojo {
       }
       if (generateClients) {
         int sz = ClientGenerator.generate(project.getBasedir().getAbsolutePath());
-        System.err.println("Client classes generated: " + sz);
+        System.out.println("Client classes generated: " + sz);
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
@@ -77,17 +77,15 @@ public class DomainModelsMojo extends AbstractMojo {
     System.out.println("DomainModelsMojo.execute()");
     System.out.println("generateInterfaces=" + generateInterfaces);
     System.out.println("generateClients=" + generateClients);
-    System.out.println("project.baseDir = " + (project == null ? "" : project.getBasedir()));
-    System.out.println("project.name = " + (project == null ? "" : project.getName()));
-    System.out.println("project.actifactId = " + (project == null ? "" : project.getArtifactId()));
+    System.out.println("project.baseDir = " + project.getBasedir());
+    System.out.println("project.name = " + project.getName());
+    System.out.println("project.actifactId = " + project.getArtifactId());
     System.out.println("Artifacts: " + project.getArtifacts());
-    System.out.println("Artifacts: " + project.getArtifactMap());
+    System.out.println("ArtifactMap: " + project.getArtifactMap());
 
-    if (ramlDirs != null) {
-      System.out.println("ramlDirs.size=" + ramlDirs.length);
-      for (File ramlDir : ramlDirs) {
-        System.out.println("ramlDir = " + ramlDir);
-      }
+    System.out.println("ramlDirs.size=" + ramlDirs.length);
+    for (File ramlDir : ramlDirs) {
+      System.out.println("ramlDir = " + ramlDir);
     }
 
     if (schemaPaths != null) {

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
@@ -243,8 +243,11 @@ public class GenerateRunner {
       .getPathMatcher("glob:" + relativePath + fileExpression);
   }
 
-  private static File rebase(String path) {
-    File input = new File(path);
+  static File rebase(String path) {
+    return rebase(new File(path));
+  }
+
+  static File rebase(File input) {
     File temp = input;
     while (true) {
       temp = temp.getParentFile();

--- a/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/ClientGeneratorTest.java
+++ b/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/ClientGeneratorTest.java
@@ -34,7 +34,8 @@ public class ClientGeneratorTest {
 
   @Test
   public void doesGenerateTestResourceClient() throws Exception {
-    ClientGenerator.main(null);
+    int sz = ClientGenerator.generate(System.getProperty("project.basedir"));
+    Assert.assertTrue(sz > 0);
     File expectedClient = new File(sourceDir + "/TestResourceClient.java");
     Assert.assertTrue(expectedClient.exists());
 


### PR DESCRIPTION
This is a clarification for client generated code, not a fix.

For earlier versions client code also required depending the artifact with generated classes.. Since the client generator is using annotations as "input" (not RAML).

 But also a bug fix for finding base path of RAML source (seen with mod-configuration).