### PR TITLE
"replaceAll" modified to replace in Criteria.class

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Criteria/Criteria.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Criteria/Criteria.java
@@ -114,7 +114,7 @@ public class Criteria {
       from = new From();
       from.setSnippet(ARRAY_FROM_CLAUSE + "("
         + PostgresClient.DEFAULT_JSONB_FIELD_NAME + GET_JSON_FIELD + arrayField + ")");
-      from.setAsValue(field.get(0).replaceAll("^'|'$", "")); //remove ''
+      from.setAsValue(field.get(0).replace("'", "")); //remove ''
     }
   }
 
@@ -122,7 +122,7 @@ public class Criteria {
     if (isArray()) {
       select = new Select();
       //replace surrounding '' from the field name
-      select.setSnippet(field.get(0).replaceAll("^'|'$", ""));
+      select.setSnippet(field.get(0).replace("'", ""));
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/facets/FacetField.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/facets/FacetField.java
@@ -23,6 +23,7 @@ public class FacetField {
     this(path2facet, amountOfValues2return, null);
   }
 
+  @SuppressWarnings("java:S5850")//Line:34 (in regex '$' has higher precedence than '|' , but it is a small regex so we can keep it)
   private FacetField(String path2facet, int topFacets2return, String alias){
     this.fieldPath = path2facet;
     this.topFacets2return = topFacets2return;
@@ -31,7 +32,6 @@ public class FacetField {
     }
     //alias is the last field name wrapped in ''
     this.alias = path2facet.trim().replaceAll(".*->>'|'$", "");
-
     if(path2facet.contains("jsonb_array_elements(")){
       //array path , get last occurrence of what is in between ''
       Matcher m = QUOTES_PATTERN.matcher(path2facet);

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HTTPJsonResponseHandler.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HTTPJsonResponseHandler.java
@@ -64,6 +64,11 @@ class HTTPJsonResponseHandler implements Handler<AsyncResult<HttpResponse<Buffer
         HttpModuleClient2.cache.put(endpoint, cf.get());
       } catch (Exception e) {
         log.error(e.getMessage(), e);
+
+        //InterruptedExceptions should never be ignored in the code
+        if(e instanceof InterruptedException){
+        //Restore interrupted state...
+         Thread.currentThread().interrupt();}
       }
     }
   }


### PR DESCRIPTION
As per my understanding,  Line:-117 & 125  "field.get(0).replaceAll("^'|'$", "")" is used for removing single quotes from the field. That can be done with "field.get(0).replace("'", "")" also.  