### PR TITLE
RMB-894: Exclude duplicate dependencies

### DIFF
--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -27,10 +27,6 @@
       <artifactId>hibernate-validator</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.el</groupId>
-      <artifactId>javax.el-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
     </dependency>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -23,6 +23,12 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
+      <exclusions>
+        <exclusion> <!-- we already get javax.ws.rs:javax.ws.rs-api via domain-models-api-aspects -->
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -59,6 +65,12 @@
       <groupId>javax.mail</groupId>
       <artifactId>mailapi</artifactId>
       <version>1.4.3</version>
+      <exclusions>
+        <exclusion> <!-- we already get jakarta.activation-api via jersey-media-json-jackson -->
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/domain-models-runtime-it/ramls/bee.json
+++ b/domain-models-runtime-it/ramls/bee.json
@@ -11,6 +11,10 @@
       "description": "name",
       "type": "string"
     },
+    "length": {
+      "type": "integer",
+      "minimum": 0
+    },
     "metadata": {
       "description" : "metadata",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/BeesApiTest.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/BeesApiTest.java
@@ -4,13 +4,17 @@ import static io.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 
 import java.util.UUID;
-
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.api.TestMethodOrder;
 import io.vertx.core.json.JsonObject;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class BeesApiTest extends ApiTestBase {
+
   @Test
+  @Order(1)
   void getPostGetPutGetDeleteGetAudit() {
     given(r).
     when().get("/bees/bees/").
@@ -63,6 +67,16 @@ public class BeesApiTest extends ApiTestBase {
           "beeHistories.findAll { it.operation == \"I\" }.beeHistory.name", hasItems("Willy"),
           "beeHistories.findAll { it.operation == \"U\" }.beeHistory.name", hasItems("Maya"),
           "beeHistories.findAll { it.operation == \"D\" }.beeHistory.name", hasItems("Maya"));
+  }
+
+  @Test
+  void minimum() {
+    JsonObject foo = new JsonObject().put("length", -1);
+    given(r).body(foo.encode()).
+    when().post("/bees/bees").
+    then().
+      statusCode(422).
+      body("errors[0].code", is("javax.validation.constraints.DecimalMin.message"));
   }
 
   @Test

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -32,6 +32,12 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
+      <exclusions>
+        <exclusion> <!-- we already get javax.ws.rs:javax.ws.rs-api via domain-models-api-aspects -->
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
         <version>4.4.0</version>
       </dependency>
       <dependency>
-        <groupId>javax.el</groupId>
-        <artifactId>javax.el-api</artifactId>
-        <version>3.0.1-b06</version>
-      </dependency>
-      <dependency>
         <groupId>javax.ws.rs</groupId>
         <artifactId>javax.ws.rs-api</artifactId>
         <version>2.0.1</version>
@@ -186,6 +181,12 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
         <version>6.2.1.Final</version>
+        <exclusions>
+          <exclusion> <!-- we have javax.validation:validation-api providing the same classes -->
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>


### PR DESCRIPTION
Duplicate dependencies – the same class provided by multiple declared dependencies – result in non-deterministic builds because maven picks one of them.

Remove javax.el:javax.el-api, it is already provided by org.glassfish:javax.el

Exclude jakarta.ws.rs-api, we already have javax.ws.rs-api

Exclude javax.activation:activation, we already have jakarta.activation-api

Exclude jakarta.validation-api, we already have javax.validation:validation-api

Add unit test with minimum constraint in bee.json to ensure that it still works.