### PR TITLE
RMB-901: reconnectAttempts and reconnectInterval for PgConnectOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ RMB implementing modules expect a set of environment variables to be passed in a
  - DB_MAXPOOLSIZE
  - DB_MAXSHAREDPOOLSIZE
  - DB_CONNECTIONRELEASEDELAY
+ - DB_RECONNECTATTEMPTS
+ - DB_RECONNECTINTERVAL
  - DB_EXPLAIN_QUERY_THRESHOLD
 
 The first five are mandatory, the others are optional.
@@ -374,6 +376,8 @@ The environment variable `DB_MAXSHAREDPOOLSIZE` sets the maximum number of concu
 Use `DB_SERVER_PEM` (or `server_pem` in the JSON config) to set SSL/TLS certificate(s) in PEM format to validate the PostgreSQL server certificate, this can be the server certificate, the root CA certificate, or the chain of the intermediate CA and the CA certificate. Defaults to none allowing unencrypted connection only. If set requires a TLSv1.3 connection and a valid server certificate, and rejects unencrypted connections.
 
 The environment variable `DB_CONNECTIONRELEASEDELAY` sets the delay in milliseconds after which an idle connection is closed. A connection becomes idle if the query ends, it is not idle if it is waiting for a response. Use 0 to keep idle connections open forever. RMB's default is one minute (60000 ms).
+
+`DB_RECONNECTATTEMPTS` and `DB_RECONNECTINTERVAL` set the maximum number of retries after a connect to the database fails, and how many milliseconds to wait before the next reconnect. Reconnecting is disabled by default.
 
 The environment variable `DB_EXPLAIN_QUERY_THRESHOLD` is not observed by
 Postgres itself, but is a value - in milliseconds - that triggers query

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -118,6 +118,8 @@ public class PostgresClient {
   private static final String    HOST      = "host";
   private static final String    PORT      = "port";
   private static final String    DATABASE  = "database";
+  private static final String    RECONNECT_ATTEMPTS = "reconnectAttempts";
+  private static final String    RECONNECT_INTERVAL = "reconnectInterval";
   private static final String    SERVER_PEM = "server_pem";
   private static final String    POSTGRES_TESTER = "postgres_tester";
 
@@ -455,6 +457,14 @@ public class PostgresClient {
     String database = sqlConfig.getString(DATABASE);
     if (database != null) {
       pgConnectOptions.setDatabase(database);
+    }
+    Integer reconnectAttempts = sqlConfig.getInteger(RECONNECT_ATTEMPTS);
+    if (reconnectAttempts != null) {
+      pgConnectOptions.setReconnectAttempts(reconnectAttempts);
+    }
+    Long reconnectInterval = sqlConfig.getLong(RECONNECT_INTERVAL);
+    if (reconnectInterval != null) {
+      pgConnectOptions.setReconnectInterval(reconnectInterval);
     }
     String serverPem = sqlConfig.getString(SERVER_PEM);
     if (serverPem != null) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -17,6 +17,8 @@ public enum Envs {
   DB_MAXPOOLSIZE,
   DB_MAXSHAREDPOOLSIZE,
   DB_CONNECTIONRELEASEDELAY,
+  DB_RECONNECTATTEMPTS,
+  DB_RECONNECTINTERVAL,
   DB_EXPLAIN_QUERY_THRESHOLD;
 
   private static Map<String, String> env = System.getenv();
@@ -50,6 +52,8 @@ public enum Envs {
     case DB_MAXPOOLSIZE:             return "maxPoolSize";
     case DB_MAXSHAREDPOOLSIZE:       return "maxSharedPoolSize";
     case DB_CONNECTIONRELEASEDELAY:  return "connectionReleaseDelay";
+    case DB_RECONNECTATTEMPTS:       return "reconnectAttempts";
+    case DB_RECONNECTINTERVAL:       return "reconnectInterval";
     case DB_EXPLAIN_QUERY_THRESHOLD: return envs.name();
     default:                         return envs.name().substring(3).toLowerCase();
     }
@@ -63,7 +67,9 @@ public enum Envs {
       case DB_MAXPOOLSIZE:
       case DB_MAXSHAREDPOOLSIZE:
       case DB_CONNECTIONRELEASEDELAY:
+      case DB_RECONNECTATTEMPTS:
         return Integer.parseInt(value);
+      case DB_RECONNECTINTERVAL:
       case DB_EXPLAIN_QUERY_THRESHOLD:
         return Long.parseLong(value);
       default:

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -180,24 +180,34 @@ public class PostgresClientTest {
   }
 
   @Test
-  public void testPgConnectOptionsFull() {
-    JsonObject conf = new JsonObject()
-        .put("host", "myhost")
-        .put("port", 5433)
-        .put("username", "myuser")
-        .put("password", "mypassword")
-        .put("database", "mydatabase")
-        .put("connectionReleaseDelay", 1000);
-
-    PgConnectOptions options = PostgresClient.createPgConnectOptions(conf);
-    assertThat("myhost", is(options.getHost()));
-    assertThat(5433, is(options.getPort()));
-    assertThat("myuser", is(options.getUser()));
-    assertThat("mypassword", is(options.getPassword()));
-    assertThat("mydatabase", is(options.getDatabase()));
-    // TODO: enable when available in vertx-sql-client/vertx-pg-client
-    // https://issues.folio.org/browse/RMB-657
-    // assertThat(1000, is(options.getConnectionReleaseDelay()));
+  public void testPgConnectOptionsFull() throws Exception {
+    try {
+      Envs.setEnv(Map.of(
+          "DB_HOST", "myhost",
+          "DB_PORT", "5433",
+          "DB_USERNAME", "myuser",
+          "DB_PASSWORD", "mypassword",
+          "DB_DATABASE", "mydatabase",
+          "DB_CONNECTIONRELEASEDELAY", "1000",
+          "DB_RECONNECTATTEMPTS", "3",
+          "DB_RECONNECTINTERVAL", "2000"
+          ));
+      JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
+      PgConnectOptions options = PostgresClient.createPgConnectOptions(conf);
+      assertThat(options.getHost(), is("myhost"));
+      assertThat(options.getPort(), is(5433));
+      assertThat(options.getUser(), is("myuser"));
+      assertThat(options.getPassword(), is("mypassword"));
+      assertThat(options.getDatabase(), is("mydatabase"));
+      // TODO: enable when available in vertx-sql-client/vertx-pg-client
+      // https://issues.folio.org/browse/RMB-657
+      // assertThat(options.getConnectionReleaseDelay(), is(1000));
+      assertThat(options.getReconnectAttempts(), is(3));
+      assertThat(options.getReconnectInterval(), is(2000L));
+    } finally {
+      // restore defaults
+      Envs.setEnv(System.getenv());
+    }
   }
 
   @Test

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/EnvsTest.java
@@ -27,6 +27,8 @@ public class EnvsTest {
     map.put("DB_QUERYTIMEOUT", "8");
     map.put("DB_MAXPOOLSIZE", "5");
     map.put("DB_CONNECTIONRELEASEDELAY", "12345");
+    map.put("DB_RECONNECTATTEMPTS", "3");
+    map.put("DB_RECONNECTINTERVAL", "2000");
     map.put("DB_EXPLAIN_QUERY_THRESHOLD", "100");
     // we dropped support for dot form. check that it is ignored
     map.put("db.username", "superwoman");
@@ -61,6 +63,16 @@ public class EnvsTest {
   }
 
   @Test
+  public void reconnectAttempts() {
+    assertEquals("3", Envs.getEnv(Envs.DB_RECONNECTATTEMPTS));
+  }
+
+  @Test
+  public void reconnectInterval() {
+    assertEquals("2000", Envs.getEnv(Envs.DB_RECONNECTINTERVAL));
+  }
+
+  @Test
   public void database() {
     assertNull(Envs.getEnv(Envs.DB_DATABASE));
   }
@@ -73,11 +85,13 @@ public class EnvsTest {
   @Test
   public void allDBConfs() {
     JsonObject json = Envs.allDBConfs();
-    assertEquals(5, json.size());
+    assertEquals(7, json.size());
     assertEquals("example.com", json.getValue("host"));
     assertEquals(Integer.valueOf(8), json.getValue("queryTimeout"));
     assertEquals(Integer.valueOf(5), json.getValue("maxPoolSize"));
     assertEquals(Integer.valueOf(12345), json.getValue("connectionReleaseDelay"));
+    assertEquals(Integer.valueOf(3), json.getValue("reconnectAttempts"));
+    assertEquals(Long.valueOf(2000), json.getValue("reconnectInterval"));
     assertEquals(Long.valueOf(100), json.getValue(Envs.DB_EXPLAIN_QUERY_THRESHOLD.name()));
   }
 


### PR DESCRIPTION
https://issues.folio.org/browse/RMB-901

DB timeout issues happen most often when the system is not warmed up and
connection pool does not contain any open connections.