### PR TITLE
Bump jersey-media-json-jackson from 2.29.1 to 2.34 (CVE-2021-28168)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.29.1</version>
+        <version>2.34</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>


### PR DESCRIPTION
Eclipse Jersey 2.28 to 2.33 contains a local information disclosure vulnerability
due to the use of the File.createTempFile.

Version 2.34 has a fix.