### PR TITLE
RMB-907: b33.2 jackson-databind 2.13.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,16 +57,16 @@
         <version>31.0.1-jre</version>
       </dependency>
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-stack-depchain</artifactId>
-        <version>${vertx.version}</version>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId> <!-- remove for vertx >= 4.2.7 -->
+        <version>2.13.2.20220324</version> <!-- jackson-databind 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId> <!-- remove for vertx >= 4.2.7 -->
-        <version>2.13.2.20220324</version> <!-- jackson-databind 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518 -->
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Move jackson entry before vertx entry like it is on master.
Otherwise jackson version provided by vertx overwrites the
patched version.