### PR TITLE
RMB-844: Properly report POST tenant with null exception message

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -283,10 +283,12 @@ public class TenantAPI implements Tenant {
           }
           return loadData(tenantAttributes, job.getTenant(), headers, context);
         })
-        .onComplete(res -> {
-          if (res.failed()) {
-            job.setError(res.cause().getMessage());
+        .onFailure(cause -> {
+          String message = cause.getMessage();
+          if (message == null) {
+            message = cause.getClass().getName();
           }
+          job.setError(message);
         }).mapEmpty();
   }
 


### PR DESCRIPTION
If a POST tenant fails TenantAPI should report the failure by setting the job error.

However, if the failure message is null the job error is set to null, this indicates no error.

Approach:

If failure message is null report the exception class name.