### PR TITLE
RMB-922: Migrate to case insensitive x-okapi-tenant header

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -93,6 +93,12 @@ New:
 
 This may cause some unit tests to fail, use java.time.Instant and compare Instants to be format agnostic.
 
+#### [RMB-944](https://issues.folio.org/browse/RMB-944)
+
+Unit tests that pass X-Okapi-Tenant header into TenantTool.tenantId must
+use a case insensitive map. Replace `Map.of("x-okapi-tenant", "foo")`
+with a `org.apache.commons.collections4.map.CaseInsensitiveMap`.
+
 ## Version 33.2
 
 #### [RMB-718](https://issues.folio.org/browse/RMB-718), [FOLIO-3351](https://issues.folio.org/browse/FOLIO-3351)

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -97,7 +97,8 @@ This may cause some unit tests to fail, use java.time.Instant and compare Instan
 
 Unit tests that pass X-Okapi-Tenant header into TenantTool.tenantId must
 use a case insensitive map. Replace `Map.of("x-okapi-tenant", "foo")`
-with a `org.apache.commons.collections4.map.CaseInsensitiveMap`.
+with `new CaseInsensitiveMap<>(Map.of("x-okapi-tenant", "foo"))` after
+`import org.apache.commons.collections4.map.CaseInsensitiveMap`.
 
 ## Version 33.2
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantTool.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantTool.java
@@ -1,7 +1,7 @@
 package org.folio.rest.tools.utils;
 
 import java.util.Map;
-
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.rest.RestVerticle;
 
 /**
@@ -24,8 +24,10 @@ public final class TenantTool {
   }
 
   /**
-   * @param headers HTTP headers to use, may be empty, but not null
-   * @return the tenantId for the headers, returns the default "folio_shared" if undefined
+   * Return the tenantId if available in the headers, or the default "folio_shared" if undefined.
+   *
+   * @param headers HTTP headers to use, may be empty, but not null; the keys of the map must be case insensitive,
+   *    for example {@link CaseInsensitiveMap}
    */
   public static String tenantId(Map<String, String> headers) {
     return calculateTenantId(headers.get(RestVerticle.OKAPI_HEADER_TENANT));


### PR DESCRIPTION
mod-inventory-storage has several unit tests that pass a Map.of() and fail when upgrading to RMB 34:
https://github.com/folio-org/mod-inventory-storage/blob/v23.0.3/src/test/java/org/folio/rest/api/AsyncMigrationTest.java#L142
https://github.com/folio-org/mod-inventory-storage/blob/v23.0.3/src/test/java/org/folio/rest/api/IterationJobRunnerTest.java#L134
https://github.com/folio-org/mod-inventory-storage/blob/v23.0.3/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java#L35
https://github.com/folio-org/mod-inventory-storage/blob/v23.0.3/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java#L185