### PR TITLE
RMB-960: Upgrade dependencies for Orchid

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.5.0</version>
+      <version>42.5.2</version>
       <scope>test</scope>
     </dependency>
 

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.29.0-GA</version>
+      <version>3.29.2-GA</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -95,9 +95,8 @@
 
     <plugins>
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -129,9 +129,8 @@
     <plugins>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <aspectj.version>1.9.5</aspectj.version>
+    <aspectj.version>1.9.19</aspectj.version>
   </properties>
 
   <dependencies>
@@ -98,9 +98,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.31</version>
+      <version>2.3.32</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -275,9 +275,8 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,10 @@
   </licenses>
 
   <properties>
-    <aspectj.version>1.9.7</aspectj.version>
+    <aspectj.version>1.9.19</aspectj.version>
     <junit-jupiter-version>5.9.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.5</vertx.version>
+    <vertx.version>4.3.7</vertx.version>
     <micrometer.version>1.9.5</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
@@ -130,7 +130,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.23.1</version>
+        <version>3.24.2</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
@@ -160,14 +160,14 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>4.8.0</version>
+        <version>5.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.37</version>
+        <version>2.38</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -193,12 +193,12 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.14.5</version>
+        <version>4.14.10</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-testing</artifactId>
-        <version>4.14.5</version>
+        <version>4.14.10</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -208,7 +208,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.4</version>
+        <version>1.17.6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -228,6 +228,12 @@
             <compilerArgument>-Xlint:unchecked</compilerArgument>
             <encoding>UTF-8</encoding>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>dev.aspectj</groupId>
+          <artifactId>aspectj-maven-plugin</artifactId>
+          <version>1.13.1</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Most notable changes:

Upgrade Vert.x from 4.3.5 to 4.3.7.

Upgrade aspectj-maven-plugin from
com.nickwongdev:aspectj-maven-plugin:1.12.6 to
dev.aspectj:aspectj-maven-plugin:1.13.1
because the former is no longer maintained and
doesn't support Java 17:
https://github.com/dev-aspectj/aspectj-maven-plugin#history