### PR TITLE
Bump postgresql from 42.3.2 to 42.3.3

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.2</version>
+      <version>42.3.3</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
This fixes an arbitrary file write vulnerability:
https://github.com/pgjdbc/pgjdbc/commit/f6d47034a4ce292e1a659fa00963f6f713117064
https://github.com/advisories/GHSA-673j-qm5f-xpv8

This JDBC driver is used by unit tests of cql2pgjson and
they are not affected, but updating resolves false positive
warnings by security scanners like GitHub dependabot.