### PR TITLE
RMB-930: Upgrade git-commit-id-plugin for JDK 17

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -472,9 +472,9 @@
       </plugin>
 
       <plugin>
-        <groupId>pl.project13.maven</groupId>
-        <artifactId>git-commit-id-plugin</artifactId>
-        <version>4.0.1</version>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>5.0.0</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>


### PR DESCRIPTION
Use JDK 17 and run mvn clean install.

It fails with this error:

```
[ERROR] Failed to execute goal pl.project13.maven:git-commit-id-plugin:4.0.1:revision
(get-the-git-infos) on project domain-models-runtime: Could not complete Mojo execution...:
Unable to make
private void java.util.Properties.store0(java.io.BufferedWriter,java.lang.String,boolean) throws java.io.IOException
accessible: module java.base does not "opens java.util" to unnamed module
@79e8a26c -> [Help 1]
```

This is fixed by upgrading pl.project13.maven:git-commit-id-plugin:4.0.1 to version 5.0.0: https://github.com/git-commit-id/git-commit-id-maven-plugin/releases/tag/v5.0.0