### PR TITLE
RMB-759: Use Z time zone for createdDate and updatedDate metadata

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -110,12 +110,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>testing</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -68,12 +68,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>testing</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/ApiTestBase.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/ApiTestBase.java
@@ -94,6 +94,7 @@ public class ApiTestBase {
         .when().get(location + "?wait=5000")
         .then()
         .statusCode(200)
+        .body("complete", is(true))
         .body("error", is(nullValue()));
   }
 

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -177,12 +177,6 @@
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>testing</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
       <artifactId>postgres-testing</artifactId>
       <version>${project.parent.version}</version>
       <scope>test</scope>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -25,11 +25,6 @@
       <artifactId>util</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>testing</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -44,13 +44,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>testing</artifactId>
-      <version>${project.parent.version}</version>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>


### PR DESCRIPTION
Existing metadata date format:

```
"metadata": {
  "createdDate": "2020-10-19T09:31:31.529",
  "updatedDate": "2020-10-19T09:31:31.529+00:00",
  "createdByUserId": "ba6baf95-bf14-4020-b44c-0cad269fb5c9",
  "updatedByUserId": "ba6baf95-bf14-4020-b44c-0cad269fb5c9"
}
```

Always having a time zone string prevents software running in an
environment with some time offset from incorrectly interpreting
the time as local time.

New metadata date format:

"metadata": {
  "createdDate": "2020-10-19T09:31:31.529Z",
  "updatedDate": "2020-10-19T09:31:31.529Z",
  "createdByUserId": "ba6baf95-bf14-4020-b44c-0cad269fb5c9",
  "updatedByUserId": "ba6baf95-bf14-4020-b44c-0cad269fb5c9"
}

No migration needed, for details see
https://issues.folio.org/browse/RMB-759