### PR TITLE
RMB-848: Always close PostgresTester

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -55,7 +55,9 @@ If [DB\_\* environment variable database configuration](../README.md#environment
 Postgres instance. See [RMB-826](https://issues.folio.org/browse/RMB-826).
 
 `PostgresClient.stopEmbeddedPostgres` replaced with
-`PostgresClient.stopPostgresTester`.
+`PostgresClient.stopPostgresTester`. The invocation is usually *not* needed
+and should be removed because PostgresClient and Testcontainers core will automatically
+close and remove the container.
 
 `PostgresClient.startEmbeddedPostgres` replaced with
 `PostgresClient.startPostgresTester`. It is usually not necessary to

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -199,22 +199,14 @@ public class PostgresClient {
    * <p>If database configuration is already provided (DB_* env variables or JSON config file),
    * this call is ignored and testing is performed against the database instance given by configuration.
    *
-   * <p>Setting the same PostgresTester instance that is already set does nothing. This allows to reuse
-   * a database that some other test has already created, for example to copy a database with sample
-   * data using the <a href="https://stackoverflow.com/a/876565">TEMPLATE method</a>. See also
-   * <a href="https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers">
-   * singleton testcontainers</a>.
-   *
-   * <p>Setting a different PostgresTester instance closes the old PostgresTester instance.
+   * <p>Setting the same or a different PostgresTester instance invokes the close method of the
+   * old PostgresTester instance.
    *
    * <p>See {@link org.folio.postgres.testing.PostgresTesterContainer#PostgresTesterContainer()}
    *
    * @param tester instance to use for testing.
    */
   public static void setPostgresTester(PostgresTester tester) {
-    if (tester == postgresTester) {
-      return;
-    }
     stopPostgresTester();
     postgresTester = tester;
   }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -55,6 +55,7 @@ import org.folio.rest.persist.interfaces.Results;
 import org.folio.rest.security.AES;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.MetadataUtil;
+import org.folio.rest.tools.utils.ModuleName;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.util.PostgresTester;
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -195,8 +195,8 @@ public class PostgresClientTest {
 
   @Test
   public void closePostgresTester() {
-    var postgresTester1 = mock(PostgresTester.class);
-    var postgresTester2 = mock(PostgresTester.class);
+    PostgresTester postgresTester1 = mock(PostgresTester.class);
+    PostgresTester postgresTester2 = mock(PostgresTester.class);
     PostgresClient.setPostgresTester(postgresTester1);
     PostgresClient.setPostgresTester(postgresTester1);
     verify(postgresTester1, times(1)).close();

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -199,11 +199,12 @@ public class PostgresClientTest {
     var postgresTester2 = mock(PostgresTester.class);
     PostgresClient.setPostgresTester(postgresTester1);
     PostgresClient.setPostgresTester(postgresTester1);
-    verify(postgresTester1, never()).close();
+    verify(postgresTester1, times(1)).close();
     PostgresClient.setPostgresTester(postgresTester2);
-    verify(postgresTester1).close();
+    verify(postgresTester1, times(2)).close();
     PostgresClient.stopPostgresTester();
-    verify(postgresTester2).close();
+    verify(postgresTester1, times(2)).close();
+    verify(postgresTester2, times(1)).close();
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -41,6 +42,7 @@ import org.folio.rest.persist.facets.FacetField;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.util.PostgresTester;
 import org.folio.util.ResourceUtil;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.persist.PostgresClient.QueryHelper;
@@ -189,6 +191,19 @@ public class PostgresClientTest {
     // TODO: enable when available in vertx-sql-client/vertx-pg-client
     // https://issues.folio.org/browse/RMB-657
     // assertThat(1000, is(options.getConnectionReleaseDelay()));
+  }
+
+  @Test
+  public void closePostgresTester() {
+    var postgresTester1 = mock(PostgresTester.class);
+    var postgresTester2 = mock(PostgresTester.class);
+    PostgresClient.setPostgresTester(postgresTester1);
+    PostgresClient.setPostgresTester(postgresTester1);
+    verify(postgresTester1, never()).close();
+    PostgresClient.setPostgresTester(postgresTester2);
+    verify(postgresTester1).close();
+    PostgresClient.stopPostgresTester();
+    verify(postgresTester2).close();
   }
 
   @Test


### PR DESCRIPTION
Add javadoc and a unit test to ensure that PostgresTester is always closed, even when the same PostgresTester instance is used twice in sequence.