### PR TITLE
RMB-898: Update Vertx (to 4.2.5) and other dependencies

### DIFF
--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.27.0-GA</version>
+      <version>3.28.0-GA</version>
     </dependency>
 
     <!-- test dependencies -->

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.0</version>
+      <version>3.6.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <junit-jupiter-version>5.8.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.2.3</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <micrometer.version>1.6.3</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.4.0</version>
+        <version>4.5.1</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.21.0</version>
+        <version>3.22.0</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -160,12 +160,12 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.12.4</version>
+        <version>4.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>3.12.4</version>
+        <version>4.3.1</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>6.2.1.Final</version>
+        <version>6.2.2.Final</version>
         <exclusions>
           <exclusion> <!-- we have javax.validation:validation-api providing the same classes -->
             <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
Update Vert.x from 4.2.3 to 4.2.5. This updates indirect dependencies
like Netty from 4.1.73.Final to 4.1.74.Final.
https://github.com/vert-x3/wiki/wiki/4.2.5-Release-Notes

Update javassist from 3.27.0-GA to 3.28.0-GA.
Update maven-plugin-annotations from 3.6.0 to 3.6.4.
Update hibernate-validator from 6.2.1.Final to 6.2.2.Final.