### PR TITLE
RMB-891: Log4j 2.17.0 fixing self-referential lookups in MDC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2021-45105

https://logging.apache.org/log4j/2.x/security.html