### PR TITLE
RMB-934: Vert.x 4.3.3 fixing disabled SSL in 4.3.0/4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <junit-jupiter-version>5.8.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.1</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
     <micrometer.version>1.8.4</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping


### PR DESCRIPTION
Vert.x 4.3.0 and 4.3.1 have this regression: They disable SSL in WebClient.

Vert.x >= 4.3.2 has a fix.

https://github.com/vert-x3/vertx-web/issues/2196 "SSL not set for secure Request"

https://github.com/vert-x3/vertx-web/pull/2226 "WebClient ignores the SSL flag when a request is created from request options with the SSL flag true"

https://github.com/vert-x3/vertx-web/issues/2225 "HttpRequestImpl's SSL Isn't Set By RequestOptions"