### PR TITLE
Don't strip enclosing {} if there are no

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/RestRouting.java
@@ -180,7 +180,11 @@ public final class RestRouting {
       error.getParameters().add(p);
       error.setMessage(cv.getMessage());
       String messageTemplate = cv.getMessageTemplate();
-      error.setCode(messageTemplate.substring(1, messageTemplate.length() - 1));  // strip {}
+      if (messageTemplate.startsWith("{") && messageTemplate.endsWith("}")) {
+        // strip enclosing {}
+        messageTemplate = messageTemplate.substring(1, messageTemplate.length() - 1);
+      }
+      error.setCode(messageTemplate);
       error.setType(DomainModelConsts.VALIDATION_FIELD_ERROR);
       //return the error if the validation is requested on a specific field
       //and that field fails validation. if another field fails validation


### PR DESCRIPTION
Example with incorrect stipping:
`{"errors":[{"message":"elements in list must match pattern","type":"1","code":"lements in list must match patter","parameters":[{"key":"statisticalCodeIds","value":"[foo]"}]}]}`