### PR TITLE
RMB-858: HttpClientMock2 not enabled due to race condition

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.resource.DomainModelConsts;
+import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 import org.folio.rest.tools.utils.InterfaceToImpl;
 import org.folio.rest.tools.utils.LogUtil;
@@ -116,6 +117,7 @@ public class RestVerticle extends AbstractVerticle {
           String mockMode = config().getString(HttpClientMock2.MOCK_MODE);
           if (mockMode != null) {
             System.setProperty(HttpClientMock2.MOCK_MODE, mockMode);
+            HttpClientFactory.setMockEnabled(true);
           }
           runPostDeployHook(res2 -> {
             if (!res2.succeeded()) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
@@ -1,10 +1,22 @@
 package org.folio.rest.tools.client;
 
+import io.vertx.core.DeploymentOptions;
+import org.folio.rest.RestVerticle;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.tools.client.test.HttpClientMock2;
 
 /**
- * Factory of HTTP clients with interface {@link HttpClientInterface}
+ * Factory of HTTP clients with interface {@link HttpClientInterface}.
+ *
+ * <p>It returns an {@link HttpClientMock2} instance if mocking is enabled and
+ * an {@link HttpModuleClient2} instance if mocking is disabled.
+ *
+ * <p>Mocking is disabled by default. It can be enabled by setting the system property
+ * {@link HttpClientMock2.MOCK_MODE} to any value (for example in pom.xml),
+ * or by setting the {@link DeploymentOptions} property {@link HttpClientMock2.MOCK_MODE}
+ * to any value when deploying {@link RestVerticle}. It can programmatically been enabled
+ * or disabled by calling {@link #setMockEnabled(boolean)}.
+ *
  * @deprecated Use {@link io.vertx.ext.web.client.WebClient} for generic HTTP client or generated client and
  * mock server with {@link io.vertx.core.Vertx#createHttpServer()} or use a mocking utility.
  */
@@ -18,6 +30,10 @@ public class HttpClientFactory {
     if(System.getProperty(HttpClientMock2.MOCK_MODE) != null ){
       mock = true;
     }
+  }
+
+  public static void setMockEnabled(boolean mock) {
+    HttpClientFactory.mock = mock;
   }
 
   public static HttpClientInterface getHttpClient(String host, int port, String tenantId, boolean keepAlive, int connTO,


### PR DESCRIPTION
Building or releasing mod-user-import master fails when run locally from the shell.

The unit tests succeed when run from IDE and on Jenkins.

Cause is a race condition:
https://github.com/folio-org/raml-module-builder/blob/v33.0.1/domain-models-runtime/src/main/java/org/folio/rest/RestVerticle.java#L114-L119
https://github.com/folio-org/raml-module-builder/blob/v33.0.1/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java#L17-L21

Mocking can be enabled by setting a Verticle DeploymentOption.
RestVerticle reads it and passes this information to
HttpClientFactory by setting a system property.
HttpClientFactory checks the system property when the class
loader loads the HttpClientFactory class, this might be
before RestVerticle sets the system property (race condition).

Solution:
RestVerticle should also programmatically enable mocking in HttpClientFactory.