### PR TITLE
RMB-859: Remove xerces:xmlParserAPIs dependency

### DIFF
--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -66,12 +66,6 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xmlParserAPIs</artifactId>
-      <version>2.6.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -118,12 +118,6 @@
       <artifactId>vertx-pg-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xmlParserAPIs</artifactId>
-      <version>2.6.2</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.ws.rs</groupId>
       <artifactId>jsr311-api</artifactId>
       <version>1.1.1</version>


### PR DESCRIPTION
RMB ships with xerces:xmlParserAPIs:2.6.2.

This library has been included into JDK since Java 9.

Using any of these classes (org.w3c.dom.**) causes this
compile error in some Java compilers (for example the one used by Eclipse):

`The package org.w3c.dom is accessible from more than one module: <unnamed>, java.xml`

Solution:

Remove this dependency.