### PR TITLE
RMB-915: public PostgresClient#getTenantId()

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -4042,7 +4042,7 @@ public class PostgresClient {
   /**
    * @return the tenantId of this PostgresClient
    */
-  String getTenantId() {
+  public String getTenantId() {
     return tenantId;
   }
 


### PR DESCRIPTION
Make PostgresClient#getTenantId() public. This may help a module because the tenantId no longer needs to be passed separately.