### PR TITLE
RMB-917: id == "", foreignKeyId == "" should never match

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/CQL2PgJSON.java
@@ -609,9 +609,6 @@ public class CQL2PgJSON {
           + "UUID " + columnName + " only supports '=', '==', and '<>' (possibly with right truncation)");
     }
 
-    if (StringUtils.isEmpty(term)) {
-      term = "*";
-    }
     if ("*".equals(term) && "id".equals(columnName)) {
       return equals ? "true" : "false";  // no need to check
       // since id is a mandatory field, so

--- a/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
+++ b/cql2pgjson/src/test/java/org/folio/cql2pgjson/CQL2PgJSONTest.java
@@ -800,12 +800,11 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
 
   @Test
   @Parameters({
-    "id=*,                                       true",
-    "id=\"\",                                    true",
+    "id=*,    true",
+    "id=\"\", false /* id == invalid UUID */",  // exact (field) match, empty string never matches UUID
     "groupId=*,                                  (groupId BETWEEN '00000000-0000-0000-0000-000000000000' "
                                                            + "AND 'ffffffff-ffff-ffff-ffff-ffffffffffff')",
-    "groupId=\"\",                               (groupId BETWEEN '00000000-0000-0000-0000-000000000000' "
-                                                           + "AND 'ffffffff-ffff-ffff-ffff-ffffffffffff')",
+    "groupId=\"\",                               false /* groupId == invalid UUID */",
     "id=\"11111111-1111-1111-1111-111111111111\",              id='11111111-1111-1111-1111-111111111111'",
     "id=\"2*\",                                       (id BETWEEN '20000000-0000-0000-0000-000000000000' "
                                                            + "AND '2fffffff-ffff-ffff-ffff-ffffffffffff')",
@@ -850,8 +849,9 @@ public class CQL2PgJSONTest extends DatabaseTestBase {
     "id=11111111-1111-1111-1111-11111111111    #",
     "id=11111111-1111-1111-1111-1111111111111  #",
     "id=11111111-1111-1111-1111-111111111111-1 #",
-    "id=\"\"                                   # Jo Jane; Ka Keller; Lea Long",
-    "id<>\"\"                                  #",
+    "id=\"\"                                   #",    // exact match, empty string never matches UUID
+    "id==\"\"                                  #",
+    "id<>\"\"                                  # Jo Jane; Ka Keller; Lea Long",
     "id=1*                                     # Jo Jane",
     "id=1**                                    # Jo Jane",
     "id=1***                                   # Jo Jane",


### PR DESCRIPTION
CQL2PgJSON handles these queries

```
id == ""
id = ""
foreignKeyId == ""
foreignKeyId = ""
```

as if they were

```
id == "*"
foreignKeyId == "*"
```

matching if the field is defined.

This is wrong. The id field and any foreign key id field are a UUID and can never match the empty string and therefore should always yield false.

People should use `id == "*"` and `foreignKeyId == "*"` instead if they want to match if the field is defined.