### PR TITLE
RMB-862: Upgrade Vert.x from 4.1.0 to 4.1.2

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -4,7 +4,7 @@ These are notes to assist upgrading to newer versions.
 See the [NEWS](../NEWS.md) summary of changes for each version.
 
 <!-- ../../okapi/doc/md2toc -l 2 -h 3 upgrading.md -->
-* [Version 33.0](#version-331)
+* [Version 33.1](#version-331)
 * [Version 33.0](#version-330)
 * [Version 32.0](#version-320)
 * [Version 31.0](#version-310)

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -21,26 +21,33 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 ## Version 33.0
 
+#### [RMB-862](https://issues.folio.org/browse/RMB-862) Upgrade to Vert.x 4.1.2
 
-#### [RMB-851](https://issues.folio.org/browse/RMB-851) Upgrade to Vert.x 4.1.0
-
-Module should depend on that version or a later version in 4.1.0 series.
+Module should depend on Vert.x 4.1.2 or a later version in 4.1.x series.
 
 Module should use `vertx-stack-depchain`:
 
 ```
-  <properties>
-    <vertx.version>4.1.0</vertx.version>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>${vertx.version}</version>
+        <version>4.1.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+    </dependencies>
+  </dependencyManagement>
+```
+
+The [FOLIO fork of the vertx-sql-client and vertx-pg-client](https://github.com/folio-org/vertx-sql-client/releases)
+is no longer needed because our fix has been merged upstream for
+Vert.x >= 4.1.1.
+
+Therefore _remove_ these dependencies from the pom.xml:
+
+```
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-sql-client</artifactId>
@@ -51,8 +58,6 @@ Module should use `vertx-stack-depchain`:
         <artifactId>vertx-pg-client</artifactId>
         <version>${vertx.version}-FOLIO</version>
       </dependency>
-    </dependencies>
-  </dependencyManagement>
 ```
 
 Module should use the vertx, netty, jackson and tcnative dependencies from `vertx-stack-depchain` to avoid

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -4,6 +4,7 @@ These are notes to assist upgrading to newer versions.
 See the [NEWS](../NEWS.md) summary of changes for each version.
 
 <!-- ../../okapi/doc/md2toc -l 2 -h 3 upgrading.md -->
+* [Version 33.0](#version-331)
 * [Version 33.0](#version-330)
 * [Version 32.0](#version-320)
 * [Version 31.0](#version-310)
@@ -19,7 +20,7 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 * [Version 25](#version-25)
 * [Version 20](#version-20)
 
-## Version 33.0
+## Version 33.1
 
 #### [RMB-862](https://issues.folio.org/browse/RMB-862) Upgrade to Vert.x 4.1.2
 
@@ -60,10 +61,12 @@ Therefore _remove_ these dependencies from the pom.xml:
       </dependency>
 ```
 
+## Version 33.0
+
 Module should use the vertx, netty, jackson and tcnative dependencies from `vertx-stack-depchain` to avoid
 old version with security vulnerabilities: Either remove the explicit vertx, netty, jackson and tcnative
 dependencies from the pom.xml or use the
-[versions that vertx-stack-depchain` ships with](https://github.com/vert-x3/vertx-dependencies/blob/4.1.0/pom.xml),
+[versions that vertx-stack-depchain` ships with](https://github.com/vert-x3/vertx-dependencies/blob/4.1.2/pom.xml),
 for example:
 
 ```

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgPoolBase.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgPoolBase.java
@@ -1,0 +1,65 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import java.util.function.Function;
+
+/**
+ * Base mock implementation to be extended for testing.
+ */
+public class PgPoolBase implements PgPool {
+
+  @Override
+  public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+    getConnection().onComplete(handler);
+  }
+
+  @Override
+  public Future<SqlConnection> getConnection() {
+    return Future.succeededFuture();
+  }
+
+  @Override
+  public Query<RowSet<Row>> query(String sql) {
+    return null;
+  }
+
+  @Override
+  public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
+    return null;
+  }
+
+  @Override
+  public void close(Handler<AsyncResult<Void>> handler) {
+    close().onComplete(handler);
+  }
+
+  @Override
+  public Future<Void> close() {
+    return Future.succeededFuture();
+  }
+
+  @Override
+  public int size() {
+    return 0;
+  }
+
+  @Override
+  public PgPool connectHandler(Handler<SqlConnection> handler) {
+    return this;
+  }
+
+  @Override
+  public PgPool connectionProvider(Function<Context, Future<SqlConnection>> provider) {
+    return this;
+  }
+
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2003,38 +2003,7 @@ public class PostgresClientIT {
    * a null result value and success status.
    */
   private PostgresClient postgresClientNullConnection() {
-    PgPool client = new PgPool() {
-      @Override
-      public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        getConnection().onComplete(handler);
-      }
-
-      @Override
-      public Future<SqlConnection> getConnection() {
-        return Future.succeededFuture();
-      }
-
-      @Override
-      public Query<RowSet<Row>> query(String s) {
-        return null;
-      }
-
-      @Override
-      public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-        return null;
-      }
-
-      @Override
-      public void close(Handler<AsyncResult<Void>> handler) {
-        handler.handle(close());
-      }
-
-      @Override
-      public Future<Void> close() {
-        // nothing to do
-        return Future.succeededFuture();
-      }
-    };
+    PgPool client = new PgPoolBase();
     try {
       PostgresClient postgresClient = new PostgresClient(vertx, TENANT);
       postgresClient.setClient(client);
@@ -2048,36 +2017,10 @@ public class PostgresClientIT {
    * @return a PostgresClient where getConnection(handler) invokes the handler with a failure.
    */
   private PostgresClient postgresClientGetConnectionFails() {
-    PgPool client = new PgPool() {
-
-      @Override
-      public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        getConnection().onComplete(handler);
-      }
-
+    PgPool client = new PgPoolBase() {
       @Override
       public Future<SqlConnection> getConnection() {
         return Future.failedFuture("postgresClientGetConnectionFails");
-      }
-
-      @Override
-      public Query<RowSet<Row>> query(String s) {
-        return null;
-      }
-
-      @Override
-      public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-        return null;
-      }
-
-      @Override
-      public void close(Handler<AsyncResult<Void>> handler) {
-
-      }
-
-      @Override
-      public Future<Void> close() {
-        return null;
       }
     };
     try {
@@ -2177,35 +2120,10 @@ public class PostgresClientIT {
       }
     };
 
-    PgPool client = new PgPool() {
-      @Override
-      public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        getConnection().onComplete(handler);
-      }
-
+    PgPool client = new PgPoolBase() {
       @Override
       public Future<SqlConnection> getConnection() {
         return Future.succeededFuture(pgConnection);
-      }
-
-      @Override
-      public Query<RowSet<Row>> query(String s) {
-        return null;
-      }
-
-      @Override
-      public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-        return null;
-      }
-
-      @Override
-      public void close(Handler<AsyncResult<Void>> handler) {
-
-      }
-
-      @Override
-      public Future<Void> close() {
-        return null;
       }
     };
     try {
@@ -2329,35 +2247,10 @@ public class PostgresClientIT {
       }
     };
 
-    PgPool client = new PgPool() {
-      @Override
-      public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        getConnection().onComplete(handler);
-      }
-
+    PgPool client = new PgPoolBase() {
       @Override
       public Future<SqlConnection> getConnection() {
         return Future.succeededFuture(pgConnection);
-      }
-
-      @Override
-      public Query<RowSet<Row>> query(String s) {
-        return null;
-      }
-
-      @Override
-      public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-        return null;
-      }
-
-      @Override
-      public void close(Handler<AsyncResult<Void>> handler) {
-        close().onComplete(handler);
-      }
-
-      @Override
-      public Future<Void> close() {
-        return Future.succeededFuture();
       }
     };
     try {
@@ -2456,35 +2349,10 @@ public class PostgresClientIT {
         return null;
       }
     };
-    PgPool client = new PgPool() {
-      @Override
-      public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-        getConnection().onComplete(handler);
-      }
-
+    PgPool client = new PgPoolBase() {
       @Override
       public Future<SqlConnection> getConnection() {
         return Future.succeededFuture(pgConnection);
-      }
-
-      @Override
-      public Query<RowSet<Row>> query(String s) {
-        return null;
-      }
-
-      @Override
-      public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-        return null;
-      }
-
-      @Override
-      public void close(Handler<AsyncResult<Void>> handler) {
-
-      }
-
-      @Override
-      public Future<Void> close() {
-        return Future.succeededFuture();
       }
     };
     try {

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
@@ -525,12 +525,7 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     try {
       PostgresClient postgresClient = new PostgresClient(vertx, tenant);
       PgPool ePool = postgresClient.getClient();
-      PgPool client = new PgPool() {
-
-        @Override
-        public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
-          getConnection().onComplete(handler);
-        }
+      PgPool client = new PgPoolBase() {
 
         @Override
         public Future<SqlConnection> getConnection() {
@@ -545,11 +540,6 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
         @Override
         public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
           return ePool.preparedQuery(s);
-        }
-
-        @Override
-        public void close(Handler<AsyncResult<Void>> handler) {
-          close().onComplete(handler);
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.6</aspectj.version>
     <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <maven.version>3.6.3</maven.version>
-    <vertx.version>4.1.0</vertx.version>
+    <vertx.version>4.1.2</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -61,16 +61,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
Most notable fix is the "prepared statement ... already exists" issue:
https://github.com/eclipse-vertx/vertx-sql-client/pull/737

The Vertx team has merged our fix upstream therefore we no longer need
to use our fork https://github.com/folio-org/vertx-sql-client

Vert.x 4.1.2 adds three new methods to PgPool. Instead of adding
them to our multiple PgPool mocks the duplicated methods are
extracted into PgPoolBase.