### PR TITLE
Release 35.0.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 35.0.1 2022-10-11
+
+Bug fixes:
+ * [RMB-945](https://issues.folio.org/browse/RMB-945) Vert.x 4.3.4, micrometer 1.9.4, log4j 2.19.0, okapi 4.14.5
+
 ## 35.0.0 2022-09-30
 
 New features:

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <properties>

--- a/cql2pgjson-cli/pom.xml
+++ b/cql2pgjson-cli/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <properties>

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
   <properties>

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-maven-plugin</artifactId>
   <description>Domain Model Generator that reads RAML files and writes Java files</description>

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
   <artifactId>domain-models-maven-plugin</artifactId>
   <description>Domain Model Generator that reads RAML files and writes Java files</description>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <repositories>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalColumnDescriptor.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalColumnDescriptor.java
@@ -1,0 +1,32 @@
+package org.folio.rest.persist.helpers;
+
+import io.vertx.sqlclient.desc.ColumnDescriptor;
+import java.sql.JDBCType;
+
+public class LocalColumnDescriptor implements ColumnDescriptor {
+  private final String name;
+
+  public LocalColumnDescriptor(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public boolean isArray() {
+    return false;
+  }
+
+  @Override
+  public String typeName() {
+    return null;
+  }
+
+  @Override
+  public JDBCType jdbcType() {
+    return null;
+  }
+}

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
@@ -1,0 +1,23 @@
+package org.folio.rest.persist.helpers;
+
+import io.vertx.sqlclient.desc.ColumnDescriptor;
+import io.vertx.sqlclient.impl.RowDesc;
+import java.util.List;
+
+public class LocalRowDesc extends RowDesc {
+  public LocalRowDesc(ColumnDescriptor[] columnDescriptors) {
+    super(columnDescriptors);
+  }
+
+  public LocalRowDesc(List<String> columnNames) {
+    super(columnDescriptors(columnNames));
+  }
+
+  private static ColumnDescriptor [] columnDescriptors(List<String> columnNames) {
+    ColumnDescriptor [] columnDescriptors = new ColumnDescriptor [columnNames.size()];
+    for (int i = 0; i < columnNames.size(); i++) {
+      columnDescriptors[i] = new LocalColumnDescriptor(columnNames.get(i));
+    }
+    return columnDescriptors;
+  }
+}

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
@@ -6,15 +6,15 @@ import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
 import io.vertx.sqlclient.impl.RowDesc;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 public class LocalRowSet implements RowSet<Row> {
+  private static final ColumnDescriptor [] NO_COLUMN_DESCRIPTORS = new ColumnDescriptor [0];
   final int rowCount;
   List<Row> rows = new LinkedList<>();
-  RowDesc rowDesc = new RowDesc(Collections.emptyList());
+  RowDesc rowDesc = new LocalRowDesc(NO_COLUMN_DESCRIPTORS);
 
   public LocalRowSet(int rowCount) {
     this.rowCount = rowCount;
@@ -26,7 +26,7 @@ public class LocalRowSet implements RowSet<Row> {
   }
 
   public LocalRowSet withColumns(List<String> columns) {
-    this.rowDesc = new RowDesc(columns);
+    this.rowDesc = new LocalRowDesc(columns);
     return this;
   }
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -54,7 +54,6 @@ import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.Transaction;
 import io.vertx.sqlclient.TransactionRollbackException;
 import io.vertx.sqlclient.Tuple;
-import io.vertx.sqlclient.impl.RowDesc;
 import org.apache.commons.io.IOUtils;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
@@ -70,6 +69,7 @@ import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.Criteria.UpdateSection;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.persist.facets.FacetField;
+import org.folio.rest.persist.helpers.LocalRowDesc;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.persist.helpers.Poline;
 import org.folio.rest.persist.helpers.SimplePojo;
@@ -3964,20 +3964,12 @@ public class PostgresClientIT {
 
   @Test
   public void selectReturnOneRow(TestContext context) {
-    List<String> columns = new LinkedList<>();
-    columns.add("field");
-    RowDesc rowDesc = new RowDesc(columns);
-    List<Row> rows = new LinkedList<>();
-    Row row = new RowImpl(rowDesc);
-    row.addString("value");
-    rows.add(row);
-    RowSet rowSet = new LocalRowSet(1).withColumns(columns).withRows(rows);
-
-    Promise<RowSet<Row>> promise = Promise.promise();
-    promise.complete(rowSet);
-    PostgresClient.selectReturn(promise.future(), context.asyncAssertSuccess(res ->
+    List<String> columns = List.of("field");
+    List<Row> rows = List.of(new RowImpl(new LocalRowDesc(columns)));
+    rows.get(0).addString("value");
+    RowSet<Row> rowSet = new LocalRowSet(1).withColumns(columns).withRows(rows);
+    PostgresClient.selectReturn(Future.succeededFuture(rowSet), context.asyncAssertSuccess(res ->
         context.assertEquals("value", res.getString(0))));
   }
-
 
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -38,6 +38,7 @@ import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.SqlResult;
 import io.vertx.sqlclient.impl.RowDesc;
 import org.folio.rest.persist.facets.FacetField;
+import org.folio.rest.persist.helpers.LocalRowDesc;
 import org.folio.rest.persist.helpers.LocalRowSet;
 import org.folio.rest.security.AES;
 import org.folio.rest.security.AESTest;
@@ -354,12 +355,7 @@ public class PostgresClientTest {
     Double biz = 1.0;
     String [] baz = new String[] { "This", "is", "a", "test" };
 
-    List<String> rowColumns = new LinkedList<>();
-    rowColumns.add("foo");
-    rowColumns.add("bar");
-    rowColumns.add("biz");
-    rowColumns.add("baz");
-    RowDesc desc = new RowDesc(rowColumns);
+    RowDesc desc = new LocalRowDesc(List.of("foo", "bar", "biz", "baz"));
     Row row = new RowImpl(desc);
     row.addString(foo);
     row.addString(bar);
@@ -403,9 +399,8 @@ public class PostgresClientTest {
           if (s.startsWith("EXPLAIN") && failExplain) {
             handler.handle(Future.failedFuture("failExplain"));
           } else if (s.startsWith("COUNT ") && asyncResult.succeeded()) {
-            List<String> columnNames = new LinkedList<>();
-            columnNames.add("COUNT");
-            RowDesc rowDesc = new RowDesc(columnNames);
+            List<String> columnNames = List.of("COUNT");
+            RowDesc rowDesc = new LocalRowDesc(columnNames);
             Row row = new RowImpl(rowDesc);
             row.addInteger(asyncResult.result().size());
             List<Row> rows = new LinkedList<>();
@@ -513,10 +508,8 @@ public class PostgresClientTest {
   }
 
   private RowSet<Row> getMockTestPojoResultSet(int total) {
-    List<String> columnNames = new ArrayList<String>(Arrays.asList(new String[] {
-      "id", "foo", "bar", "biz", "baz"
-    }));
-    RowDesc rowDesc = new RowDesc(columnNames);
+    List<String> columnNames = List.of("id", "foo", "bar", "biz", "baz");
+    RowDesc rowDesc = new LocalRowDesc(columnNames);
     List<Row> rows = new LinkedList<>();
     for (int i = 0; i < total; i++) {
       Row row = new RowImpl(rowDesc);
@@ -546,10 +539,8 @@ public class PostgresClientTest {
   }
 
   private RowSet<Row> getMockTestJsonbPojoResultSet(int total) {
-    List<String> columnNames = new ArrayList<String>(Arrays.asList(new String[] {
-      "jsonb"
-    }));
-    RowDesc rowDesc = new RowDesc(columnNames);
+    List<String> columnNames = List.of("jsonb");
+    RowDesc rowDesc = new LocalRowDesc(columnNames);
     List<String> baz = new ArrayList<String>(Arrays.asList(new String[] {
         "This", "is", "a", "test"
     }));

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,10 @@
 
   <properties>
     <aspectj.version>1.9.7</aspectj.version>
-    <junit-jupiter-version>5.8.1</junit-jupiter-version>
+    <junit-jupiter-version>5.9.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.3</vertx.version>
-    <micrometer.version>1.8.4</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <vertx.version>4.3.4</vertx.version>
+    <micrometer.version>1.9.4</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.1.0</version>
+        <version>5.2.0</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -103,7 +103,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.2</version>
+        <version>2.19.0</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.22.0</version>
+        <version>3.23.1</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -160,14 +160,14 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>4.6.0</version>
+        <version>4.8.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.35</version>
+        <version>2.37</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -177,7 +177,7 @@
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>6.2.3.Final</version>
+        <version>6.2.5.Final</version>
         <exclusions>
           <exclusion> <!-- we have javax.validation:validation-api providing the same classes -->
             <groupId>jakarta.validation</groupId>
@@ -193,12 +193,12 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.14.1</version>
+        <version>4.14.5</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-testing</artifactId>
-        <version>4.14.1</version>
+        <version>4.14.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -208,7 +208,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.2</version>
+        <version>1.17.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>35.0.1-SNAPSHOT</version>
+  <version>35.0.1</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -463,7 +463,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v35.0.1</tag>
   </scm>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>raml-module-builder</artifactId>
-  <version>35.0.1</version>
+  <version>35.0.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>raml-module-builder</name>
   <modules>
@@ -463,7 +463,7 @@
     <url>https://github.com/folio-org/raml-module-builder</url>
     <connection>scm:git:git://github.com:folio-org/raml-module-builder.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/raml-module-builder.git</developerConnection>
-    <tag>v35.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <distributionManagement>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <artifactId>postgres-testing</artifactId>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>postgres-testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <artifactId>testing</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1</version>
+    <version>35.0.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>util</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>raml-module-builder</artifactId>
-    <version>35.0.1-SNAPSHOT</version>
+    <version>35.0.1</version>
   </parent>
 
   <artifactId>util</artifactId>


### PR DESCRIPTION
RMB <= 35.0.0 used with Vert.x >= 4.3.4 fails with this error:
`java.lang.NoSuchMethodError: 'void io.vertx.sqlclient.impl.RowDesc.<init>(io.vertx.sqlclient.desc.ColumnDescriptor[])'`

RMB >= 35.0.1 used with Vert.x <= 4.3.3 fails with this error:
`java.lang.NoSuchMethodError: 'void io.vertx.sqlclient.impl.RowDesc.<init>(java.util.List, java.util.List)'`