### PR TITLE
RMB-874: Update Vert.x to 4.1.4 and okapi-common to 4.9.0

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -24,7 +24,8 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 #### [RMB-862](https://issues.folio.org/browse/RMB-862) Upgrade to Vert.x 4.1.2
 
-Module should depend on Vert.x 4.1.2 or a later version in 4.1.x series.
+RMB 33.1.0 requires Vert.x 4.1.2 and okapi-common 4.8.2.
+RMB >= 33.1.1 requires Vert.x >= 4.1.3 and okapi-common >= 4.9.0.
 
 Module should use `vertx-stack-depchain`:
 
@@ -34,7 +35,7 @@ Module should use `vertx-stack-depchain`:
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.1.2</version>
+        <version>4.1.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -22,7 +22,7 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 
 ## Version 33.1
 
-#### [RMB-862](https://issues.folio.org/browse/RMB-862) Upgrade to Vert.x 4.1.2
+#### [RMB-862](https://issues.folio.org/browse/RMB-862), [RMB-874](https://issues.folio.org/browse/RMB-874) Upgrade to Vert.x 4.1.2/4.1.4
 
 RMB 33.1.0 requires Vert.x 4.1.2 and okapi-common 4.8.2.
 RMB >= 33.1.1 requires Vert.x >= 4.1.3 and okapi-common >= 4.9.0.

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.6</aspectj.version>
     <junit-jupiter-version>5.7.0</junit-jupiter-version>
     <maven.version>3.6.3</maven.version>
-    <vertx.version>4.1.2</vertx.version>
+    <vertx.version>4.1.4</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -182,7 +182,7 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.8.0</version>
+        <version>4.9.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Running a module with RMB 33.1.0 and Vert.x >= 4.1.3 causes this failure at runtime:

java.lang.NoSuchMethodError: 'java.lang.Object io.vertx.core.Context.getLocal(java.lang.String)'
        at org.folio.okapi.common.logging.FolioLoggingContext.lookup(FolioLoggingContext.java:62)

Vert.x <= 4.1.2 uses Context.getLocal(String).
Vert.x >= 4.1.3 uses Context.getLocal(Object).
https://github.com/eclipse-vertx/vert.x/commit/4d408d28d764d1eac65dccefa1578251f0060e5f

okapi-common < 4.9.0 uses Vert.x <= 4.1.2 yielding Context.getLocal(String).
okapi-common >= 4.9.0 uses Vert.x >= 4.1.3 yielding Context.getLocal(Object).
https://github.com/folio-org/okapi/commit/625c85021d0689fdc3872048a4b7249efc5c771b