### PR TITLE
UXPROD-3833. Logging adjustment (NFR) - Orchid work

### DIFF
--- a/domain-models-runtime/src/main/resources/log4j2-json.properties
+++ b/domain-models-runtime/src/main/resources/log4j2-json.properties
@@ -15,6 +15,7 @@ appender.console.layout.type = JSONLayout
 appender.console.layout.compact = true
 appender.console.layout.eventEol = true
 appender.console.layout.stacktraceAsString = true
+appender.console.layout.includeTimeMillis = true
 
 ## Folio fields
 appender.console.layout.requestId.type = KeyValuePair


### PR DESCRIPTION
In folio-spring-base we use param appender.console.layout.includeTimeMillis as true [Link](https://github.com/folio-org/folio-spring-base/blob/master/src/main/resources/log4j2-json.properties).
This PR has been created to make logging configuration consistent between vertx and spring modules.
Here is article that describes desired logging configuration: https://wiki.folio.org/display/DD/Folio+logging+solution 