### PR TITLE
RMB-919: Delete by CQL rejects missing or empty CQL

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dbschema.ObjectMapperTool;
@@ -918,17 +919,16 @@ public final class PgUtil {
     }
   }
 
-    /**
-    * Delete records by CQL.
-    * @param table  the table that contains the records
-    * @param cql  the CQL query for filtering the records
-    * @param okapiHeaders  http headers provided by okapi
-    * @param vertxContext  the current context
-    * @param responseDelegateClass  the ResponseDelegate class generated as defined by the RAML file,
-    *    must have these methods:  respond204(), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
-    * @param asyncResultHandler  where to return the result created by the responseDelegateClass
-    */
-  @SuppressWarnings({"unchecked", "squid:S107"})     // Method has >7 parameters
+  /**
+   * Delete records by CQL.
+   * @param table  the table that contains the records
+   * @param cql  the CQL query for filtering the records, required
+   * @param okapiHeaders  http headers provided by okapi
+   * @param vertxContext  the current context
+   * @param responseDelegateClass  the ResponseDelegate class generated as defined by the RAML file,
+   *    must have these methods:  respond204(), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
+   * @param asyncResultHandler  where to return the result created by the responseDelegateClass
+   */
   public static void delete(String table,
       String cql,
       Map<String, String> okapiHeaders, Context vertxContext,
@@ -937,17 +937,16 @@ public final class PgUtil {
     delete(table, cql, okapiHeaders, vertxContext, responseDelegateClass).onComplete(asyncResultHandler);
   }
 
-   /**
+  /**
    * Delete records by CQL.
-    * @param table  the table that contains the records
-    * @param cql  the CQL query for filtering the records
-    * @param okapiHeaders  http headers provided by okapi
-    * @param vertxContext  the current context
-    * @param responseDelegateClass  the ResponseDelegate class generated as defined by the RAML file,
-*    must have these methods:  respond204(), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
-    * @return future where to return the result created by the responseDelegateClass
-    */
-  @SuppressWarnings({"unchecked", "squid:S107"})     // Method has >7 parameters
+   * @param table  the table that contains the records
+   * @param cql  the CQL query for filtering the records, required
+   * @param okapiHeaders  http headers provided by okapi
+   * @param vertxContext  the current context
+   * @param responseDelegateClass  the ResponseDelegate class generated as defined by the RAML file,
+   *     must have these methods:  respond204(), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
+   * @return future where to return the result created by the responseDelegateClass
+   */
   public static Future<Response> delete(String table,
       String cql,
       Map<String, String> okapiHeaders, Context vertxContext,
@@ -972,6 +971,10 @@ public final class PgUtil {
     }
 
     try {
+      if (StringUtils.isBlank(cql)) {
+        return response("query with CQL expression is required", respond400, respond500);
+      }
+
       CQL2PgJSON cql2pgJson = new CQL2PgJSON(table + "." + JSON_COLUMN);
       CQLWrapper cqlWrapper = new CQLWrapper(cql2pgJson, cql, -1, -1);
       PreparedCQL preparedCql = new PreparedCQL(table, cqlWrapper, okapiHeaders);
@@ -1003,7 +1006,7 @@ public final class PgUtil {
     }
   }
 
-    /**
+  /**
    * Get a record by id.
    *
    * <p>All exceptions are caught and reported via the asyncResultHandler.

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgUtilIT.java
@@ -415,6 +415,27 @@ public class PgUtilIT {
   }
 
   @Test
+  public void deleteByCQLWithoutCql(TestContext testContext) {
+    PgUtil.delete("users", null,
+        null, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
+        asyncAssertSuccess(testContext, 400, "query with CQL expression is required"));
+  }
+
+  @Test
+  public void deleteByCQLWithEmptyCql(TestContext testContext) {
+    PgUtil.delete("users", "",
+        null, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
+        asyncAssertSuccess(testContext, 400, "query with CQL expression is required"));
+  }
+
+  @Test
+  public void deleteByCQLWithWhitespaceCql(TestContext testContext) {
+    PgUtil.delete("users", "\t\n \t\n ",
+        null, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
+        asyncAssertSuccess(testContext, 400, "query with CQL expression is required"));
+  }
+
+  @Test
   public void deleteByCQLOK(TestContext testContext) {
     PostgresClient pg = PostgresClient.getInstance(vertx, "testtenant");
     insert(testContext, pg, "delete_a",  1);
@@ -454,7 +475,6 @@ public class PgUtilIT {
 
   @Test
   public void deleteByCQLSyntaxError(TestContext testContext) {
-    PostgresClient pg = PostgresClient.getInstance(vertx, "testtenant");
     PgUtil.delete("users",  "username==",
         okapiHeaders, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
         asyncAssertSuccess(testContext, 400, "expected index or term, got EOF"));
@@ -462,7 +482,6 @@ public class PgUtilIT {
 
   @Test
   public void deleteByCQLBadTable(TestContext testContext) {
-    PostgresClient pg = PostgresClient.getInstance(vertx, "testtenant");
     PgUtil.delete("users1",  "username==delete_test",
         okapiHeaders, vertx.getOrCreateContext(), Users.DeleteUsersByUserIdResponse.class,
         asyncAssertSuccess(testContext, 400, "relation \"testtenant_raml_module_builder.users1\" does not exist"));


### PR DESCRIPTION
As a sysop or librarian using the DELETE by CQL API I might accidentally omit the query parameter or mistype it: quer=username==foo

How to reproduce:
Call PgUtil.delete by CQL with CQL query parameter that is null (= missing), empty or whitespace only.

Expected Results:
PgUtil.delete by CQL rejects the API call with a 400 HTTP status code and doesn't delete anything.

Actual Results:
PgUtil.delete deletes all records.

Additional Information:
This bug has already caused severe issues: https://issues.folio.org/browse/MODINVSTOR-901