### PR TITLE
RMB-348 (Cont.)

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
@@ -991,6 +991,15 @@ public class Conn {
    *     .compose(x -> ...
    * </pre>
    *
+   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):
+   *    *
+   *    * <pre>
+   *    * postgresClient.withReadTrans(conn ->
+   *    *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5), 100,
+   *    *         rowStream -> rowStream.handler(row -> task.process(row))));
+   *    * </pre>
+   * </p>
+   *
    * @param params arguments for {@code $} placeholders in {@code sql}
    * @param chunkSize cursor fetch size
    */
@@ -1021,6 +1030,15 @@ public class Conn {
    *         rowStream -> rowStream.handler(row -> task.process(row))))
    *     .compose(x -> ...
    * </pre>
+   *
+   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):
+   *    *
+   *    * <pre>
+   *    * postgresClient.withReadTrans(conn ->
+   *    *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5),
+   *    *         rowStream -> rowStream.handler(row -> task.process(row))));
+   *    * </pre>
+   * </p>
    *
    * @param params arguments for {@code $} placeholders in {@code sql}
    */

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
@@ -1030,14 +1030,13 @@ public class Conn {
    *     .compose(x -> ...
    * </pre>
    *
-   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):
-   *    *
-   *    * <pre>
-   *    * postgresClient.withReadTrans(conn ->
-   *    *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5),
-   *    *         rowStream -> rowStream.handler(row -> task.process(row))));
-   *    * </pre>
-   * </p>
+   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):</p>
+   *
+   * <pre>
+   * postgresClient.withReadTrans(conn ->
+   *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5),
+   *         rowStream -> rowStream.handler(row -> task.process(row))));
+   * </pre>
    *
    * @param params arguments for {@code $} placeholders in {@code sql}
    */

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
@@ -991,14 +991,13 @@ public class Conn {
    *     .compose(x -> ...
    * </pre>
    *
-   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):
-   *    *
-   *    * <pre>
-   *    * postgresClient.withReadTrans(conn ->
-   *    *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5), 100,
-   *    *         rowStream -> rowStream.handler(row -> task.process(row))));
-   *    * </pre>
-   * </p>
+   * <p>Use withReadTrans if all SQL queries are read-only (no nextval(), no UPDATE, ...):</p>
+   *
+   * <pre>
+   *  postgresClient.withReadTrans(conn ->
+   *     conn.selectStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5), 100,
+   *         rowStream -> rowStream.handler(row -> task.process(row))));
+   * </pre>
    *
    * @param params arguments for {@code $} placeholders in {@code sql}
    * @param chunkSize cursor fetch size

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -168,12 +168,12 @@ public class PostgresClient {
   private JsonObject postgreSQLClientConfig = null;
   /**
    * PgPool client that is initialized with mainly the database writer instance's connection string.
-   * */
+   */
   private PgPool client;
   /**
    * PgPool client that is initialized with mainly the database reader instance's connection string.
    * When there is no reader instance, then this client should be initialized with the writer's connection string
-   * **/
+   */
   private PgPool readClient;
   private final String tenantId;
   private final String schemaName;
@@ -504,10 +504,9 @@ public class PostgresClient {
     String hostToResolve = HOST;
     String portToResolve = PORT;
 
-    if (isReader)
-    {
+    if (isReader) {
        hostToResolve = HOST_READER;
-       portToResolve = PORT_READER ;
+       portToResolve = PORT_READER;
     }
 
     String host = sqlConfig.getString(hostToResolve);
@@ -522,7 +521,7 @@ public class PostgresClient {
       pgConnectOptions.setPort(port);
     }
 
-    if (isReader && (host == null || port == null)){
+    if (isReader && (host == null || port == null)) {
       return null;
     }
 
@@ -3086,17 +3085,29 @@ public class PostgresClient {
   }
 
   /**
-   * Run a select query using the readonly connection.
-   *
+   * <p>To update see {@link #execute(String, Handler)}.
+   * @param sql - the sql query to run
+   * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
+   * @param replyHandler the query result or the failure
+   */
+  public void select(String sql, int queryTimeout, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
+    getSQLConnection(queryTimeout,
+        conn -> select(conn, sql, closeAndHandleResult(conn, replyHandler))
+        );
+  }
+
+
+  /**
+   * Method use to exclusively execute read statements from the database
    * <p>To update see {@link #execute(String, Handler)}.
    *  @param sql - the sql query to run
    * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
    * @param replyHandler the query result or the failure
    */
-  public void select(String sql, int queryTimeout, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
+  public void selectRead(String sql, int queryTimeout, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
     getSQLReadConnection(queryTimeout,
         conn -> select(conn, sql, closeAndHandleResult(conn, replyHandler))
-        );
+    );
   }
 
   static void queryAndAnalyze(PgConnection conn, String sql, String statMethod,
@@ -3158,6 +3169,17 @@ public class PostgresClient {
   }
 
   /**
+   * <p>To update see {@link #execute(String, Tuple, Handler)}.
+   *
+   * @param sql  The sql query to run.
+   * @param params  The parameters for the placeholders in sql.
+   * @param replyHandler  The query result or the failure.
+   */
+  public void select(String sql, Tuple params, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
+    getSQLConnection(conn -> select(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
+  }
+
+  /**
    * Run a parameterized/prepared select query using the readonly connection.
    *
    * <p>To update see {@link #execute(String, Tuple, Handler)}.
@@ -3166,7 +3188,7 @@ public class PostgresClient {
    * @param params  The parameters for the placeholders in sql.
    * @param replyHandler  The query result or the failure.
    */
-  public void select(String sql, Tuple params, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
+  public void selectRead(String sql, Tuple params, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
     getSQLReadConnection(conn -> select(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
   }
 
@@ -3197,7 +3219,6 @@ public class PostgresClient {
   }
 
   /**
-   * Run a select query with the readonly connection and return the first record, or null if there is no result.
    *
    * <p>To update see {@link #execute(String, Handler)}.
    *
@@ -3205,6 +3226,19 @@ public class PostgresClient {
    * @param replyHandler  The query result or the failure.
    */
   public void selectSingle(String sql, Handler<AsyncResult<Row>> replyHandler) {
+    getSQLConnection(conn -> selectSingle(conn, sql, closeAndHandleResult(conn, replyHandler)));
+  }
+
+
+  /**
+   * Executes a SELECT query on the readonly connection and return the first record, or null if there is no result.
+   *
+   * <p>To update see {@link #execute(String, Handler)}.
+   *
+   * @param sql  The sql query to run.
+   * @param replyHandler  The query result or the failure.
+   */
+  public void selectSingleRead(String sql, Handler<AsyncResult<Row>> replyHandler) {
     getSQLReadConnection(conn -> selectSingle(conn, sql, closeAndHandleResult(conn, replyHandler)));
   }
 
@@ -3236,7 +3270,7 @@ public class PostgresClient {
   }
 
   /**
-   * Run a parameterized/prepared select query with the readonly connection
+   * Run a parameterized/prepared select query
    * and return the first record, or null if there is no result.
    *
    * <p>To update see {@link #execute(String, Handler)}.
@@ -3246,8 +3280,23 @@ public class PostgresClient {
    * @param replyHandler  The query result or the failure.
    */
   public void selectSingle(String sql, Tuple params, Handler<AsyncResult<Row>> replyHandler) {
+    getSQLConnection(conn -> selectSingle(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
+  }
+
+  /**
+   * Run a parameterized/prepared select query with the readonly connection
+   * and return the first record, or null if there is no result.
+   *
+   * <p>To update see {@link #execute(String, Handler)}.
+   *
+   * @param sql  The sql query to run.
+   * @param params  The parameters for the placeholders in sql.
+   * @param replyHandler  The query result or the failure.
+   */
+  public void selectSingleRead(String sql, Tuple params, Handler<AsyncResult<Row>> replyHandler) {
     getSQLReadConnection(conn -> selectSingle(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
   }
+
 
   /**
    * Run a parameterized/prepared select query and return the first record, or null if there is no result.
@@ -3322,6 +3371,25 @@ public class PostgresClient {
    * @param chunkSize cursor fetch size
    */
   public Future<Void> selectStream(String sql, Tuple params, int chunkSize, Handler<RowStream<Row>> rowStreamHandler) {
+    return withTrans(trans -> trans.selectStream(sql, params, chunkSize, rowStreamHandler));
+  }
+
+  /**
+   * Get a stream of the results of the {@code sql} read-only query (no nextval(), no UPDATE, etc..)
+   * using the readonly connection.
+   *
+   * Sample usage:
+   *
+   * <pre>
+   * postgresClient.selectReadStream("SELECT i FROM numbers WHERE i > $1", Tuple.tuple(5), 100,
+   *         rowStream -> rowStream.handler(row -> task.process(row))))
+   * .compose(x -> ...
+   * </pre>
+   *
+   * @param params arguments for {@code $} placeholders in {@code sql}
+   * @param chunkSize cursor fetch size
+   */
+  public Future<Void> selectReadStream(String sql, Tuple params, int chunkSize, Handler<RowStream<Row>> rowStreamHandler) {
     return withReadTrans(trans -> trans.selectStream(sql, params, chunkSize, rowStreamHandler));
   }
 
@@ -3461,8 +3529,8 @@ public class PostgresClient {
    *
    * @see #withReadConn(Function)
    * @see #withReadConnection(Function)
-   * @see #withTrans(Function)
-   * @see #withTransaction(Function)
+   * @see #withReadTrans(Function)
+   * @see #withReadTransaction(Function)
    */
   public void getReadConnection(Handler<AsyncResult<PgConnection>> replyHandler) {
     getReadConnection().onComplete(replyHandler);
@@ -3482,10 +3550,10 @@ public class PostgresClient {
    * @see #withTrans(Function)
    * @see #withTransaction(Function)
    */
-
   void getSQLConnection(Handler<AsyncResult<SQLConnection>> handler) {
     getSQLConnection(0, handler);
   }
+
   /**
    * Don't forget to close the connection!
    *
@@ -3497,8 +3565,8 @@ public class PostgresClient {
    *
    * @see #withReadConn(Function)
    * @see #withReadConnection(Function)
-   * @see #withTrans(Function)
-   * @see #withTransaction(Function)
+   * @see #withReadTrans(Function)
+   * @see #withReadTransaction(Function)
    */
   void getSQLReadConnection(Handler<AsyncResult<SQLConnection>> handler) {
     getSQLReadConnection(0, handler);
@@ -3549,8 +3617,8 @@ public class PostgresClient {
   /**
    * Get the SQL Write connection
    *
-   * @see #withReadConn(Function)
-   * @see #withReadConnection(Function)
+   * @see #withConn(Function)
+   * @see #withConnection(Function)
    * @see #withTrans(Function)
    * @see #withTransaction(Function)
    */
@@ -3563,8 +3631,8 @@ public class PostgresClient {
    *
    * @see #withReadConn(Function)
    * @see #withReadConnection(Function)
-   * @see #withTrans(Function)
-   * @see #withTransaction(Function)
+   * @see #withReadTrans(Function)
+   * @see #withReadTransaction(Function)
    */
   void getSQLReadConnection(int queryTimeout, Handler<AsyncResult<SQLConnection>> handler) {
     getReadConnection(res -> getSQLConnection(res, queryTimeout, handler));

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3085,7 +3085,9 @@ public class PostgresClient {
   }
 
   /**
-   * Run an SQL statement that updates data and returns data, for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
+   * Run an SQL statement that updates data and returns data,
+   * for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
+   *
    * @see #selectRead(String, int, Handler)
    * @see #execute(String, Handler)
    * @param sql - the sql query to run
@@ -3171,7 +3173,8 @@ public class PostgresClient {
   }
 
   /**
-   * Run an prepared/parameterized SQL statement that updates data and returns data, for example {@code SELECT nextval($1)} or {@code UPDATE ... RETURNING ...}.
+   * Run an prepared/parameterized SQL statement that updates data and returns data,
+   * for example {@code SELECT nextval($1)} or {@code UPDATE ... RETURNING ...}.
    *
    * @param sql  The sql query to run.
    * @param params  The parameters for the placeholders in sql.
@@ -3223,7 +3226,8 @@ public class PostgresClient {
   }
 
   /**
-   * Run an SQL statement that may write data and returns data, for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
+   * Run an SQL statement that may write data and returns data,
+   * for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
    *
    * @param sql  The sql query to run.
    * @param replyHandler  The query result or the failure.

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -3085,7 +3085,9 @@ public class PostgresClient {
   }
 
   /**
-   * <p>To update see {@link #execute(String, Handler)}.
+   * Run an SQL statement that updates data and returns data, for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
+   * @see #selectRead(String, int, Handler)
+   * @see #execute(String, Handler)
    * @param sql - the sql query to run
    * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
    * @param replyHandler the query result or the failure
@@ -3096,11 +3098,11 @@ public class PostgresClient {
         );
   }
 
-
   /**
-   * Method use to exclusively execute read statements from the database
-   * <p>To update see {@link #execute(String, Handler)}.
-   *  @param sql - the sql query to run
+   * Execute a read-only SQL statement that returns data.
+   * @see #select(String, int, Handler)
+   * @see #execute(String, Handler)
+   * @param sql - the sql query to run
    * @param queryTimeout query timeout in milliseconds, or 0 for no timeout
    * @param replyHandler the query result or the failure
    */
@@ -3169,11 +3171,13 @@ public class PostgresClient {
   }
 
   /**
-   * <p>To update see {@link #execute(String, Tuple, Handler)}.
+   * Run an prepared/parameterized SQL statement that updates data and returns data, for example {@code SELECT nextval($1)} or {@code UPDATE ... RETURNING ...}.
    *
    * @param sql  The sql query to run.
    * @param params  The parameters for the placeholders in sql.
    * @param replyHandler  The query result or the failure.
+   * @see #selectRead(String, Tuple, Handler)
+   * @see #execute(String, Tuple, Handler)
    */
   public void select(String sql, Tuple params, Handler<AsyncResult<RowSet<Row>>> replyHandler) {
     getSQLConnection(conn -> select(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
@@ -3219,24 +3223,20 @@ public class PostgresClient {
   }
 
   /**
-   *
-   * <p>To update see {@link #execute(String, Handler)}.
+   * Run an SQL statement that may write data and returns data, for example {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
    *
    * @param sql  The sql query to run.
    * @param replyHandler  The query result or the failure.
+   * @see #selectSingleRead(String, Handler)
    */
   public void selectSingle(String sql, Handler<AsyncResult<Row>> replyHandler) {
     getSQLConnection(conn -> selectSingle(conn, sql, closeAndHandleResult(conn, replyHandler)));
   }
 
-
   /**
-   * Executes a SELECT query on the readonly connection and return the first record, or null if there is no result.
-   *
-   * <p>To update see {@link #execute(String, Handler)}.
-   *
    * @param sql  The sql query to run.
    * @param replyHandler  The query result or the failure.
+   * @see #selectSingle(String, Handler)
    */
   public void selectSingleRead(String sql, Handler<AsyncResult<Row>> replyHandler) {
     getSQLReadConnection(conn -> selectSingle(conn, sql, closeAndHandleResult(conn, replyHandler)));
@@ -3270,14 +3270,14 @@ public class PostgresClient {
   }
 
   /**
-   * Run a parameterized/prepared select query
-   * and return the first record, or null if there is no result.
-   *
-   * <p>To update see {@link #execute(String, Handler)}.
+   * Run an SQL statement that may write data and returns data, for example
+   * {@code SELECT nextval('foo')} or {@code UPDATE ... RETURNING ...}.
+   * The first record is returned, or null if there is no result.
    *
    * @param sql  The sql query to run.
    * @param params  The parameters for the placeholders in sql.
    * @param replyHandler  The query result or the failure.
+   * @see #selectSingleRead(String, Tuple, Handler)
    */
   public void selectSingle(String sql, Tuple params, Handler<AsyncResult<Row>> replyHandler) {
     getSQLConnection(conn -> selectSingle(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
@@ -3287,7 +3287,7 @@ public class PostgresClient {
    * Run a parameterized/prepared select query with the readonly connection
    * and return the first record, or null if there is no result.
    *
-   * <p>To update see {@link #execute(String, Handler)}.
+   * @see #selectSingle(String, Tuple, Handler)
    *
    * @param sql  The sql query to run.
    * @param params  The parameters for the placeholders in sql.
@@ -3296,7 +3296,6 @@ public class PostgresClient {
   public void selectSingleRead(String sql, Tuple params, Handler<AsyncResult<Row>> replyHandler) {
     getSQLReadConnection(conn -> selectSingle(conn, sql, params, closeAndHandleResult(conn, replyHandler)));
   }
-
 
   /**
    * Run a parameterized/prepared select query and return the first record, or null if there is no result.

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -108,11 +108,9 @@ public class PostgresClientIT {
 
   @BeforeClass
   public static void doesNotCompleteOnWindows() {
-   /*
     final String os = System.getProperty("os.name").toLowerCase();
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     org.junit.Assume.assumeFalse(os.contains("win")); // RMB-261
-    */
   }
 
   @BeforeClass

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2840,10 +2840,10 @@ public class PostgresClientIT {
 
   @Test
   public void selectReadSql(TestContext context) {
-    createNumbers(context, 7, 8, 9)
+    createNumbers(context, 10, 11, 12)
         .selectRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
             5, context.asyncAssertSuccess(select -> {
-              context.assertEquals("7, 9",  intsAsString(select));
+              context.assertEquals("10, 11, 12",  intsAsString(select));
             }));
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2830,6 +2830,24 @@ public class PostgresClientIT {
   }
 
   @Test
+  public void selectReadParam(TestContext context) {
+    createNumbers(context, 7, 8, 9)
+        .selectRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
+            Tuple.of(7, 9, 11), context.asyncAssertSuccess(select -> {
+              context.assertEquals("7, 9",  intsAsString(select));
+            }));
+  }
+
+  @Test
+  public void selectReadSql(TestContext context) {
+    createNumbers(context, 7, 8, 9)
+        .selectRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
+            5, context.asyncAssertSuccess(select -> {
+              context.assertEquals("7, 9",  intsAsString(select));
+            }));
+  }
+
+  @Test
   public void selectParamTrans(TestContext context) {
     postgresClient = createNumbers(context, 11, 12, 13);
     postgresClient.startTx(asyncAssertTx(context, trans -> {
@@ -2857,6 +2875,15 @@ public class PostgresClientIT {
     .selectStream("SELECT i FROM numbers WHERE i IN (21, 23, 25) ORDER BY i", Tuple.tuple(), 2,
         rowStream -> rowStream.handler(row -> list.add(row.getInteger(0))))
     .onComplete(context.asyncAssertSuccess(x -> assertThat(list.toString(), is("[21, 23]"))));
+  }
+
+  @Test
+  public void selectReadStreamChunkSize(TestContext context) {
+    List<Integer> list = new ArrayList<>();
+    createNumbers(context, 21, 22, 23)
+        .selectReadStream("SELECT i FROM numbers WHERE i IN (21, 23, 25) ORDER BY i", Tuple.tuple(), 2,
+            rowStream -> rowStream.handler(row -> list.add(row.getInteger(0))))
+        .onComplete(context.asyncAssertSuccess(x -> assertThat(list.toString(), is("[21, 23]"))));
   }
 
   @Test
@@ -2938,6 +2965,15 @@ public class PostgresClientIT {
   }
 
   @Test
+  public void selectSingleRead(TestContext context) {
+    postgresClient = createNumbers(context, 41, 42, 43);
+    postgresClient.selectSingleRead("SELECT i FROM numbers WHERE i IN (41, 43, 45) ORDER BY i",
+        context.asyncAssertSuccess(select -> {
+          context.assertEquals(41, select.getInteger(0));
+        }));
+  }
+
+  @Test
   public void selectSingleFuture(TestContext context) {
     postgresClient = createNumbers(context, 41, 42, 43);
     postgresClient.selectSingle("SELECT i FROM numbers WHERE i IN (41, 43, 45) ORDER BY i")
@@ -2962,6 +2998,16 @@ public class PostgresClientIT {
   public void selectSingleParam(TestContext context) {
     postgresClient = createNumbers(context, 51, 52, 53);
     postgresClient.selectSingle("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
+        Tuple.of(51, 53, 55),
+        context.asyncAssertSuccess(select -> {
+          context.assertEquals(51, select.getInteger(0));
+        }));
+  }
+
+  @Test
+  public void selectSingleReadParam(TestContext context) {
+    postgresClient = createNumbers(context, 51, 52, 53);
+    postgresClient.selectSingleRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
         Tuple.of(51, 53, 55),
         context.asyncAssertSuccess(select -> {
           context.assertEquals(51, select.getInteger(0));

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -2842,7 +2842,7 @@ public class PostgresClientIT {
   public void selectReadSql(TestContext context) {
     createNumbers(context, 10, 11, 12)
         .selectRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
-            5, context.asyncAssertSuccess(select -> {
+            200, context.asyncAssertSuccess(select -> {
               context.assertEquals("10, 11, 12",  intsAsString(select));
             }));
   }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -108,9 +108,11 @@ public class PostgresClientIT {
 
   @BeforeClass
   public static void doesNotCompleteOnWindows() {
+   /*
     final String os = System.getProperty("os.name").toLowerCase();
     PostgresClient.setPostgresTester(new PostgresTesterContainer());
     org.junit.Assume.assumeFalse(os.contains("win")); // RMB-261
+    */
   }
 
   @BeforeClass
@@ -2841,7 +2843,7 @@ public class PostgresClientIT {
   @Test
   public void selectReadSql(TestContext context) {
     createNumbers(context, 10, 11, 12)
-        .selectRead("SELECT i FROM numbers WHERE i IN ($1, $2, $3) ORDER BY i",
+        .selectRead("SELECT i FROM numbers WHERE i IN (10, 11, 12) ORDER BY i",
             200, context.asyncAssertSuccess(select -> {
               context.assertEquals("10, 11, 12",  intsAsString(select));
             }));


### PR DESCRIPTION
Implemented additional Read methods that handle exclusive reads while undo changes to some existing read methods that can be used in writing to the database as well. This work is done to address the comments raised by @julianladisch in https://github.com/folio-org/raml-module-builder/pull/1047.  (The 1047 PR is still open but the new commits don't seem to be recognized by Github in this PR to show the differences, thus this new PR is created.)