### PR TITLE
RMB-664: One connection pool for all tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ RMB implementing modules expect a set of environment variables to be passed in a
  - DB_QUERYTIMEOUT
  - DB_CHARSET
  - DB_MAXPOOLSIZE
+ - DB_MAXSHAREDPOOLSIZE
  - DB_CONNECTIONRELEASEDELAY
  - DB_EXPLAIN_QUERY_THRESHOLD
 
@@ -364,7 +365,9 @@ Environment variables with periods/dots in their names are deprecated in RMB bec
 
 See the [Vert.x Async PostgreSQL Client Configuration documentation](https://vertx.io/docs/vertx-mysql-postgresql-client/java/#_configuration) for the details.
 
-The environment variable `DB_MAXPOOLSIZE` sets the maximum number of concurrent connections for a tenant that one module instance opens. They are only opened if needed. If all connections for a tenant are in use further requests for that tenant will wait until one connnection becomes free. Other tenants and other instances of a module are unaffected. The default is 4.
+The environment variable `DB_MAXPOOLSIZE` sets the maximum number of concurrent connections for a tenant that one module instance opens. They are only opened if needed. If all connections for a tenant are in use further requests for that tenant will wait until one connection becomes free. Other tenants and other instances of a module are unaffected. The default is 4.
+
+The environment variable `DB_MAXSHAREDPOOLSIZE` sets the maximum number of concurrent connections that one module instance opens. They are only opened if needed. If all connections are in use further requests will wait until one connection becomes free. This way one tenant may block other tenants. If the variable is set `DB_MAXPOOLSIZE` is ignored and all connections are shared across tenants.
 
 The environment variable `DB_CONNECTIONRELEASEDELAY` sets the delay in milliseconds after which an idle connection is closed. A connection becomes idle if the query ends, it is not idle if it is waiting for a response. Use 0 to keep idle connections open forever. RMB's default is one minute (60000 ms).
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -131,9 +131,9 @@ public class PostgresClient {
   /**
    * Used only if {@link #sharedPgPool} is true.
    */
-  private static Map<Vertx,PgPool> pgPools = new HashMap<>();
+  private static final Map<Vertx,PgPool> pgPools = new HashMap<>();
   /** map (Vertx, String tenantId) to PostgresClient */
-  private static MultiKeyMap<Object, PostgresClient> connectionPool = MultiKeyMap.multiKeyMap(new HashedMap<>());
+  private static final MultiKeyMap<Object, PostgresClient> connectionPool = MultiKeyMap.multiKeyMap(new HashedMap<>());
 
   private static final Pattern POSTGRES_DOLLAR_QUOTING =
       // \\B = a non-word boundary, the first $ must not be part of an identifier (foo$bar$baz)

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -14,6 +14,7 @@ public enum Envs {
   DB_QUERYTIMEOUT,
   DB_CHARSET,
   DB_MAXPOOLSIZE,
+  DB_MAXSHAREDPOOLSIZE,
   DB_CONNECTIONRELEASEDELAY,
   DB_EXPLAIN_QUERY_THRESHOLD;
 
@@ -45,6 +46,7 @@ public enum Envs {
     switch (envs) {
     case DB_QUERYTIMEOUT:            return "queryTimeout";
     case DB_MAXPOOLSIZE:             return "maxPoolSize";
+    case DB_MAXSHAREDPOOLSIZE:       return "maxSharedPoolSize";
     case DB_CONNECTIONRELEASEDELAY:  return "connectionReleaseDelay";
     case DB_EXPLAIN_QUERY_THRESHOLD: return envs.name();
     default:                         return envs.name().substring(3).toLowerCase();
@@ -57,6 +59,7 @@ public enum Envs {
       case DB_PORT:
       case DB_QUERYTIMEOUT:
       case DB_MAXPOOLSIZE:
+      case DB_MAXSHAREDPOOLSIZE:
       case DB_CONNECTIONRELEASEDELAY:
         return Integer.parseInt(value);
       case DB_EXPLAIN_QUERY_THRESHOLD:

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -104,7 +104,6 @@ public class DemoRamlRestTest {
    * Cleanup: Delete temporary file, close the vert.x instance.
    *
    * @param context  the test context
-   * @throws Throwable
    */
   @AfterClass
   public static void tearDown(TestContext context) {

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -107,16 +107,7 @@ public class DemoRamlRestTest {
    * @throws Throwable
    */
   @AfterClass
-  public static void tearDown(TestContext context) throws Throwable {
-    String sql = "select grantee, table_catalog, privilege_type, table_schema, table_name "
-        + "from information_schema.table_privileges order by grantee, table_schema, table_name "
-        + "where grantee not in ('PUBLIC') AND table_schema NOT IN ('pg_catalog', 'information_schema')";
-    PostgresClient.getInstance(vertx).execute(sql)
-    .onSuccess(rowSet -> {
-      System.out.println("rowSet.size=" + rowSet.size());
-      rowSet.forEach(row -> System.out.println("row: " + row.deepToString()));
-    });
-    Thread.sleep(1000);
+  public static void tearDown(TestContext context) {
     TenantInit.purge(client, 60000).onComplete(context.asyncAssertSuccess(x -> {
       PostgresClient.stopPostgresTester();
       vertx.close(context.asyncAssertSuccess());

--- a/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/DemoRamlRestTest.java
@@ -104,9 +104,19 @@ public class DemoRamlRestTest {
    * Cleanup: Delete temporary file, close the vert.x instance.
    *
    * @param context  the test context
+   * @throws Throwable
    */
   @AfterClass
-  public static void tearDown(TestContext context) {
+  public static void tearDown(TestContext context) throws Throwable {
+    String sql = "select grantee, table_catalog, privilege_type, table_schema, table_name "
+        + "from information_schema.table_privileges order by grantee, table_schema, table_name "
+        + "where grantee not in ('PUBLIC') AND table_schema NOT IN ('pg_catalog', 'information_schema')";
+    PostgresClient.getInstance(vertx).execute(sql)
+    .onSuccess(rowSet -> {
+      System.out.println("rowSet.size=" + rowSet.size());
+      rowSet.forEach(row -> System.out.println("row: " + row.deepToString()));
+    });
+    Thread.sleep(1000);
     TenantInit.purge(client, 60000).onComplete(context.asyncAssertSuccess(x -> {
       PostgresClient.stopPostgresTester();
       vertx.close(context.asyncAssertSuccess());


### PR DESCRIPTION
DB_MAXSHAREDPOOLSIZE uses "SET ROLE ..." to switch to a tenant specific database role with restricted permission.

Vert.x prints a warning "Parameter is_superuser changed to off" or "Parameter is_superuser changed to on" since 4.1.0: https://github.com/eclipse-vertx/vertx-sql-client/commit/0bd1571d033ba35f57d188472c902b81b35dbd11
This should be changed in Vert.x: https://github.com/eclipse-vertx/vertx-sql-client/pull/1060