### PR TITLE
RMB-864: Ignore deleted index in schema.json

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/util/DbSchemaUtils.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/util/DbSchemaUtils.java
@@ -10,6 +10,7 @@ import org.folio.dbschema.ForeignKeys;
 import org.folio.dbschema.Index;
 import org.folio.dbschema.Schema;
 import org.folio.dbschema.Table;
+import org.folio.dbschema.TableOperation;
 
 /**
  * Help method to extract info from RMB db schema.json
@@ -40,6 +41,9 @@ public class DbSchemaUtils {
   public static Index getIndex(String cqlIndex, List<Index> indexes) {
     if (indexes != null) {
       for (Index i : indexes) {
+        if (TableOperation.DELETE == i.gettOps()) {
+          continue;
+        }
         if (cqlIndex.equals(i.getFieldName())) {
           return i;
         }

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/DeletedIndexTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/DeletedIndexTest.java
@@ -1,0 +1,22 @@
+package org.folio.cql2pgjson;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.Test;
+
+public class DeletedIndexTest {
+
+  @Test
+  public void multiFieldNamesNonUniqueIndex() throws Exception {
+    CQL2PgJSON cql2pgJson = new CQL2PgJSON("users");
+    cql2pgJson.setDbSchemaPath("templates/db_scripts/schemaWithDeletedIndex.json");
+    // uniqueIndex, "caseSensitive": true, "removeAccents": false
+    assertThat(cql2pgJson.toSql("a == x").toString(), containsString("LIKE 'x'"));
+    // index, "caseSensitive": false, "removeAccents": false
+    assertThat(cql2pgJson.toSql("b == y").toString(), containsString("LIKE lower('y')"));
+    // full text index, "caseSensitive": false, "removeAccents": true
+    assertThat(cql2pgJson.toSql("c == z").toString(), containsString("LIKE lower(f_unaccent('z'))"));
+  }
+
+}

--- a/cql2pgjson/src/test/resources/templates/db_scripts/schemaWithDeletedIndex.json
+++ b/cql2pgjson/src/test/resources/templates/db_scripts/schemaWithDeletedIndex.json
@@ -1,0 +1,67 @@
+{
+  "tables": [
+    {
+      "tableName": "users",
+      "uniqueIndex": [
+        {
+          "fieldName": "a",
+          "tOps": "ADD",
+          "caseSensitive": true,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "b",
+          "tOps": "DELETE",
+          "caseSensitive": true,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "c",
+          "tOps": "DELETE",
+          "caseSensitive": true,
+          "removeAccents": false
+        }
+      ],
+      "index": [
+        {
+          "fieldName": "a",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "b",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "c",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": false
+        }
+      ],
+      "fullTextIndex": [
+        {
+          "fieldName": "a",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "b",
+          "tOps": "DELETE",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
+          "fieldName": "c",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
RMB (CQL2PgJSON, DbSchemaUtils) uses an index that has been deleted and has tOps been set to DELETE.