### PR TITLE
RMB-853: ModuleName.getModuleVersion()

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -192,6 +192,8 @@ Add FOLIO Maven repository for plugins after existing `<repositories>` section:
 
 Replace `PomReader.INSTANCE.getModuleName()` by `ModuleName.getModuleName()`.
 
+Replace `PomReader.INSTANCE.getVersion()` by `ModuleName.getModuleVersion()`.
+
 Replace any joda class usage by a java.time class usage. RMB no longer ships with
 joda-time that is deprecated because the replacement java.time has been in JDK core
 since Java 8.

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ModuleNameWriter.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/ModuleNameWriter.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import org.apache.maven.project.MavenProject;
 
 public class ModuleNameWriter {
@@ -11,11 +12,22 @@ public class ModuleNameWriter {
       "package org.folio.rest.tools.utils;\n"
       + "\n"
       + "public class ModuleName {\n"
-      // {} is replaced before writing this .java file
-      + "  private static final String MODULE_NAME = \"{}\";\n"
+      // {name} and {version} are replaced before writing this .java file
+      + "  private static final String MODULE_NAME = \"{name}\";\n"
+      + "  private static final String MODULE_VERSION = \"{version}\";\n"
       + "\n"
+      + "  /**\n"
+      + "   * The module name with minus replaced by underscore, for example {@code mod_foo_bar}.\n"
+      + "   */\n"
       + "  public static String getModuleName() {\n"
       + "    return MODULE_NAME;\n"
+      + "  }\n"
+      + "\n"
+      + "  /**\n"
+      + "   * The module version taken from pom.xml at compile time.\n"
+      + "   */\n"
+      + "  public static String getModuleVersion() {\n"
+      + "    return MODULE_VERSION;\n"
       + "  }\n"
       + "}\n"
       + "";
@@ -30,9 +42,9 @@ public class ModuleNameWriter {
     project.addCompileSourceRoot(sourceRoot.getPath());
     Path dir = new File(sourceRoot, "org/folio/rest/tools/utils").toPath();
     Files.createDirectories(dir);
-    project.getParentArtifact();
-    String moduleName = project.getParent() == null ? project.getArtifactId() : project.getParent().getArtifactId();
-    moduleName = moduleName.replace('-', '_');
-    Files.writeString(dir.resolve("ModuleName.java"), JAVA.replace("{}", moduleName));
+    MavenProject root = Objects.requireNonNullElse(project.getParent(), project);
+    String name = root.getArtifactId().replace('-', '_');
+    String version = root.getVersion();
+    Files.writeString(dir.resolve("ModuleName.java"), JAVA.replace("{name}", name).replace("{version}", version));
   }
 }

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/ModuleNameTest.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/ModuleNameTest.java
@@ -1,0 +1,18 @@
+package org.folio.rest;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.folio.rest.tools.utils.ModuleName;
+import org.junit.jupiter.api.Test;
+
+class ModuleNameTest {
+
+  @Test
+  void moduleName() {
+    assertThat(ModuleName.getModuleName(), is("raml_module_builder"));
+    assertThat(ModuleName.getModuleVersion(), matchesPattern("\\d+\\.\\d+\\.\\d.*"));
+  }
+
+}


### PR DESCRIPTION
RMB 33.0.0 removed PomReader.INSTANCE.getVersion().

Some RMB based modules need this, for example

MODPUBSUB-179 = https://github.com/folio-org/mod-pubsub/pull/160

Solution:

Provide ModuleName.getModuleVersion() that returns the same value as PomReader.INSTANCE.getVersion() did before.