### PR TITLE
RMB-892: Vert.x 4.2.2, Netty 4.1.72 fixing CVE-2021-43197

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <junit-jupiter-version>5.8.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.2.1</vertx.version>
+    <vertx.version>4.2.2</vertx.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->


### PR DESCRIPTION
Vert.x 4.2.2 comes with Netty 4.1.72.Final that fixes a header request smuggling vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2021-43197