### PR TITLE
RMB-913: Fail if PostgreSQL version is too old

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -280,6 +281,13 @@ public class TenantAPIIT {
   }
 
   @Test
+  public void requirePostgres(TestContext context) {
+    new TenantAPI().requirePostgres(vertx.getOrCreateContext(), "990000", "99.0")
+    .onComplete(context.asyncAssertFailure(
+        e -> assertThat(e.getMessage(), startsWith("Expected PostgreSQL server version 99.0 or later"))));
+  }
+
+  @Test
   public void previousSchemaSqlExistsTrue(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI();
     String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -314,6 +322,11 @@ public class TenantAPIIT {
       }
 
       @Override
+      Future<Void> requirePostgres12(Context context) {
+        return Future.succeededFuture();
+      }
+
+      @Override
       Future<Boolean> tenantExists(Context context, String tenantId) {
         return Future.succeededFuture(false);
       }
@@ -335,6 +348,11 @@ public class TenantAPIIT {
       @Override
       PostgresClient postgresClient(Context context) {
         return postgresClient;
+      }
+
+      @Override
+      Future<Void> requirePostgres12(Context context) {
+        return Future.succeededFuture();
       }
 
       @Override


### PR DESCRIPTION
As a sysop, devop or developer I want a good error message if the PostgreSQL server version is too old.

Currently I get an error message like this:

```
Tenant operation failed for module mod-inventory-storage-23.0.2: SQL error
CREATE TRIGGER check_statistical_code_references_on_insert BEFORE INSERT ON
item FOR EACH ROW WHEN (NEW.jsonb->'statisticalCodeIds' IS NOT NULL AND
NEW.jsonb->'statisticalCodeIds' <> '[]') EXECUTE FUNCTION
check_statistical_code_references();ERROR: 42601: syntax error at or near "FUNCTION"
```

This doesn't give any indication what the root cause is.

Solution: On POST /_/tenant check the server version and fail if no longer supported.