### PR TITLE
Perform module check at compile time RMB-903

### DIFF
--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/PomReader.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/PomReader.java
@@ -27,6 +27,9 @@ public enum PomReader {
 
   INSTANCE;
 
+  private static final String MODULE_PATTERN_STRING = "^[a-z][-_a-z0-9]*$";
+  private static final int MODULE_MAX_LENGTH = 31;
+
   private String moduleName = null;
   private String version = null;
   private Properties props = null;
@@ -84,6 +87,14 @@ public enum PomReader {
     }
     version = version.replaceAll("-.*", "");
 
+    if (!moduleName.matches(MODULE_PATTERN_STRING)) {
+      throw new IllegalArgumentException("Invalid module name \"" + moduleName
+          + "\" does not match " + MODULE_PATTERN_STRING);
+    }
+    if (moduleName.length() > MODULE_MAX_LENGTH) {
+      throw new IllegalArgumentException("Invalid module name \"" + moduleName
+          + "\" must not exceed " + MODULE_MAX_LENGTH + " characters");
+    }
     moduleName = moduleName.replaceAll("-", "_");
     props = model.getProperties();
     dependencies = model.getDependencies();

--- a/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/PomReaderTest.java
+++ b/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/PomReaderTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.text.MatchesPattern.matchesPattern;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
@@ -62,6 +63,22 @@ class PomReaderTest {
     PomReader pom = PomReader.INSTANCE;
 
     assertThrows(NullPointerException.class, () -> pom.readIt(null, "pom/pom-sample.xml"));
+  }
+
+  @Test
+  void readBadModuleName() {
+    PomReader pom = PomReader.INSTANCE;
+
+    Throwable t = assertThrows(IllegalArgumentException.class, () -> pom.readIt("src/test/resources/pom/pom-007.xml", null));
+    assertThat(t.getMessage(), containsString("does not match"));
+  }
+
+  @Test
+  void readBadLongName() {
+    PomReader pom = PomReader.INSTANCE;
+
+    Throwable t = assertThrows(IllegalArgumentException.class, () -> pom.readIt("src/test/resources/pom/pom-long-name.xml", null));
+    assertThat(t.getMessage(), containsString("exceed"));
   }
 
   @Test

--- a/domain-models-maven-plugin/src/test/resources/pom/pom-007.xml
+++ b/domain-models-maven-plugin/src/test/resources/pom/pom-007.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>007</artifactId>
+  <groupId>org.folio</groupId>
+  <version>19.4.0-SNAPSHOT</version>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://spdx.org/licenses/Apache-2.0</url>
+    </license>
+  </licenses>
+</project>

--- a/domain-models-maven-plugin/src/test/resources/pom/pom-long-name.xml
+++ b/domain-models-maven-plugin/src/test/resources/pom/pom-long-name.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>abcdefghijklmnopqrstuvxyz-123456</artifactId>
+  <groupId>org.folio</groupId>
+  <version>19.4.0-SNAPSHOT</version>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>http://spdx.org/licenses/Apache-2.0</url>
+    </license>
+  </licenses>
+</project>


### PR DESCRIPTION
The resulting schema in RMB has a limit of 63 characters
as that is the default identifier max length for Postgres.
However, if the tenant is know to be at most 31 bytes it's
safe to asseume the module may be up to 31 bytes. This PR
checks the module name during build time. An invalid name would
result in an errors such as:
[INFO] Reading from pom.xml
[ERROR] Invalid module name "007" does not match ^[a-z][-_a-z0-9]*$
java.lang.IllegalArgumentException: Invalid module name "007" does not match ^[a-z][-_a-z0-9]*$
    at org.folio.rest.tools.PomReader.readIt (PomReader.java:91)
    at org.folio.rest.tools.PomReader.init (PomReader.java:54)