### PR TITLE
RMB-880: Update Vert.x from 4.1.4 to 4.2.1

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgPoolBase.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgPoolBase.java
@@ -5,6 +5,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.Query;
 import io.vertx.sqlclient.Row;
@@ -34,6 +35,11 @@ public class PgPoolBase implements PgPool {
 
   @Override
   public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
+    return null;
+  }
+
+  @Override
+  public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
     return null;
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
@@ -464,7 +464,7 @@ public class PgUtilIT {
     PostgresClient pg = PostgresClient.getInstance(vertx, "testtenant");
     PgUtil.delete("users1",  "username==delete_test",
         okapiHeaders, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
-        asyncAssertSuccess(testContext, 400, "relation \\\"testtenant_raml_module_builder.users1\\\" does not exist"));
+        asyncAssertSuccess(testContext, 400, "relation \"testtenant_raml_module_builder.users1\" does not exist"));
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -44,6 +44,7 @@ import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.impl.RowImpl;
+import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.Query;
@@ -2107,6 +2108,17 @@ public class PostgresClientIT {
       }
 
       @Override
+      public SqlConnection prepare(String sql, PrepareOptions options,
+          Handler<AsyncResult<PreparedStatement>> handler) {
+        return null;
+      }
+
+      @Override
+      public Future<PreparedStatement> prepare(String s, PrepareOptions prepareOptions) {
+        return null;
+      }
+
+      @Override
       public PgConnection exceptionHandler(Handler<Throwable> handler) {
         return null;
       }
@@ -2144,6 +2156,11 @@ public class PostgresClientIT {
 
       @Override
       public Query<RowSet<Row>> query(String s) {
+        throw new RuntimeException();
+      }
+
+      @Override
+      public PreparedQuery<RowSet<Row>> preparedQuery(String s, PrepareOptions options) {
         throw new RuntimeException();
       }
 
@@ -2212,6 +2229,18 @@ public class PostgresClientIT {
       }
 
       @Override
+      public SqlConnection prepare(String sql, PrepareOptions options,
+          Handler<AsyncResult<PreparedStatement>> handler) {
+        prepare(sql, options).onComplete(handler);
+        return null;
+      }
+
+      @Override
+      public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+        return prepare(sql);
+      }
+
+      @Override
       public PgConnection exceptionHandler(Handler<Throwable> handler) {
         return null;
       }
@@ -2267,6 +2296,11 @@ public class PostgresClientIT {
             return null;
           }
         };
+      }
+
+      @Override
+      public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+        return preparedQuery(sql);
       }
 
       @Override
@@ -2336,6 +2370,17 @@ public class PostgresClientIT {
       }
 
       @Override
+      public SqlConnection prepare(String sql, PrepareOptions options,
+          Handler<AsyncResult<PreparedStatement>> handler) {
+        return null;
+      }
+
+      @Override
+      public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+        return null;
+      }
+
+      @Override
       public PgConnection exceptionHandler(Handler<Throwable> handler) {
         return null;
       }
@@ -2374,6 +2419,11 @@ public class PostgresClientIT {
       @Override
       public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
         return null;
+      }
+
+      @Override
+      public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+        return preparedQuery(sql);
       }
 
       @Override

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -32,11 +32,13 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.impl.RowImpl;
+import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.Query;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.RowDesc;
@@ -344,6 +346,16 @@ public class PostgresClientTest {
     }
 
     @Override
+    public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
+      return prepare(sql, handler);
+    }
+
+    @Override
+    public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+      return prepare(sql);
+    }
+
+    @Override
     public PgConnection exceptionHandler(Handler<Throwable> handler) {
       return this;
     }
@@ -417,6 +429,11 @@ public class PostgresClientTest {
 
     @Override
     public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+      return null;
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
       return null;
     }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
@@ -6,6 +6,7 @@ import io.vertx.core.Handler;
 import io.vertx.pgclient.PgConnection;
 import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.PgPool;
+import io.vertx.sqlclient.PrepareOptions;
 import io.vertx.sqlclient.PreparedQuery;
 import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.Query;
@@ -467,6 +468,17 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     }
 
     @Override
+    public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
+      conn.prepare(sql, options, handler);
+      return this;
+    }
+
+    @Override
+    public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+      return conn.prepare(sql, options);
+    }
+
+    @Override
     public PgConnection exceptionHandler(Handler<Throwable> handler) {
       conn.exceptionHandler(handler);
       return this;
@@ -502,6 +514,11 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     @Override
     public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
       return conn.preparedQuery(s);
+    }
+
+    @Override
+    public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+      return conn.preparedQuery(sql, options);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <junit-jupiter-version>5.8.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.1</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->


### PR DESCRIPTION
mod-inventory-storage successfully builds with this RMB commit after adopting some test asserts to the new SQL error string of Vert.x 4.2.0: https://github.com/eclipse-vertx/vertx-sql-client/commit/6fa1180ad8c3d8683716d0de3b81ecdac394ca3f