### PR TITLE
RMB-843: Use percent encoding, not url encoding, for HTTP requests

### DIFF
--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ClientGenerator.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ClientGenerator.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -48,6 +47,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMultipart;
+
+import org.folio.util.PercentCodec;
 
 /**
  *
@@ -476,10 +477,9 @@ public class ClientGenerator implements ClientGrabber {
   }
 
   private void encodeParameter(JBlock b, ParameterDetails details) {
-    JExpression expr = jcodeModel.ref(java.net.URLEncoder.class)
+    JExpression expr = jcodeModel.ref(PercentCodec.class)
       .staticInvoke("encode")
-        .arg(JExpr.ref(details.valueName))
-        .arg(jcodeModel.ref(StandardCharsets.class).staticRef("UTF_8"));
+        .arg(JExpr.ref(details.valueName));
     b.invoke(details.queryParams, APPEND).arg(expr);
   }
 

--- a/domain-models-maven-plugin/src/test/resources/clients/TestClient.txt
+++ b/domain-models-maven-plugin/src/test/resources/clients/TestClient.txt
@@ -2,8 +2,6 @@
 package org.folio.rest.client;
 
 import java.math.BigDecimal;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -17,6 +15,7 @@ import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.folio.rest.tools.utils.VertxUtils;
+import org.folio.util.PercentCodec;
 
 
 /**
@@ -187,7 +186,7 @@ public class TestResourceClient {
         StringBuilder queryParams = new StringBuilder("?");
         if (name!= null) {
             queryParams.append("name=");
-            queryParams.append(URLEncoder.encode(name, StandardCharsets.UTF_8));
+            queryParams.append(PercentCodec.encode(name));
             queryParams.append("&");
         }
         if (success!= null) {
@@ -229,7 +228,7 @@ public class TestResourceClient {
         StringBuilder queryParams = new StringBuilder("?");
         if (author!= null) {
             queryParams.append("author=");
-            queryParams.append(URLEncoder.encode(author, StandardCharsets.UTF_8));
+            queryParams.append(PercentCodec.encode(author));
             queryParams.append("&");
         }
         if (publicationDate!= null) {
@@ -244,7 +243,7 @@ public class TestResourceClient {
         }
         if (isbn!= null) {
             queryParams.append("isbn=");
-            queryParams.append(URLEncoder.encode(isbn, StandardCharsets.UTF_8));
+            queryParams.append(PercentCodec.encode(isbn));
             queryParams.append("&");
         }
         if (facets!= null) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/BuildCQL.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.folio.rest.tools.parser.JsonPathParser;
-import org.folio.util.StringUtil;
+import org.folio.util.PercentCodec;
 
 /**
  * Build CQL string by parsing response JSON
@@ -177,10 +177,10 @@ public class BuildCQL {
         sb.append(" ").append(operatorBetweenArgs).append(" ");
       }
     }
-    if(sb.length() > 0){
-      return prefix.append(StringUtil.urlEncode(sb.toString())).toString();
+    if (sb.length() == 0) {
+      return "";
     }
-    return "";
+    return prefix.append(PercentCodec.encode(sb)).toString();
   }
 
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
@@ -32,7 +32,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.util.StringUtil;
+import org.folio.util.PercentCodec;
 
 /**
  * TenantLoading is utility for loading data into modules during the Tenant Init service.
@@ -207,7 +207,7 @@ public class TenantLoading {
           log.warn(msg);
           return Future.failedFuture(msg);
         }
-        return Future.succeededFuture(StringUtil.urlEncode(id));
+        return Future.succeededFuture(PercentCodec.encodeAsString(id));
       case RAW_PUT:
       case RAW_POST:
         break;

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/BuildCQLTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/BuildCQLTest.java
@@ -3,7 +3,7 @@ package org.folio.rest.tools.utils;
 import static org.junit.Assert.assertEquals;
 import org.folio.rest.tools.client.BuildCQL;
 import org.folio.rest.tools.client.Response;
-import org.folio.util.StringUtil;
+import org.folio.util.PercentCodec;
 import org.junit.Test;
 
 import io.vertx.core.json.JsonArray;
@@ -35,22 +35,22 @@ public class BuildCQLTest {
       r.setBody(j);
 
       String g = new BuildCQL(r, "arr2[0]", "group").buildCQL();
-      assertEquals("?query=" + StringUtil.urlEncode("group=={\"o\":{\"bbb\":\"aaa\"}}"), g);
+      assertEquals("?query=" + PercentCodec.encode("group=={\"o\":{\"bbb\":\"aaa\"}}"), g);
       g = new BuildCQL(r, "arr", "group").buildCQL();
-      assertEquals("?query=" + StringUtil.urlEncode("group==[\"librarian3\",\"librarian2\"]"), g);
+      assertEquals("?query=" + PercentCodec.encode("group==[\"librarian3\",\"librarian2\"]"), g);
       g = new BuildCQL(r, "arr[0]", "group").buildCQL();
-      assertEquals("?query=" + StringUtil.urlEncode("group==librarian3"), g);
+      assertEquals("?query=" + PercentCodec.encode("group==librarian3"), g);
       g = new BuildCQL(r, "arr[*]", "group").buildCQL();
-      assertEquals("?query=" + StringUtil.urlEncode("group==librarian3 or group==librarian2"), g);
+      assertEquals("?query=" + PercentCodec.encode("group==librarian3 or group==librarian2"), g);
       g = new BuildCQL(r, "arr[*]", "group", "query1").buildCQL();
-      assertEquals("?query1=" + StringUtil.urlEncode("group==librarian3 or group==librarian2"), g);
+      assertEquals("?query1=" + PercentCodec.encode("group==librarian3 or group==librarian2"), g);
       g = new BuildCQL(r, "arr[*]", "group", "query1", false, "and").buildCQL();
-      assertEquals("&query1=" + StringUtil.urlEncode("group==librarian3 and group==librarian2"), g);
+      assertEquals("&query1=" + PercentCodec.encode("group==librarian3 and group==librarian2"), g);
       //build cql by requesting values from a non existent field in the json, should be an emptry string ""
       g = new BuildCQL(r, "arr3", "group").buildCQL();
       assertEquals("", g);
       g = new BuildCQL(r, "arr[*]", "group", "query1", false, "and", "=").buildCQL();
-      assertEquals("&query1=" + StringUtil.urlEncode("group=librarian3 and group=librarian2"), g);
+      assertEquals("&query1=" + PercentCodec.encode("group=librarian3 and group=librarian2"), g);
   }
 
 }

--- a/util/src/main/java/org/folio/util/PercentCodec.java
+++ b/util/src/main/java/org/folio/util/PercentCodec.java
@@ -1,0 +1,134 @@
+package org.folio.util;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Percent encoding of UTF-8 strings, conforming to RFC 3986.
+ *
+ * <p>These are the characters that are never encoded: The letters a-z and A-Z and the digits 0-9, and the
+ * {@code -._~} characters. They are the
+ * <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-2.3">Unreserved Characters (RFC 3986 Section 2.3)</a>.
+ *
+ * <p>All other characters are always percent encoded.
+ *
+ * <p>Space is always encoded as {@code %20} to conform with RFC 3986.
+ * <a href="https://datatracker.ietf.org/doc/html/rfc1630#page-7">RFC 1630</a> allows to encode space as {@code +}
+ * but RFC 1630's category is "Informational" only, whereas RFC 3986's category is "Standards Track".
+ *
+ * <p>The only encoding difference between {@link java.net.URLEncoder} and this class is the space character:
+ * URLEncoder encodes it as {@code +} and this class encodes it as {@code %20}.
+ */
+public final class PercentCodec {
+  private static final char [] UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~".toCharArray();
+  private static final char [] HEX = "0123456789ABCDEF".toCharArray();
+  private static final char [][] ENCODE = getEncodeArray();
+
+  private PercentCodec() {
+    throw new UnsupportedOperationException();
+  }
+
+  private static char [][] getEncodeArray() {
+    char [][] encode = new char [256][];
+    for (char c : UNRESERVED) {
+      char [] cc = { c };
+      encode[c] = cc;
+    }
+    for (int i=0; i<256; i++) {
+      if (encode[i] != null) {
+        continue;
+      }
+      char [] cc = { '%', HEX[i >> 4], HEX[i & 0xf] };
+      encode[i] = cc;
+    }
+    return encode;
+  }
+
+  /**
+   * Apply percent encoding (RFC 3986) to charSequence and append the result to appendable.
+   *
+   * <p>All characters except these get percent encoded: The letters a-z and A-Z and the digits 0-9, and the
+   * {@code -._~} characters.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * String baseUrl = "https://example.com/users";
+   * String query =  "status == open";
+   * StringBuilder url = new StringBuilder(baseUrl);
+   * url.append("?query=");
+   * PercentCodec.encode(url, query);
+   * // yields "https://example.com/users?query=status%20%3D%3D%20open"
+   * </pre>
+   *
+   * @param charSequence the input in UTF8 encoding; if null or empty the appendable is unchanged
+   * @return appendable
+   */
+  public static Appendable encode(Appendable appendable, CharSequence charSequence) {
+    if (charSequence == null || charSequence.length() == 0) {
+      return appendable;
+    }
+    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(charSequence));
+    while (byteBuffer.hasRemaining()) {
+      int i = byteBuffer.get() & 0xff;
+      char [] encode = ENCODE[i];
+      for (char c : encode) {
+        try {
+          appendable.append(c);
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      }
+    }
+    return appendable;
+  }
+
+  /**
+   * Return charSequence with percent encoding (RFC 3986) applied.
+   *
+   * <p>All characters except these get percent encoded: The letters a-z and A-Z and the digits 0-9, and the
+   * {@code -._~} characters.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * String baseUrl = "https://example.com/users";
+   * String query =  "status == open";
+   * String url = baseUrl + "?query=" + PercentCodec.encode(query);
+   * // yields "https://example.com/users?query=status%20%3D%3D%20open"
+   * </pre>
+   *
+   * @param charSequence the input in UTF8 encoding; if null or empty then "" is returned
+   */
+  public static CharSequence encode(CharSequence in) {
+    if (in == null || in.length() == 0) {
+      return "";
+    }
+    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(in));
+    CharBuffer out = CharBuffer.allocate(3 * byteBuffer.limit());
+
+    while (byteBuffer.hasRemaining()) {
+      int c = byteBuffer.get() & 0xff;
+      out.put(ENCODE[c]);
+    }
+
+    out.limit(out.position());
+    out.position(0);
+    return out;
+  }
+
+  /**
+   * Return charSequence with percent encoding (RFC 3986) applied.
+   *
+   * <p>All characters except these get percent encoded: The letters a-z and A-Z and the digits 0-9, and the
+   * {@code -._~} characters.
+   *
+   * @param charSequence the input in UTF8 encoding; if null or empty then "" is returned
+   */
+  public static String encodeAsString(CharSequence in) {
+    return encode(in).toString();
+  }
+}

--- a/util/src/main/java/org/folio/util/PercentCodec.java
+++ b/util/src/main/java/org/folio/util/PercentCodec.java
@@ -20,7 +20,9 @@ import java.nio.charset.StandardCharsets;
  * but RFC 1630's category is "Informational" only, whereas RFC 3986's category is "Standards Track".
  *
  * <p>The only encoding difference between {@link java.net.URLEncoder} and this class is the space character:
- * URLEncoder encodes it as {@code +} and this class encodes it as {@code %20}.
+ * URLEncoder encodes it as {@code +} and this class encodes it as {@code %20}. In addition this class
+ * supports Appendable and CharSequence for ease of use and performance, and it doesn't require a charset
+ * parameter because it always uses UTF8 regardless of the locale.
  */
 public final class PercentCodec {
   private static final char [] UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~".toCharArray();
@@ -37,7 +39,7 @@ public final class PercentCodec {
       char [] cc = { c };
       encode[c] = cc;
     }
-    for (int i=0; i<256; i++) {
+    for (int i = 0; i < 256; i++) {
       if (encode[i] != null) {
         continue;
       }
@@ -64,7 +66,7 @@ public final class PercentCodec {
    * // yields "https://example.com/users?query=status%20%3D%3D%20open"
    * </pre>
    *
-   * @param charSequence the input in UTF8 encoding; if null or empty the appendable is unchanged
+   * @param charSequence in UTF8 encoding; if null or empty the appendable is unchanged
    * @return appendable
    */
   public static Appendable encode(Appendable appendable, CharSequence charSequence) {
@@ -101,7 +103,7 @@ public final class PercentCodec {
    * // yields "https://example.com/users?query=status%20%3D%3D%20open"
    * </pre>
    *
-   * @param charSequence the input in UTF8 encoding; if null or empty then "" is returned
+   * @param charSequence in UTF8 encoding; if null or empty then "" is returned
    */
   public static CharSequence encode(CharSequence in) {
     if (in == null || in.length() == 0) {
@@ -126,7 +128,7 @@ public final class PercentCodec {
    * <p>All characters except these get percent encoded: The letters a-z and A-Z and the digits 0-9, and the
    * {@code -._~} characters.
    *
-   * @param charSequence the input in UTF8 encoding; if null or empty then "" is returned
+   * @param charSequence in UTF8 encoding; if null or empty then "" is returned
    */
   public static String encodeAsString(CharSequence in) {
     return encode(in).toString();

--- a/util/src/main/java/org/folio/util/PercentCodec.java
+++ b/util/src/main/java/org/folio/util/PercentCodec.java
@@ -105,11 +105,11 @@ public final class PercentCodec {
    *
    * @param charSequence in UTF8 encoding; if null or empty then "" is returned
    */
-  public static CharSequence encode(CharSequence in) {
-    if (in == null || in.length() == 0) {
+  public static CharSequence encode(CharSequence charSequence) {
+    if (charSequence == null || charSequence.length() == 0) {
       return "";
     }
-    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(in));
+    ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode(CharBuffer.wrap(charSequence));
     CharBuffer out = CharBuffer.allocate(3 * byteBuffer.limit());
 
     while (byteBuffer.hasRemaining()) {
@@ -130,7 +130,7 @@ public final class PercentCodec {
    *
    * @param charSequence in UTF8 encoding; if null or empty then "" is returned
    */
-  public static String encodeAsString(CharSequence in) {
-    return encode(in).toString();
+  public static String encodeAsString(CharSequence charSequence) {
+    return encode(charSequence).toString();
   }
 }

--- a/util/src/main/java/org/folio/util/StringUtil.java
+++ b/util/src/main/java/org/folio/util/StringUtil.java
@@ -93,6 +93,10 @@ public final class StringUtil {
   /**
    * Encode source using www-form-urlencoded scheme and charset.
    *
+   * <p>This is for web forms only.
+   *
+   * <p>Otherwise use {@link PercentCodec}, for example for HTTP requests.
+   *
    * @param source  String to encode
    * @param charset  name of the charset to use
    * @return the encoded String, "" if source is null, or null if charset is not supported or null
@@ -110,8 +114,8 @@ public final class StringUtil {
 
   /**
    * Encode source using www-form-urlencoded scheme and UTF-8 charset.
-   * <p>
-   * Note that <a href="https://tools.ietf.org/html/rfc3986#section-2.5">RFC3986 Section 2.5</a>
+   *
+   * <p>Note that <a href="https://tools.ietf.org/html/rfc3986#section-2.5">RFC3986 Section 2.5</a>
    * requires UTF-8 encoding and that {@link java.net.URLEncoder#encode(String)} is deprecated
    * because it uses the platform's default encoding. See also
    * <a href="https://en.wikipedia.org/wiki/Percent-encoding">https://en.wikipedia.org/wiki/Percent-encoding</a>.
@@ -145,8 +149,8 @@ public final class StringUtil {
 
   /**
    * Decode source using www-form-urlencoded scheme and UTF-8 charset.
-   * <p>
-   * Note that <a href="https://tools.ietf.org/html/rfc3986#section-2.5">RFC3986 Section 2.5</a>
+   *
+   * <p>Note that <a href="https://tools.ietf.org/html/rfc3986#section-2.5">RFC3986 Section 2.5</a>
    * requires UTF-8 encoding and that {@link java.net.URLDecoder#decode(String)} is deprecated
    * because it uses the platform's default encoding. See also
    * <a href="https://en.wikipedia.org/wiki/Percent-encoding">https://en.wikipedia.org/wiki/Percent-encoding</a>.

--- a/util/src/main/java/org/folio/util/StringUtil.java
+++ b/util/src/main/java/org/folio/util/StringUtil.java
@@ -25,7 +25,7 @@ public final class StringUtil {
    * <pre>
    * StringBuilder query = new StringBuilder("username==");
    * StringUtil.appendCqlEncoded(query, username).append(" AND x=y";
-   * String url = "https://example.com/users?query=" + StringUtil.urlEncode(query.toString());
+   * String url = "https://example.com/users?query=" + PercentCodec.encode(query);
    * </pre>
    *
    * <p>query is {@code username=="" AND x=y} if username is null
@@ -71,7 +71,7 @@ public final class StringUtil {
    *
    * <pre>
    * String query = "username==" + StringUtil.cqlEncode(username);
-   * String url = "https://example.com/users?query=" + StringUtil.urlEncode(query);
+   * String url = "https://example.com/users?query=" + PercentCodec.encode(query);
    * </pre>
    *
    * <p>query is {@code username==""} if s is null
@@ -114,6 +114,10 @@ public final class StringUtil {
 
   /**
    * Encode source using www-form-urlencoded scheme and UTF-8 charset.
+   *
+   * <p>This is for web forms only.
+   *
+   * <p>Otherwise use {@link PercentCodec}, for example for HTTP requests.
    *
    * <p>Note that <a href="https://tools.ietf.org/html/rfc3986#section-2.5">RFC3986 Section 2.5</a>
    * requires UTF-8 encoding and that {@link java.net.URLEncoder#encode(String)} is deprecated

--- a/util/src/test/java/org/folio/util/PercentCodecTest.java
+++ b/util/src/test/java/org/folio/util/PercentCodecTest.java
@@ -2,7 +2,10 @@ package org.folio.util;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.folio.rest.testing.UtilityClassTester;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -24,10 +27,30 @@ class PercentCodecTest {
     "ääääääääää    , %C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4",
     "a b c         , a%20b%20c",
   })
-  void uriEncode(String s, String expected) {
-    assertThat(PercentCodec.encode(s).toString(), is(expected));
+  void encode(String s, String expected) {
+    assertThat(PercentCodec.encodeAsString(s), is(expected));
     StringBuffer stringBuffer = new StringBuffer("foo = ");
     PercentCodec.encode(stringBuffer, s);
     assertThat(stringBuffer.toString(), is("foo = " + expected));
+  }
+
+  @Test
+  void encodeThrowsUncheckedIOException() throws IOException {
+    var out = new Appendable() {
+      @Override
+      public Appendable append(CharSequence csq) throws IOException {
+        throw new IOException("failing mock");
+      }
+      @Override
+      public Appendable append(CharSequence csq, int start, int end) throws IOException {
+        throw new IOException("failing mock");
+      }
+      @Override
+      public Appendable append(char c) throws IOException {
+        throw new IOException("failing mock");
+      }
+    };
+
+    assertThrows(UncheckedIOException.class, () -> PercentCodec.encode(out, "foo"));
   }
 }

--- a/util/src/test/java/org/folio/util/PercentCodecTest.java
+++ b/util/src/test/java/org/folio/util/PercentCodecTest.java
@@ -1,0 +1,33 @@
+package org.folio.util;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.folio.rest.testing.UtilityClassTester;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class PercentCodecTest {
+  @Test
+  void isUtilityClass() {
+    UtilityClassTester.assertUtilityClass(PercentCodec.class);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "              , ''",  // null -> empty
+    "''            , ''",  // empty -> empty
+    "abc           , abc",
+    "status == open, status%20%3D%3D%20open",
+    "key=a-umlaut-ä, key%3Da-umlaut-%C3%A4",
+    "ääääääääää    , %C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4%C3%A4",
+    "a b c         , a%20b%20c",
+  })
+  void uriEncode(String s, String expected) {
+    assertThat(PercentCodec.encode(s).toString(), is(expected));
+    StringBuffer stringBuffer = new StringBuffer("foo = ");
+    PercentCodec.encode(stringBuffer, s);
+    assertThat(stringBuffer.toString(), is("foo = " + expected));
+  }
+}


### PR DESCRIPTION
RFC 3986 mandates that only percent encoding is used for
HTTP requests. Using a plus to encode a space is wrong:
https://datatracker.ietf.org/doc/html/rfc3986

Wrong encoding of status == open:
`?query=status+%3D%3D+open`

Correct encoding of status == open:
`?query=status%20%3D%3D%20open`

Approach:

Implement PercentCodec.

Put a warning into the StringUtil.urlEncode javadoc.

Replace StringUtil.urlEncode calls by PercentCodec calls.