### PR TITLE
Revert "RMB-913: Fail if PostgreSQL version is too old"

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/impl/TenantAPI.java
@@ -49,25 +49,6 @@ public class TenantAPI implements Tenant {
     return PostgresClient.getInstance(context.owner());
   }
 
-  Future<Void> requirePostgres(Context context, String minNum, String minVersion) {
-    return
-        postgresClient(context)
-        .select("SELECT current_setting('server_version_num') AS num, current_setting('server_version') AS version")
-        .map(rowSet -> {
-          String num = rowSet.iterator().next().getString("num");
-          String version = rowSet.iterator().next().getString("version");
-          if (minNum.compareTo(num) > 0) {
-            throw new UnsupportedOperationException(
-                "Expected PostgreSQL server version " + minVersion + " or later but found " + version);
-          }
-          return null;
-        });
-  }
-
-  Future<Void> requirePostgres12(Context context) {
-    return requirePostgres(context, "120000", "12.0");
-  }
-
   Future<Boolean> tenantExists(Context context, String tenantId){
     /* connect as user in postgres-conf.json file (super user) - so that all commands will be available */
     return postgresClient(context).select(
@@ -226,8 +207,7 @@ public class TenantAPI implements Tenant {
     job.setComplete(false);
 
     String location = "/_/tenant/" + id;
-    requirePostgres12(context)
-        .compose(x -> tenantExists(context, tenantId))
+    tenantExists(context, tenantId)
         .compose(exists -> sqlFile(context, tenantId, tenantAttributes, exists))
         .onFailure(cause -> {
           log.error(cause.getMessage(), cause);

--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -3,7 +3,6 @@ package org.folio.rest.impl;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -262,13 +261,6 @@ public class TenantAPIIT {
   }
 
   @Test
-  public void requirePostgres(TestContext context) {
-    new TenantAPI().requirePostgres(vertx.getOrCreateContext(), "990000", "99.0")
-    .onComplete(context.asyncAssertFailure(
-        e -> assertThat(e.getMessage(), startsWith("Expected PostgreSQL server version 99.0 or later"))));
-  }
-
-  @Test
   public void previousSchemaSqlExistsTrue(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI();
     String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -303,11 +295,6 @@ public class TenantAPIIT {
       }
 
       @Override
-      Future<Void> requirePostgres12(Context context) {
-        return Future.succeededFuture();
-      }
-
-      @Override
       Future<Boolean> tenantExists(Context context, String tenantId) {
         return Future.succeededFuture(false);
       }
@@ -329,11 +316,6 @@ public class TenantAPIIT {
       @Override
       PostgresClient postgresClient(Context context) {
         return postgresClient;
-      }
-
-      @Override
-      Future<Void> requirePostgres12(Context context) {
-        return Future.succeededFuture();
       }
 
       @Override


### PR DESCRIPTION
This reverts commit b95e3dca74bb26ca02bef4c06171851c31a3e66b.
That commit was cherry-pick 19da0fc9ee0c70a1101fb3db7a4c8e0223e720b6 from master.