### PR TITLE
RMB-939: failOnConflictUnlessSuppressed for optimistic locking

### DIFF
--- a/dbschema/src/main/java/org/folio/dbschema/OptimisticLockingMode.java
+++ b/dbschema/src/main/java/org/folio/dbschema/OptimisticLockingMode.java
@@ -11,6 +11,9 @@ public enum OptimisticLockingMode {
   LOG,
 
   @JsonProperty("failOnConflict")
-  FAIL
+  FAIL,
+
+  @JsonProperty("failOnConflictUnlessSuppressed")
+  FAIL_SUPPRESS
 
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -1424,6 +1424,7 @@ public final class PgUtil {
    *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
    * @return result created by responseClass
    */
+  @SuppressWarnings("squid:S107")  // Suppress "Method has 8 parameters, which is greater than 7 authorized."
   public static <T> Future<Response> postSync(String table, List<T> entities, int maxEntities,
       boolean upsert, boolean optimisticLocking,
       Map<String, String> okapiHeaders, Context vertxContext,

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.rest.tools.utils.MetadataUtil;
+import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.rest.tools.utils.OutStream;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.rest.tools.utils.ValidationHelper;
@@ -1239,6 +1240,7 @@ public final class PgUtil {
   /**
    * Put entity to table.
    *
+   * <p>To enforce optimistic locking the version of entity is set to null if it is -1.
    * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
    * @param table  table name
@@ -1255,12 +1257,13 @@ public final class PgUtil {
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> clazz,
       Handler<AsyncResult<Response>> asyncResultHandler) {
-      put(table,entity,id,okapiHeaders,vertxContext,clazz).onComplete(asyncResultHandler);
+    put(table,entity,id,okapiHeaders,vertxContext,clazz).onComplete(asyncResultHandler);
   }
 
   /**
    * Put entity to table.
    *
+   * <p>To enforce optimistic locking the version of entity is set to null if it is -1.
    * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
    * @param table  table name
@@ -1295,6 +1298,7 @@ public final class PgUtil {
         return responseInvalidUuid(table + ".id", id, clazz, respond400, respond500);
       }
       setId(entity, id);
+      OptimisticLockingUtil.unsetVersionIfMinusOne(entity);
       final Promise<Response> promise = Promise.promise();
       PostgresClient postgresClient = postgresClient(vertxContext, okapiHeaders);
       postgresClient.update(table, entity, id, reply -> {
@@ -1340,22 +1344,69 @@ public final class PgUtil {
 
   /**
    * Post a list of T entities to the database. Fail all if any of them fails.
+   *
+   * <p>To enforce optimistic locking each entity's version is set to null if it is -1.
+   *
    * @param table database table to store into
    * @param entities  the records to store
    * @param maxEntities  fail with HTTP 413 if entities.size() > maxEntities to avoid out of memory;
- *     suggested value is from 100 ... 10000.
+   *     suggested value is from 100 ... 10000.
    * @param upsert  true to update records with the same id, false to fail all entities if one has an existing id
    * @param okapiHeaders  http headers provided by okapi
    * @param vertxContext  the current context
    * @param responseClass  the ResponseDelegate class created from the RAML file with these methods:
-  *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
+   *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
    * @param asyncResultHandler where to return the result created by responseClass
    */
   public static <T> void postSync(String table, List<T> entities, int maxEntities, boolean upsert,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> responseClass,
       Handler<AsyncResult<Response>> asyncResultHandler) {
-    postSync(table, entities, maxEntities, upsert, okapiHeaders, vertxContext, responseClass).onComplete(asyncResultHandler);
+    postSync(table, entities, maxEntities, upsert, true, okapiHeaders, vertxContext, responseClass).onComplete(asyncResultHandler);
+  }
+
+  /**
+   * Post a list of T entities to the database. Fail all if any of them fails.
+   *
+   * <p>To enforce optimistic locking each entity's version is set to null if it is -1.
+   *
+   * @param table database table to store into
+   * @param entities  the records to store
+   * @param maxEntities  fail with HTTP 413 if entities.size() > maxEntities to avoid out of memory;
+   *     suggested value is from 100 ... 10000.
+   * @param upsert  true to update records with the same id, false to fail all entities if one has an existing id
+   * @param okapiHeaders  http headers provided by okapi
+   * @param vertxContext  the current context
+   * @param responseClass  the ResponseDelegate class created from the RAML file with these methods:
+   *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
+   * @return future where to return the result created by responseClass
+   */
+  public static <T> Future<Response> postSync(String table, List<T> entities, int maxEntities, boolean upsert,
+      Map<String, String> okapiHeaders, Context vertxContext,
+      Class<? extends ResponseDelegate> responseClass) {
+    return postSync(table, entities, maxEntities, upsert, true, okapiHeaders, vertxContext, responseClass);
+  }
+
+  /**
+   * Post a list of T entities to the database using upsert and with optimistic locking disabled.
+   *
+   * <p>To enforce optimistic locking each entity's version is set to null if it is -1.
+   * <p>Fail all if any of them fails.
+   *
+   * @param table database table to store into
+   * @param entities  the records to store
+   * @param maxEntities  fail with HTTP 413 if entities.size() > maxEntities to avoid out of memory;
+   *     suggested value is from 100 ... 10000.
+   * @param okapiHeaders  http headers provided by okapi
+   * @param vertxContext  the current context
+   * @param responseClass  the ResponseDelegate class created from the RAML file with these methods:
+   *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
+   * @return result created by responseClass
+   */
+  public static <T> Future<Response> postSyncUnsafe(String table, List<T> entities, int maxEntities,
+      Map<String, String> okapiHeaders, Context vertxContext,
+      Class<? extends ResponseDelegate> responseClass) {
+    return postSync(table, entities, maxEntities, true, false, okapiHeaders, vertxContext, responseClass);
   }
 
   /**
@@ -1363,15 +1414,18 @@ public final class PgUtil {
    * @param table database table to store into
    * @param entities  the records to store
    * @param maxEntities  fail with HTTP 413 if entities.size() > maxEntities to avoid out of memory;
- *     suggested value is from 100 ... 10000.
+   *     suggested value is from 100 ... 10000.
    * @param upsert  true to update records with the same id, false to fail all entities if one has an existing id
+   * @param optimisticLocking  If false and DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING allows this then optimistic locking is disabled.
+   *         Otherwise each entity's version is set to null if it is -1 to enforce optimistic locking.
    * @param okapiHeaders  http headers provided by okapi
    * @param vertxContext  the current context
    * @param responseClass  the ResponseDelegate class created from the RAML file with these methods:
-*               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
-   * @return future where to return the result created by responseClass
+   *               respond201(), respond409WithTextPlain(Object), respond413WithTextPlain(Object), respond500WithTextPlain(Object).
+   * @return result created by responseClass
    */
-  public static <T> Future<Response> postSync(String table, List<T> entities, int maxEntities, boolean upsert,
+  public static <T> Future<Response> postSync(String table, List<T> entities, int maxEntities,
+      boolean upsert, boolean optimisticLocking,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> responseClass) {
 
@@ -1393,11 +1447,21 @@ public final class PgUtil {
             + " records to prevent out of memory but got " + entities.size();
         return response(message, respond413, respond500);
       }
+
+      if (optimisticLocking) {
+        OptimisticLockingUtil.unsetVersionIfMinusOne(entities);
+      } else {
+        if (! OptimisticLockingUtil.isSuppressingOptimisticLockingAllowed()) {
+          return response("DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING environment variable doesn't allow "
+              + "to disable optimistic locking", respond413, respond500);
+        }
+        OptimisticLockingUtil.setVersionToMinusOne(entities);
+      }
+
       // RestVerticle populates a single record only, not an array of records
+      MetadataUtil.populateMetadata(entities, okapiHeaders);
 
       Promise<Response> promise = Promise.promise();
-
-      MetadataUtil.populateMetadata(entities, okapiHeaders);
       PostgresClient postgresClient = postgresClient(vertxContext, okapiHeaders);
       Handler<AsyncResult<RowSet<Row>>> replyHandler = result -> {
         if (result.failed()) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OptimisticLockingUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OptimisticLockingUtil.java
@@ -1,0 +1,139 @@
+package org.folio.rest.tools.utils;
+
+import java.lang.reflect.Method;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class OptimisticLockingUtil {
+  public final static String DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING = "DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING";
+  private static ZonedDateTime allowSuppressOptimistcLocking;
+
+  static {
+    configureAllowSuppressOptimisticLocking(System.getenv());
+  }
+
+  private OptimisticLockingUtil() {
+    throw new UnsupportedOperationException("Cannot instantiate utility class");
+  }
+
+  public static void configureAllowSuppressOptimisticLocking(Map<String,String> env) {
+    String s = env.getOrDefault(DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING, "0001-01-01T00:00:00Z");
+    allowSuppressOptimistcLocking = ZonedDateTime.parse(s);
+  }
+
+  /**
+   * Whether DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING environment variable allows suppressing optimistic locking
+   * at the current time.
+   */
+  public static boolean isSuppressingOptimisticLockingAllowed() {
+    return ZonedDateTime.now().isBefore(allowSuppressOptimistcLocking);
+  }
+
+  /**
+   * @return a two element array containing {@code Integer entity.getVersion()} and
+   *     {@code entity.setVersion(Integer); each element can be null if not found;
+   *     entity is the first non-null list element.
+   */
+  private static <T> Method [] getVersionMethods(List<T> list) {
+    Method [] methods = new Method [2];
+
+    Optional<T> any = list.stream().filter(Objects::nonNull).findAny();
+    if (any.isEmpty()) {
+      return methods;
+    }
+
+    T entity = any.get();
+
+    // entity.getClass().getMethod("setMetadata", null)
+    // is 20 times slower than this loop when not found because of throwing the exception
+    for (Method method : entity.getClass().getMethods()) {
+      System.out.println(method.getName() + " " + method.getReturnType().getName());
+      if (method.getName().equals("getVersion") &&
+          method.getReturnType().equals(java.lang.Integer.class) &&
+          method.getParameterCount() == 0) {
+        methods[0] = method;
+      } else if (method.getName().equals("setVersion") &&
+          method.getParameterCount() == 1 &&
+          method.getParameters()[0].getType().equals(Integer.class)) {
+        methods[1] = method;
+      } else {
+        continue;
+      }
+      if (methods[0] != null && methods[1] != null) {
+        return methods;
+      }
+    }
+    return methods;
+  }
+
+  /**
+   * Set version to -1 for each T of entities.
+   *
+   * <p>This disables optimistic locking.
+   */
+  public static <T> void setVersionToMinusOne(List<T> entities)
+      throws ReflectiveOperationException {
+
+    if (entities == null) {
+      return;
+    }
+
+    Method setVersion = getVersionMethods(entities)[1];
+
+    if (setVersion == null) {
+      return;
+    }
+
+    for (T entity : entities) {
+      if (entity == null) {
+        continue;
+      }
+      setVersion.invoke(entity, -1);
+    }
+  }
+
+  /**
+   * For each T of entities set version to null if version is -1.
+   *
+   * <p>This enforces optimistic locking as -1 disables optimistic locking.
+   */
+  public static <T> void unsetVersionIfMinusOne(List<T> entities)
+      throws ReflectiveOperationException {
+
+    if (entities == null) {
+      return;
+    }
+
+    Method [] methods = getVersionMethods(entities);
+    Method getVersion = methods[0];
+    Method setVersion = methods[1];
+
+    if (getVersion == null || setVersion == null) {
+      return;
+    }
+
+    for (T entity : entities) {
+      if (entity == null) {
+        continue;
+      }
+      Integer version = (Integer) getVersion.invoke(entity, (Object []) null);
+      if (version == null || version.intValue() != -1) {
+        continue;
+      }
+
+      setVersion.invoke(entity, (Object) null);
+    }
+  }
+
+  /**
+   * Set version to null if version is -1.
+   *
+   * <p>This enforces optimistic locking as -1 disables optimistic locking.
+   */
+  public static <T> void unsetVersionIfMinusOne(T entity) throws ReflectiveOperationException {
+    unsetVersionIfMinusOne(List.of(entity));
+  }
+}

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OptimisticLockingUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/OptimisticLockingUtil.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 public final class OptimisticLockingUtil {
-  public final static String DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING = "DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING";
+  public static final String DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING = "DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING";
   private static ZonedDateTime allowSuppressOptimistcLocking;
 
   static {
@@ -50,7 +50,6 @@ public final class OptimisticLockingUtil {
     // entity.getClass().getMethod("setMetadata", null)
     // is 20 times slower than this loop when not found because of throwing the exception
     for (Method method : entity.getClass().getMethods()) {
-      System.out.println(method.getName() + " " + method.getReturnType().getName());
       if (method.getName().equals("getVersion") &&
           method.getReturnType().equals(java.lang.Integer.class) &&
           method.getParameterCount() == 0) {
@@ -120,11 +119,9 @@ public final class OptimisticLockingUtil {
         continue;
       }
       Integer version = (Integer) getVersion.invoke(entity, (Object []) null);
-      if (version == null || version.intValue() != -1) {
-        continue;
+      if (Integer.valueOf(-1).equals(version)) {
+        setVersion.invoke(entity, (Object) null);
       }
-
-      setVersion.invoke(entity, (Object) null);
     }
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OptimisticLockingUtilTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OptimisticLockingUtilTest.java
@@ -1,0 +1,149 @@
+package org.folio.rest.tools.utils;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.folio.okapi.testing.UtilityClassTester;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.jaxrs.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OptimisticLockingUtilTest {
+
+  @BeforeEach
+  void beforeEach() {
+    OptimisticLockingUtil.configureAllowSuppressOptimisticLocking(Map.of());
+  }
+
+  @Test
+  void isUtilityClass() {
+    UtilityClassTester.assertUtilityClass(OptimisticLockingUtil.class);
+  }
+
+  @Test
+  void setVersionToMinusOne_null() throws ReflectiveOperationException {
+    OptimisticLockingUtil.setVersionToMinusOne(null);
+  }
+
+  @Test
+  void setVersionToMinusOne_empty() throws ReflectiveOperationException {
+    OptimisticLockingUtil.setVersionToMinusOne(List.of());
+  }
+
+  @Test
+  void setVersionToMinusOne_one() throws ReflectiveOperationException {
+    String uuid = UUID.randomUUID().toString();
+    User user = new User().withId(uuid);
+    OptimisticLockingUtil.setVersionToMinusOne(List.of(user));
+    assertThat(user.getVersion(), is(-1));
+    assertThat(user.getId(), is(uuid));
+  }
+
+  @Test
+  void setVersionToMinusOne_three() throws ReflectiveOperationException {
+    String uuid1 = UUID.randomUUID().toString();
+    String uuid2 = UUID.randomUUID().toString();
+    String uuid3 = UUID.randomUUID().toString();
+    User user1 = new User().withId(uuid1).withVersion(0);
+    User user2 = new User().withId(uuid2).withVersion(Integer.MIN_VALUE);
+    User user3 = new User().withId(uuid3).withVersion(Integer.MAX_VALUE);
+    OptimisticLockingUtil.setVersionToMinusOne(List.of(user1, user2, user3));
+    assertThat(user1.getVersion(), is(-1));
+    assertThat(user2.getVersion(), is(-1));
+    assertThat(user3.getVersion(), is(-1));
+    assertThat(user1.getId(), is(uuid1));
+    assertThat(user2.getId(), is(uuid2));
+    assertThat(user3.getId(), is(uuid3));
+  }
+
+  class WrongMethods {
+    public void setMetadata(String s) {
+    }
+    public void setMetadata(Metadata metadata, String x) {
+    }
+  }
+
+  @Test
+  void setVersionToMinusOne_wrongMethods() {
+    assertDoesNotThrow(() ->
+        OptimisticLockingUtil.setVersionToMinusOne(List.of(new WrongMethods())));
+  }
+
+  @Test
+  void unsetVersionIfMinusOne_null() throws ReflectiveOperationException {
+    OptimisticLockingUtil.unsetVersionIfMinusOne(null);
+  }
+
+  @Test
+  void unsetVersionIfMinusOne_empty() throws ReflectiveOperationException {
+    OptimisticLockingUtil.unsetVersionIfMinusOne(List.of());
+  }
+
+  @Test
+  void unsetVersionIfMinusOne_one() throws ReflectiveOperationException {
+    String uuid = UUID.randomUUID().toString();
+    User user = new User().withId(uuid).withVersion(-1);
+    OptimisticLockingUtil.unsetVersionIfMinusOne(List.of(user));
+    assertThat(user.getVersion(), is(nullValue()));
+    assertThat(user.getId(), is(uuid));
+  }
+
+  @Test
+  void unsetVersionIfMinusOne_six() throws ReflectiveOperationException {
+    String uuid1 = UUID.randomUUID().toString();
+    String uuid2 = UUID.randomUUID().toString();
+    String uuid3 = UUID.randomUUID().toString();
+    String uuid4 = UUID.randomUUID().toString();
+    String uuid5 = UUID.randomUUID().toString();
+    String uuid6 = UUID.randomUUID().toString();
+    User user1 = new User().withId(uuid1).withVersion(-1);
+    User user2 = new User().withId(uuid2).withVersion(Integer.MIN_VALUE);
+    User user3 = new User().withId(uuid3).withVersion(0);
+    User user4 = new User().withId(uuid4).withVersion(Integer.MAX_VALUE);
+    User user5 = new User().withId(uuid5);
+    User user6 = new User().withId(uuid6).withVersion(-1);
+    OptimisticLockingUtil.unsetVersionIfMinusOne(List.of(user1, user2, user3, user4, user5, user6));
+    assertThat(user1.getVersion(), is(nullValue()));
+    assertThat(user2.getVersion(), is(Integer.MIN_VALUE));
+    assertThat(user3.getVersion(), is(0));
+    assertThat(user4.getVersion(), is(Integer.MAX_VALUE));
+    assertThat(user5.getVersion(), is(nullValue()));
+    assertThat(user6.getVersion(), is(nullValue()));
+    assertThat(user1.getId(), is(uuid1));
+    assertThat(user2.getId(), is(uuid2));
+    assertThat(user3.getId(), is(uuid3));
+    assertThat(user4.getId(), is(uuid4));
+    assertThat(user5.getId(), is(uuid5));
+    assertThat(user6.getId(), is(uuid6));
+  }
+
+  @Test
+  void unsetVersionIfMinusOne_wrongMethods() {
+    assertDoesNotThrow(() ->
+        OptimisticLockingUtil.unsetVersionIfMinusOne(List.of(new WrongMethods())));
+  }
+
+  @Test
+  void isSuppressAllowed_default() {
+    assertThat(OptimisticLockingUtil.isSuppressingOptimisticLockingAllowed(), is(false));
+  }
+
+  @Test
+  void isSupporessAllowed_expired() {
+    OptimisticLockingUtil.configureAllowSuppressOptimisticLocking(
+        Map.of(OptimisticLockingUtil.DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING, "2022-01-01T00:00:00Z"));
+    assertThat(OptimisticLockingUtil.isSuppressingOptimisticLockingAllowed(), is(false));
+  }
+
+  @Test
+  void isSupporessAllowed_future() {
+    OptimisticLockingUtil.configureAllowSuppressOptimisticLocking(
+        Map.of(OptimisticLockingUtil.DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING, "2999-01-01T00:00:00Z"));
+    assertThat(OptimisticLockingUtil.isSuppressingOptimisticLockingAllowed(), is(true));
+  }
+}

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OptimisticLockingUtilTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/OptimisticLockingUtilTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -27,12 +28,12 @@ class OptimisticLockingUtilTest {
 
   @Test
   void setVersionToMinusOne_null() throws ReflectiveOperationException {
-    OptimisticLockingUtil.setVersionToMinusOne(null);
+    assertDoesNotThrow(() -> OptimisticLockingUtil.setVersionToMinusOne(null));
   }
 
   @Test
   void setVersionToMinusOne_empty() throws ReflectiveOperationException {
-    OptimisticLockingUtil.setVersionToMinusOne(List.of());
+    assertDoesNotThrow(() -> OptimisticLockingUtil.setVersionToMinusOne(List.of()));
   }
 
   @Test
@@ -45,20 +46,25 @@ class OptimisticLockingUtilTest {
   }
 
   @Test
-  void setVersionToMinusOne_three() throws ReflectiveOperationException {
+  void setVersionToMinusOne_four() throws ReflectiveOperationException {
     String uuid1 = UUID.randomUUID().toString();
     String uuid2 = UUID.randomUUID().toString();
-    String uuid3 = UUID.randomUUID().toString();
+    String uuid4 = UUID.randomUUID().toString();
     User user1 = new User().withId(uuid1).withVersion(0);
     User user2 = new User().withId(uuid2).withVersion(Integer.MIN_VALUE);
-    User user3 = new User().withId(uuid3).withVersion(Integer.MAX_VALUE);
-    OptimisticLockingUtil.setVersionToMinusOne(List.of(user1, user2, user3));
+    User user4 = new User().withId(uuid4).withVersion(Integer.MAX_VALUE);
+    List<User> list = new ArrayList<>();
+    list.add(user1);
+    list.add(user2);
+    list.add(null);
+    list.add(user4);
+    OptimisticLockingUtil.setVersionToMinusOne(list);
     assertThat(user1.getVersion(), is(-1));
     assertThat(user2.getVersion(), is(-1));
-    assertThat(user3.getVersion(), is(-1));
+    assertThat(user4.getVersion(), is(-1));
     assertThat(user1.getId(), is(uuid1));
     assertThat(user2.getId(), is(uuid2));
-    assertThat(user3.getId(), is(uuid3));
+    assertThat(user4.getId(), is(uuid4));
   }
 
   class WrongMethods {
@@ -76,12 +82,12 @@ class OptimisticLockingUtilTest {
 
   @Test
   void unsetVersionIfMinusOne_null() throws ReflectiveOperationException {
-    OptimisticLockingUtil.unsetVersionIfMinusOne(null);
+    assertDoesNotThrow(() -> OptimisticLockingUtil.unsetVersionIfMinusOne(null));
   }
 
   @Test
   void unsetVersionIfMinusOne_empty() throws ReflectiveOperationException {
-    OptimisticLockingUtil.unsetVersionIfMinusOne(List.of());
+    assertDoesNotThrow(() -> OptimisticLockingUtil.unsetVersionIfMinusOne(List.of()));
   }
 
   @Test

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking.json
@@ -13,6 +13,10 @@
       "withOptimisticLocking": "failOnConflict"
     },
     {
+      "tableName": "tab_ol_fail_suppress",
+      "withOptimisticLocking": "failOnConflictUnlessSuppressed"
+    },
+    {
       "tableName": "tab_ol_none"
     }
   ]

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking2.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking2.json
@@ -13,6 +13,10 @@
       "withOptimisticLocking": "off"
     },
     {
+      "tableName": "tab_ol_fail_suppress",
+      "withOptimisticLocking": "failOnConflictUnlessSuppressed"
+    },
+    {
       "tableName": "tab_ol_none"
     }
   ]

--- a/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking3.json
+++ b/domain-models-runtime/src/test/resources/templates/db_scripts/schemaWithOptimisticLocking3.json
@@ -13,6 +13,10 @@
       "withOptimisticLocking": "off"
     },
     {
+      "tableName": "tab_ol_fail_suppress",
+      "withOptimisticLocking": "off"
+    },
+    {
       "tableName": "tab_ol_none"
     }
   ]


### PR DESCRIPTION
* Add environment variable DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING
* Add schema configuration "withOptimisticLocking": "failOnConflictUnlessSuppressed"
* Add OptimisticLockingUtil with helper methods
* Add PgUtil.postSyncUnsafe
* Handle "_version": -1 in PgUtil.put and PgUtil.postSync

For details see https://issues.folio.org/browse/MODINVSTOR-924