### PR TITLE
RMB-911: Optimistic locking _version overflow

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/optimistic_locking.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/optimistic_locking.ftl
@@ -21,7 +21,7 @@
                 USING ERRCODE = '23F09', TABLE = '${table.tableName}', SCHEMA = '${myuniversity}_${mymodule}';
         END IF;
         NEW.jsonb = jsonb_set(NEW.jsonb, '{${ol_version}}',
-            to_jsonb(COALESCE((OLD.jsonb->>'${ol_version}')::numeric + 1, 1)));
+            to_jsonb(COALESCE(((OLD.jsonb->>'${ol_version}')::numeric + 1) % 2147483648, 1)));
     END CASE;
     RETURN NEW;
   END;

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking3.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking3.json
@@ -1,0 +1,19 @@
+{
+  "tables": [
+    {
+      "tableName": "tab_ol_off",
+      "withOptimisticLocking": "off"
+    },
+    {
+      "tableName": "tab_ol_log",
+      "withOptimisticLocking": "off"
+    },
+    {
+      "tableName": "tab_ol_fail",
+      "withOptimisticLocking": "off"
+    },
+    {
+      "tableName": "tab_ol_none"
+    }
+  ]
+}


### PR DESCRIPTION
PostgreSQL allows up to 1000 digits for the _version number: https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-DECIMAL

JSON has no number restriction: https://www.json.org/json-en.html

RAML also has no restrictions for the number and integer types: https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/#number

mod-inventory-storage declares _version to be of RAML type integer: https://github.com/folio-org/mod-inventory-storage/blob/v23.0.2/ramls/instance.json#L11

RMB incorrectly generates Java type Integer in org.folio.rest.jaxrs.model.Instance.java.

This will result in a parse exception when Integer.MAX_VALUE = 2147483647 is exceeded.

It takes 68 years when incrementing each second. It takes only 1 year when incrementing 68 times per second.

There might be stress tests, load tests, performance tests or other tests that update the same instance, holding or item frequently and therefore it might be possible that an overflow occurs.

Changing the optimistic locking trigger to wrap around from 2147483647 to 0 is the easiest fix:

`(oldvalue::numeric + 1) % 2147483648`