### PR TITLE
RMB-947: LocalRowSet for RowDesc from both 4.3.3 and 4.3.4

### DIFF
--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
@@ -6,15 +6,17 @@ import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
 import io.vertx.sqlclient.impl.RowDesc;
+import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 public class LocalRowSet implements RowSet<Row> {
-  private static final ColumnDescriptor [] NO_COLUMN_DESCRIPTORS = new ColumnDescriptor [0];
+  private static final Constructor<?> ROW_DESC_CONSTRUCTOR = getRowDescConstructor();
   final int rowCount;
   List<Row> rows = new LinkedList<>();
-  RowDesc rowDesc = new LocalRowDesc(NO_COLUMN_DESCRIPTORS);
+  RowDesc rowDesc = createRowDesc(Collections.emptyList());
 
   public LocalRowSet(int rowCount) {
     this.rowCount = rowCount;
@@ -26,8 +28,36 @@ public class LocalRowSet implements RowSet<Row> {
   }
 
   public LocalRowSet withColumns(List<String> columns) {
-    this.rowDesc = new LocalRowDesc(columns);
+    this.rowDesc = createRowDesc(columns);
     return this;
+  }
+
+  /**
+   * For Vert.x 4.3.3 and before returns RowDesc(List<String>),
+   * for Vert.x 4.3.4 and later returns LocalRowDesc(List<String>).
+   */
+  private static Constructor<?> getRowDescConstructor() {
+    // .getConstructor(new Class[] { List.class })
+    // is 20 times slower than this loop when not found because of throwing the exception
+    for (Constructor<?> constructor : RowDesc.class.getConstructors()) {
+      if (constructor.getParameterCount() == 1 &&
+          constructor.getParameters()[0].getType().equals(List.class)) {
+        return constructor;
+      }
+    }
+    try {
+      return LocalRowDesc.class.getConstructor(new Class[] { List.class });
+    } catch (NoSuchMethodException | SecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static RowDesc createRowDesc(List<String> columns) {
+    try {
+      return (RowDesc) ROW_DESC_CONSTRUCTOR.newInstance(columns);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Vert.x 4.3.4 has a breaking change in the constructor of RowDesc.

Add reflection to LocalRowSet so that is can use RowDesc from both Vert.x 4.3.3 and 4.3.4.

This allows to downgrade Vert.x, 4.3.1 less frequently (32%) fails the mod-inventory-storage unit tests than 4.3.4 (94%).