### PR TITLE
Fix NPE in PomReader url test

### DIFF
--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/PomReader.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/PomReader.java
@@ -98,8 +98,8 @@ public enum PomReader {
   private Model getModelFromJar(String directoryName) throws IOException, XmlPullParserException {
     MavenXpp3Reader mavenreader = new MavenXpp3Reader();
     URL url = Thread.currentThread().getContextClassLoader().getResource(directoryName);
-    if (! url.getProtocol().equals("jar")) {
-      throw new IllegalArgumentException("Is not jar: " + url);
+    if (url == null || ! "jar".equals(url.getProtocol())) {
+      throw new IllegalArgumentException("Is not jar: " + directoryName + " -> " + url);
     }
     String dirname = directoryName + "/";
     String path = url.getPath();


### PR DESCRIPTION
Fixes this NPE that I cannot reproduce locally but happens on Jenkins:
```
java.lang.NullPointerException
	at org.folio.rest.tools.PomReader.getModelFromJar(PomReader.java:101)
	at org.folio.rest.tools.PomReader.readIt(PomReader.java:77)
	at org.folio.rest.tools.PomReaderTest.lambda$readFromJarNoResource$1(PomReaderTest.java:67)
```
https://jenkins-aws.indexdata.com/job/folio-org/job/raml-module-builder/job/PomReaderTest-NPE/7/execution/node/53/log/