### PR TITLE
RMB-849: Remove ModuleName class from domain-models-api-interfaces

### DIFF
--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -129,6 +129,25 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <id>delete-modulename-class</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <delete dir="${project.build.directory}/generated-sources/modulename"/>
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 </project>

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ModuleNameWriter.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ModuleNameWriter.java
@@ -14,6 +14,9 @@ public class ModuleNameWriter {
       // {} is replaced before writing this .java file
       + "  private static final String MODULE_NAME = \"{}\";\n"
       + "\n"
+      + "  /**\n"
+      + "   * The module name with minus replaced by underscore, for example {@code mod_foo_bar}.\n"
+      + "   */\n"
       + "  public static String getModuleName() {\n"
       + "    return MODULE_NAME;\n"
       + "  }\n"

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -1,12 +1,15 @@
 package org.folio.rest.persist;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.collection.ArrayMatching.arrayContaining;
 import static org.hamcrest.collection.ArrayMatching.hasItemInArray;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
@@ -734,6 +737,13 @@ public class PostgresClientTest {
     assertEquals((Integer)30, PostgresClient.getTotalRecords(10, 20, 20, 10));
 
     assertEquals((Integer) 25, PostgresClient.getTotalRecords(5, 20, 20, 10));
+  }
+
+  @Test
+  public void getModuleName() {
+    Exception e = assertThrows(RuntimeException.class, () -> PostgresClient.getModuleName("foo.Bar"));
+    assertThat(e.getMessage(), containsString("src/test/java/foo/Bar.java"));
+    assertThat(e.getCause(), is(instanceOf(ClassNotFoundException.class)));
   }
 
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -1,0 +1,10 @@
+package org.folio.rest.tools.utils;
+
+public class ModuleName {
+  /**
+   * The module name with minus replaced by underscore, for example {@code mod_foo_bar}.
+   */
+  public static String getModuleName() {
+    return "raml_module_builder";
+  }
+}


### PR DESCRIPTION
domain-models-api-interfaces (and domain-models-runtime
that depends on it) ships with a ModuleName class with
getModuleName() returning "raml_module_builder".

An RMB based module creates a correct ModuleName class
when running domain-models-maven-plugin.

If we are lucky the latter is included in the final jar.
For mod-feesfines I sometimes have integration tests failure
because of wrong order resulting in the
wrong "raml_module_builder" where it should be "mod_feesfines".

Removing ModuleName class from domain-models-api-interfaces jar
resolves this issue; it requires reflection to load
ModuleName class, though.