### PR TITLE
RMB-946: Retry GET request in TenantLoading (reference/sample data)

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
@@ -358,6 +358,7 @@ public class TenantLoading {
    *
    * @param millisMin the minimum time in milliseconds to sleep
    */
+  @SuppressWarnings("java:S2245")  // Using pseudorandom number generator Math.random() for sleep time is safe
   Future<Void> sleep(long millisMin) {
     long millis = (long) (millisMin + Math.random() * millisMin);
     Vertx vertx = VertxUtils.getVertxFromContextOrNew();

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/TenantLoadingTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/utils/TenantLoadingTest.java
@@ -235,7 +235,7 @@ public class TenantLoadingTest {
     TenantLoading tl = new TenantLoading() {
       Future<Void> sleep(long millis) {
         sleepCounter.countDown();
-        return Future.succeededFuture();  // speed up unit test by not sleeping
+        return super.sleep(1);  // speed up unit test by not sleeping
       }
     };
     tl.withKey("loadRef").withLead("tenant-load-ref").withIdContent().add("data", "data");
@@ -255,7 +255,7 @@ public class TenantLoadingTest {
     when(webClient.getAbs(anyString())).thenReturn(httpRequest);
     TenantLoading tl = new TenantLoading() {
       Future<Void> sleep(long millis) {
-        return Future.succeededFuture();  // speed up unit test by not sleeping
+        return super.sleep(1);  // speed up unit test by not sleeping
       }
     };
     tl.getWithRetry("url", new HashMap<>(), webClient)


### PR DESCRIPTION
Trying to build the platform complete snapshot reference environment repeatedly failed with error message from https://github.com/folio-org/raml-module-builder/blob/v35.0.1/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java#L326-L341 :

```
GET http://10.36.1.44:9134/identifier-types/1795ea23-6856-48a5-a772-f356e16a8a6c returned status 500: Timeout
POST http://10.36.1.44:9134/identifier-types returned status 400: duplicate key value violates unique constraint
```

Retrying the GET request after some sleep time might resolve the issue.