### PR TITLE
RMB-865: Ensure that PgUtil returns 400 (not 500) on invalid CQL

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -736,9 +736,16 @@ public final class PgUtil {
       PreparedCQL preparedCql = new PreparedCQL(table, cqlWrapper, okapiHeaders);
       return get(preparedCql, clazz, collectionClazz, okapiHeaders, vertxContext, responseDelegateClass);
     } catch (Exception e) {
+      final Method respond500;
+      try {
+        respond500 = responseDelegateClass.getMethod(RESPOND_500_WITH_TEXT_PLAIN, Object.class);
+      } catch (Exception e2) {
+        logger.error(e2.getMessage(), e2);
+        return response(e2.getMessage(), null, null);
+      }
       logger.error(e.getMessage(), e);
       // invalid CQL is handled by get(...), here we get Exception about invalid table
-      return response(e.getMessage(), null, null);
+      return response(e.getMessage(), respond500, respond500);
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -736,6 +736,7 @@ public final class PgUtil {
       PreparedCQL preparedCql = new PreparedCQL(table, cqlWrapper, okapiHeaders);
       return get(preparedCql, clazz, collectionClazz, okapiHeaders, vertxContext, responseDelegateClass);
     } catch (Exception e) {
+      logger.error(e.getMessage(), e);
       final Method respond500;
       try {
         respond500 = responseDelegateClass.getMethod(RESPOND_500_WITH_TEXT_PLAIN, Object.class);
@@ -743,7 +744,6 @@ public final class PgUtil {
         logger.error(e2.getMessage(), e2);
         return response(e2.getMessage(), null, null);
       }
-      logger.error(e.getMessage(), e);
       // invalid CQL is handled by get(...), here we get Exception about invalid table
       return response(e.getMessage(), respond500, respond500);
     }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -724,30 +724,21 @@ public final class PgUtil {
    *    must have these methods: respond200(C), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
    * @return future  where to return the result created by the responseDelegateClass
    */
-  @SuppressWarnings({"unchecked", "squid:S107"})     // Method has >7 parameters
+  @SuppressWarnings({"squid:S107"})     // Method has >7 parameters
   public static <T, C> Future<Response> get(String table, Class<T> clazz, Class<C> collectionClazz,
       String cql, int offset, int limit,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> responseDelegateClass) {
-
-    final Method respond500;
-    final Method respond400;
-    try {
-      respond500 = responseDelegateClass.getMethod(RESPOND_500_WITH_TEXT_PLAIN, Object.class);
-      respond400 = responseDelegateClass.getMethod(RESPOND_400_WITH_TEXT_PLAIN, Object.class);
-    } catch (Exception e) {
-      logger.error(e.getMessage(), e);
-      return response(e.getMessage(), null, null);
-    }
 
     try {
       CQL2PgJSON cql2pgJson = new CQL2PgJSON(table + "." + JSON_COLUMN);
       CQLWrapper cqlWrapper = new CQLWrapper(cql2pgJson, cql, limit, offset);
       PreparedCQL preparedCql = new PreparedCQL(table, cqlWrapper, okapiHeaders);
       return get(preparedCql, clazz, collectionClazz, okapiHeaders, vertxContext, responseDelegateClass);
-    } catch (FieldException e) {
+    } catch (Exception e) {
       logger.error(e.getMessage(), e);
-      return response(e.getMessage(), respond400, respond500);
+      // invalid CQL is handled by get(...), here we get Exception about invalid table
+      return response(e.getMessage(), null, null);
     }
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
@@ -470,6 +470,20 @@ public class PgUtilIT {
   }
 
   @Test
+  public void getWithInvalidTable(TestContext testContext) {
+    PgUtil.get("foo'bar", User.class, UserdataCollection.class, "username=b", 0, 9,
+        okapiHeaders, vertx.getOrCreateContext(), Users.GetUsersResponse.class,
+        asyncAssertSuccess(testContext, 500));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void getWithInvalidTableWithout500(TestContext testContext) {
+    PgUtil.get("foo'bar", User.class, UserdataCollection.class, "username=b", 0, 9,
+        okapiHeaders, vertx.getOrCreateContext(), ResponseWithout500.class,
+        asyncAssertSuccess(testContext, 500));
+  }
+
+  @Test
   public void getResponseWithout500(TestContext testContext) {
     PgUtil.get("users", User.class, UserdataCollection.class, "username=b", 0, 9,
         okapiHeaders, vertx.getOrCreateContext(), ResponseWithout500.class,


### PR DESCRIPTION
Add unit tests for invalid CQL that checks that 400 is returned.

No code change to PgUtil because it already returns 400 on invalid CQL:
* get
* getWithOptimizedSql
* streamGet
* delete

However, this pull request makes a PgUtil code change to fix the HTTP status on invalid table name that
should return 500 but has returned 400.