### PR TITLE
RMB-934: Vert.x 4.3.3 fixing disabled SSL in 4.3.0/4.3.1

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgConnectionMock.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgConnectionMock.java
@@ -1,0 +1,128 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.pgclient.PgNotice;
+import io.vertx.pgclient.PgNotification;
+import io.vertx.pgclient.impl.PgDatabaseMetadata;
+import io.vertx.sqlclient.PrepareOptions;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.PreparedStatement;
+import io.vertx.sqlclient.Query;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Transaction;
+import io.vertx.sqlclient.spi.DatabaseMetadata;
+
+public class PgConnectionMock implements PgConnection {
+  public class PgConnectionMockException extends RuntimeException {
+    public PgConnectionMockException() {
+      super();
+    }
+  }
+
+  @Override
+  public PgConnection notificationHandler(Handler<PgNotification> handler) {
+    return this;
+  }
+
+  @Override
+  public PgConnection cancelRequest(Handler<AsyncResult<Void>> handler) {
+    return this;
+  }
+
+  @Override
+  public int processId() {
+    return 0;
+  }
+
+  @Override
+  public int secretKey() {
+    return 0;
+  }
+
+  @Override
+  public PgConnection prepare(String s, Handler<AsyncResult<PreparedStatement>> handler) {
+    prepare(s).onComplete(handler);
+    return this;
+  }
+
+  @Override
+  public Future<PreparedStatement> prepare(String s) {
+    return Future.failedFuture(new PgConnectionMockException());
+  }
+
+  @Override
+  public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
+    prepare(sql, options).onComplete(handler);
+    return this;
+  }
+
+  @Override
+  public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
+    return prepare(sql);
+  }
+
+  @Override
+  public PgConnection exceptionHandler(Handler<Throwable> handler) {
+    return this;
+  }
+
+  @Override
+  public PgConnection closeHandler(Handler<Void> handler) {
+    return this;
+  }
+
+  @Override
+  public PgConnection noticeHandler(Handler<PgNotice> handler) {
+    throw new RuntimeException();
+  }
+
+  @Override
+  public void begin(Handler<AsyncResult<Transaction>> handler) {
+    begin().onComplete(handler);
+  }
+
+  @Override
+  public Future<Transaction> begin() {
+    throw new PgConnectionMockException();
+  }
+
+  @Override
+  public boolean isSSL() {
+    return false;
+  }
+
+  @Override
+  public Query<RowSet<Row>> query(String s) {
+    throw new PgConnectionMockException();
+  }
+
+  @Override
+  public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
+    throw new PgConnectionMockException();
+  }
+
+  @Override
+  public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
+    throw new PgConnectionMockException();
+  }
+
+  @Override
+  public void close(Handler<AsyncResult<Void>> handler) {
+    close().onComplete(handler);
+  }
+
+  @Override
+  public Future<Void> close() {
+    return Future.succeededFuture();
+  }
+
+  @Override
+  public DatabaseMetadata databaseMetadata() {
+    return new PgDatabaseMetadata("12.0.0");
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -30,20 +30,13 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgNotification;
 import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.impl.RowImpl;
-import io.vertx.sqlclient.PrepareOptions;
-import io.vertx.sqlclient.PreparedQuery;
-import io.vertx.sqlclient.PreparedStatement;
 import io.vertx.sqlclient.Query;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
-import io.vertx.sqlclient.SqlConnection;
 import io.vertx.sqlclient.SqlResult;
-import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.impl.RowDesc;
-import io.vertx.sqlclient.spi.DatabaseMetadata;
 import org.folio.rest.persist.facets.FacetField;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.security.AES;
@@ -391,86 +384,13 @@ public class PostgresClientTest {
     assertThat(setterMethodName, is("setTestField"));
   }
 
-  public class FakeSqlConnection implements PgConnection {
+  public class FakeSqlConnection extends PgConnectionMock {
     final AsyncResult<RowSet<Row>> asyncResult;
     final boolean failExplain;
 
     FakeSqlConnection(AsyncResult<RowSet<Row>> result, boolean failExplain) {
       this.asyncResult = result;
       this.failExplain = failExplain;
-    }
-
-    @Override
-    public PgConnection notificationHandler(Handler<PgNotification> handler) {
-      return this;
-    }
-
-    @Override
-    public PgConnection cancelRequest(Handler<AsyncResult<Void>> handler) {
-      handler.handle(Future.failedFuture("not implemented"));
-      return this;
-    }
-
-    @Override
-    public int processId() {
-      return 0;
-    }
-
-    @Override
-    public int secretKey() {
-      return 0;
-    }
-
-    @Override
-    public PgConnection prepare(String s, Handler<AsyncResult<PreparedStatement>> handler) {
-      handler.handle(prepare(s));
-      return this;
-    }
-
-    @Override
-    public Future<PreparedStatement> prepare(String s) {
-      return Future.failedFuture("not implemented");
-    }
-
-    @Override
-    public SqlConnection prepare(String sql, PrepareOptions options, Handler<AsyncResult<PreparedStatement>> handler) {
-      return prepare(sql, handler);
-    }
-
-    @Override
-    public Future<PreparedStatement> prepare(String sql, PrepareOptions options) {
-      return prepare(sql);
-    }
-
-    @Override
-    public PgConnection exceptionHandler(Handler<Throwable> handler) {
-      return this;
-    }
-
-    @Override
-    public PgConnection closeHandler(Handler<Void> handler) {
-      return null;
-    }
-
-    @Override
-    public void begin(
-        Handler<AsyncResult<Transaction>> handler) {
-
-    }
-
-    @Override
-    public Future<Transaction> begin() {
-      return null;
-    }
-
-    @Override
-    public boolean isSSL() {
-      return false;
-    }
-
-    @Override
-    public void close(Handler<AsyncResult<Void>> handler) {
-
     }
 
     @Override
@@ -512,26 +432,6 @@ public class PostgresClientTest {
           return null;
         }
       };
-    }
-
-    @Override
-    public PreparedQuery<RowSet<Row>> preparedQuery(String s) {
-      return null;
-    }
-
-    @Override
-    public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
-      return null;
-    }
-
-    @Override
-    public Future<Void> close() {
-      return Future.succeededFuture();
-    }
-
-    @Override
-    public DatabaseMetadata databaseMetadata() {
-      return null;
     }
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTransactionsIT.java
@@ -422,7 +422,7 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     }
   }
 
-  class MonitorPgConnection implements PgConnection {
+  class MonitorPgConnection extends PgConnectionMock {
     final PgConnection conn;
     final AtomicInteger open;
     final AtomicInteger active;
@@ -491,11 +491,6 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     }
 
     @Override
-    public void begin(Handler<AsyncResult<Transaction>> handler) {
-      begin().onComplete(handler);
-    }
-
-    @Override
     public Future<Transaction> begin() {
       active.incrementAndGet();
       return conn.begin().map(trans -> new MonitorTransaction(trans, active));
@@ -519,11 +514,6 @@ public class PostgresClientTransactionsIT extends PostgresClientITBase {
     @Override
     public PreparedQuery<RowSet<Row>> preparedQuery(String sql, PrepareOptions options) {
       return conn.preparedQuery(sql, options);
-    }
-
-    @Override
-    public void close(Handler<AsyncResult<Void>> handler) {
-      close().onComplete(handler);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <aspectj.version>1.9.7</aspectj.version>
     <junit-jupiter-version>5.8.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.1</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
     <micrometer.version>1.8.4</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping


### PR DESCRIPTION
Vert.x 4.3.0 and 4.3.1 have this regression: They disable SSL in WebClient.

Vert.x >= 4.3.2 has a fix.

https://github.com/vert-x3/vertx-web/issues/2196 "SSL not set for secure Request"

https://github.com/vert-x3/vertx-web/pull/2226 "WebClient ignores the SSL flag when a request is created from request options with the SSL flag true"

https://github.com/vert-x3/vertx-web/issues/2225 "HttpRequestImpl's SSL Isn't Set By RequestOptions"