### PR TITLE
Fix Sonar code smells in PomReader

### DIFF
--- a/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/PomReaderTest.java
+++ b/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/PomReaderTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.tools;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 import org.apache.maven.model.Dependency;
@@ -54,14 +55,14 @@ class PomReaderTest {
   void readFromJarNoPom() {
     PomReader pom = PomReader.INSTANCE;
 
-    assertThrows(NullPointerException.class, () -> pom.readIt(null, "ramls"));
+    assertThrows(FileNotFoundException.class, () -> pom.readIt(null, "javax/ws/rs"));
   }
 
   @Test
   void readFromJarNoResource() {
     PomReader pom = PomReader.INSTANCE;
 
-    assertThrows(NullPointerException.class, () -> pom.readIt(null, "pom/pom-sample.xml"));
+    assertThrows(IllegalArgumentException.class, () -> pom.readIt(null, "ramls"));
   }
 
   @Test


### PR DESCRIPTION
getModelFromJar no longer returns null on error causing a NullPointerException. Instead IllegalArgumentException or FileNotFoundException is thrown.

getModelFromJar uses try-with-resources when reading the jar file.

Use .replace, not .replaceAll, to replace a constant that is no regexp.

Fix [] position when declaring an array variable.