### PR TITLE
RMB-832: Implement upsert, updateBatch for optimistic locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1783,11 +1783,11 @@ RMB adds a `totalRecords` field to result sets. For `limit = 0` it contains the 
 For estimation it uses this algorithm:
 
 1. Run "EXPLAIN SELECT" to get an estimation from PostgreSQL.
-2. If this is greater than 4*1000 return it and stop.
-3. Run "SELECT COUNT(*) FROM query LIMIT 1000".
+2. If this is greater than `4\*1000 return it and stop.
+3. Run "SELECT COUNT(\*) FROM query LIMIT 1000".
 4. If this is less than 1000 return it (this is the exact number) and stop.
 5. If the result from 1. is less than 1000 return 1000 and stop.
-6. Return result from 1. (this is a value between 1000 and 4*1000).
+6. Return result from 1. (this is a value between 1000 and 4\*1000).
 
 Step 2. contains the factor 4 that should be adjusted when there is empirical data for a better number.
 Step 3. may take long for full text queries with many hits, therefore we need steps 1.-2.
@@ -1823,6 +1823,8 @@ RMB supports optimistic locking. By default it is disabled. Module developer can
 * `off` Optimistic Locking is disabled. The trigger is removed if it existed before.
 * `failOnConflict` Optimistic Locking is enabled. Version conflict will fail the transaction with a customized SQL error code 23F09.
 * `logOnConflict` Optimistic Locking is enabled but the conflicting update succeeds, the version conflict info is logged with a customized SQL error code 23F09. Consult [Vertx logging](https://vertx.io/docs/vertx-core/java/#_logging) and [PostgreSQL Errors and Messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) if `logOnConflict` doesn't log.
+
+Upsert fails when using `INSERT ... ON CONFLICT (id) DO UPDATE` because the `INSERT` trigger overwrites the `\_version` property that the `UPDATE` trigger uses to detect optimistic locking conflicts. Instead use [RMB's `upsert` plpgsql function](domain-models-runtime/src/main/resources/templates/db_scripts/general_functions.ftl) or implement upsert using a transaction and `UPDATE ...; IF NOT FOUND THEN INSERT ...`
 
 _Sample log entries:_
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -124,10 +124,10 @@ public class SchemaMaker {
       Table table = new Table();
       table.setTableName(tablename);
       table.setWithOptimisticLocking(OptimisticLockingMode.FAIL);
-      Map<String, Object> parameters = Map.of(
-          "myuniversity", tenant,
-          "mymodule", module,
-          "table", table);
+      Map<String, Object> parameters = new HashMap<>(3);
+      parameters.put("myuniversity", tenant);
+      parameters.put("mymodule", module);
+      parameters.put("table", table);
       Template tableTemplate = cfg.getTemplate("optimistic_locking.ftl");
       Writer writer = new StringWriter();
       tableTemplate.process(parameters, writer);

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/ddlgen/SchemaMaker.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.folio.dbschema.ForeignKeys;
+import org.folio.dbschema.OptimisticLockingMode;
 import org.folio.dbschema.Schema;
 import org.folio.dbschema.Table;
 import org.folio.dbschema.TableOperation;
@@ -28,7 +29,7 @@ import freemarker.template.Version;
  */
 public class SchemaMaker {
 
-  private static Configuration cfg;
+  private static Configuration cfg = getConfiguration();
   private Map<String, Object> templateInput = new HashMap<>();
   private String tenant;
   private String module;
@@ -42,21 +43,22 @@ public class SchemaMaker {
 
   public SchemaMaker(String tenant, String module, TenantOperation mode, String previousVersion,
                      String newVersion) {
-    if(SchemaMaker.cfg == null) {
-      //do this ONLY ONCE
-      SchemaMaker.cfg = new Configuration(new Version(2, 3, 26));
-      // Where do we load the templates from:
-      cfg.setClassForTemplateLoading(SchemaMaker.class, "/templates/db_scripts");
-      cfg.setDefaultEncoding("UTF-8");
-      cfg.setLocale(Locale.US);
-      cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
-    }
     this.tenant = tenant;
     this.module = module;
     this.mode = mode;
     this.previousVersion = previousVersion;
     this.newVersion = newVersion;
     this.rmbVersion = RmbVersion.getRmbVersion();
+  }
+
+  private static Configuration getConfiguration() {
+    Configuration configuration = new Configuration(new Version(2, 3, 26));
+    // Where do we load the templates from:
+    configuration.setClassForTemplateLoading(SchemaMaker.class, "/templates/db_scripts");
+    configuration.setDefaultEncoding("UTF-8");
+    configuration.setLocale(Locale.US);
+    configuration.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+    return configuration;
   }
 
   public String generatePurge() throws IOException, TemplateException {
@@ -115,6 +117,24 @@ public class SchemaMaker {
 
   public String generateIndexesOnly() throws IOException, TemplateException {
     return generateDDL("indexes_only.ftl");
+  }
+
+  public static String generateOptimisticLocking(String tenant, String module, String tablename) {
+    try {
+      Table table = new Table();
+      table.setTableName(tablename);
+      table.setWithOptimisticLocking(OptimisticLockingMode.FAIL);
+      Map<String, Object> parameters = Map.of(
+          "myuniversity", tenant,
+          "mymodule", module,
+          "table", table);
+      Template tableTemplate = cfg.getTemplate("optimistic_locking.ftl");
+      Writer writer = new StringWriter();
+      tableTemplate.process(parameters, writer);
+      return writer.toString();
+    } catch (IOException | TemplateException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**

--- a/domain-models-runtime/src/test/java/org/folio/rest/jaxrs/model/User.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/jaxrs/model/User.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonPropertyOrder({
     "username",
     "id",
+    "_version",
     "metadata",
     "dummy"
 })
@@ -39,6 +40,14 @@ public class User {
     @JsonPropertyDescription("A globally unique (UUID) identifier for the user")
     @NotNull
     private String id;
+
+    /**
+     * Record version for optimistic locking
+     *
+     */
+    @JsonProperty("_version")
+    @JsonPropertyDescription("Record version for optimistic locking")
+    private Integer version;
 
     /**
      * Metadata Schema
@@ -105,6 +114,29 @@ public class User {
 
     public User withId(String id) {
         this.id = id;
+        return this;
+    }
+
+    /**
+     * Record version for optimistic locking
+     *
+     */
+    @JsonProperty("_version")
+    public Integer getVersion() {
+        return version;
+    }
+
+    /**
+     * Record version for optimistic locking
+     *
+     */
+    @JsonProperty("_version")
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public User withVersion(Integer version) {
+        this.version = version;
         return this;
     }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/GeneralFunctionsIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/GeneralFunctionsIT.java
@@ -5,15 +5,39 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import java.util.UUID;
 
 /**
  * Test src/main/resources/templates/db_scripts/general_functions.ftl
  */
 @RunWith(VertxUnitRunner.class)
 public class GeneralFunctionsIT extends PostgresClientITBase {
+
+  private Future<Row> upsert(TestContext context, UUID id, JsonObject json) {
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenant);
+    String sql = "SELECT upsert('t', $1, $2)";
+    return postgresClient.selectSingle(sql, Tuple.of(id, json))
+    .onComplete(context.asyncAssertSuccess(upsert -> {
+      assertThat(sql, upsert.getUUID(0), is(id));
+      postgresClient.getById("t", id.toString(), context.asyncAssertSuccess(get -> {
+        assertThat(get, is(json));
+      }));
+    }));
+  }
+
+  @Test
+  public void upsert(TestContext context) {
+    execute(context, "CREATE TABLE " + schema + ".t (id uuid primary key, jsonb jsonb);");
+    UUID id = UUID.randomUUID();
+    upsert(context, id, new JsonObject().put("a", 1))
+    .compose(x -> upsert(context, id, new JsonObject().put("b", 2)));
+  }
 
   void normalizeDigits(TestContext context, String raw, String expected) {
     String sql = "SELECT normalize_digits('" + raw + "')";

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/LoadGeneralFunctions.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/LoadGeneralFunctions.java
@@ -23,7 +23,8 @@ public class LoadGeneralFunctions {
   static void loadFuncs(TestContext context, PostgresClient postgresClient, String schema) {
     Async async = context.async();
     loadFuncs(postgresClient, schema)
-    .onComplete(x -> async.complete());
-    async.awaitSuccess(1000);
+    .onSuccess(x -> async.complete())
+    .onFailure(e -> context.fail(e));
+    async.await(1000);
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -42,6 +42,7 @@ import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.folio.util.ResourceUtil;
+import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.PostgresClient.QueryHelper;
 import org.junit.After;
 import org.junit.Assert;
@@ -661,6 +662,14 @@ public class PostgresClientTest {
     String sqlFile = ResourceUtil.asString("import.sql");
     assertThat(PostgresClient.preprocessSqlStatements(sqlFile), hasItemInArray(stringContainsInOrder(
         "COPY test.po_line", "24\t")));
+  }
+
+  @Test
+  public void pojo2JsonObject() throws Exception {
+    String id = UUID.randomUUID().toString();
+    User user = new User().withId(id).withUsername("name").withVersion(5);
+    JsonObject json = PostgresClient.pojo2JsonObject(user);
+    assertThat(json.getMap(), is(Map.of("id", id, "username", "name", "_version", 5)));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/ddlgen/SchemaMakerTest.java
@@ -57,6 +57,11 @@ public class SchemaMakerTest {
   }
 
   @Test
+  void failGenerateOptimisticLocking() {
+    assertThrows(RuntimeException.class, () -> SchemaMaker.generateOptimisticLocking("tenant", null, "table"));
+  }
+
+  @Test
   public void testCreateCreate() throws IOException, TemplateException {
     SchemaMaker schemaMaker = schemaMaker("harvard", "circ", TenantOperation.CREATE,
         "mod-foo-18.2.3", null, "templates/db_scripts/schemaWithAudit.json");
@@ -428,7 +433,7 @@ public class SchemaMakerTest {
     }
     assertThat(SchemaMaker.sameForeignKey(a, b), is(expected));
   }
-  
+
   @Test
   public void optimisticLocking() throws Exception {
     String tenant = "olTenant";


### PR DESCRIPTION
Upsert using INSERT ... ON CONFLICT (id) DO UPDATE fails because the INSERT
trigger overwrites the _version property that the UPDATE trigger uses to
detect optimistic locking conflicts.

Solution:

Implement upsert using a transaction and executing two SQL commands:

UPDATE ...;
IF NOT FOUND THEN INSERT ...;

Adding updateBatch allows to replace upsertBatch depending on the use case:
insertBatch or updateBatch. When optimistic locking is enabled the client
must know in advance whether it is insert or update.