### PR TITLE
RMB-940: postgresql client 42.5.0 fixing SQL Injection CVE-2022-31197

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.3.6</version>
+      <version>42.5.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Upgrade org.postgresql:postgresql from 42.3.6 to 42.5.0 fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197