### PR TITLE
Fix previous version used for migration scripts RMB-937

### DIFF
--- a/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/impl/TenantAPIIT.java
@@ -316,7 +316,7 @@ public class TenantAPIIT {
   public void previousSchemaSqlExistsTrue(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI();
     String tenantId = TenantTool.tenantId(okapiHeaders);
-    tenantAPI.previousSchema(vertx.getOrCreateContext(), tenantId, true)
+    tenantAPI.getRmbInternal(vertx.getOrCreateContext(), tenantId, true)
       .onComplete(context.asyncAssertFailure());
   }
 
@@ -328,9 +328,9 @@ public class TenantAPIIT {
     // only run create.ftl .. This makes previousSchema to find nothing on 2nd invocation
     tenantAPI.sqlFile(vertx.getOrCreateContext(), tenantId, null, false)
         .compose(files -> tenantAPI.postgresClient(vertx.getOrCreateContext()).runSQLFile(files[0], true))
-        .compose(x -> tenantAPI.previousSchema(vertx.getOrCreateContext(), tenantId, true)
-        .onComplete(context.asyncAssertSuccess(schema -> {
-          context.assertNull(schema);
+        .compose(x -> tenantAPI.getRmbInternal(vertx.getOrCreateContext(), tenantId, true)
+        .onComplete(context.asyncAssertSuccess(result -> {
+          context.assertNull(result.getString("schemaJson"));
           async.complete();
         })));
     async.await();
@@ -418,8 +418,8 @@ public class TenantAPIIT {
   public void postWithSqlFileIOException(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI() {
       @Override
-      public String [] sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity, Schema previousSchema)
-          throws IOException {
+      public String [] sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity,
+          String previousVersion, Schema previousSchema) throws IOException {
         throw new IOException();
       }
     };
@@ -430,8 +430,8 @@ public class TenantAPIIT {
   public void postWithSqlFileTemplateException(TestContext context) {
     TenantAPI tenantAPI = new TenantAPI() {
       @Override
-      public String [] sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity, Schema previousSchema)
-          throws TemplateException {
+      public String [] sqlFile(String tenantId, boolean tenantExists, TenantAttributes entity,
+          String previousVersion, Schema previousSchema) throws TemplateException {
         throw new TemplateException(null);
       }
     };


### PR DESCRIPTION
Use the stored moduleVersion as previous version rather than module_from from tenant init call. The module_from does not always reflect the true state of module data.