### PR TITLE
RMB-922: Case insensitive header name matching in TenantTool

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantTool.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantTool.java
@@ -28,6 +28,13 @@ public final class TenantTool {
    * @return the tenantId for the headers, returns the default "folio_shared" if undefined
    */
   public static String tenantId(Map<String, String> headers) {
-    return calculateTenantId(headers.get(RestVerticle.OKAPI_HEADER_TENANT));
+    String tenant = null;
+    for (var entry : headers.entrySet()) {
+      if (entry.getKey().equalsIgnoreCase(RestVerticle.OKAPI_HEADER_TENANT)) {
+        tenant = entry.getValue();
+        break;
+      }
+    }
+    return calculateTenantId(tenant);
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/TenantToolTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/TenantToolTest.java
@@ -3,10 +3,8 @@ package org.folio.rest.tools.utils;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import org.folio.okapi.testing.UtilityClassTester;
-import org.folio.rest.RestVerticle;
 import org.junit.Test;
 
 public class TenantToolTest {
@@ -35,14 +33,13 @@ public class TenantToolTest {
     assertEquals("folio_shared", TenantTool.tenantId(Collections.emptyMap()));
   }
 
-  private Map<String, String> map(String key, String value) {
-    Map<String, String> map = new HashMap<>(1);
-    map.put(key, value);
-    return map;
+  @Test
+  public void lowerCase() {
+    assertEquals("a", TenantTool.tenantId(Map.of("foo", "x", "x-okapi-tenant", "a")));
   }
 
   @Test
-  public void b() {
-    assertEquals("b", TenantTool.tenantId(map(RestVerticle.OKAPI_HEADER_TENANT, "b")));
+  public void upperCase() {
+    assertEquals("b", TenantTool.tenantId(Map.of("bar", "y", "X-OKAPI-TENANT", "b", "baz", "z")));
   }
 }


### PR DESCRIPTION
TenantTool.tenantId switched from x-okapi-tenant to X-Okapi-Tenant
for RMB 34.0.0, therefore we need to fix the matching.