### PR TITLE
RMB-961: Vert.x 4.3.8, Micrometer 1.10.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     <aspectj.version>1.9.19</aspectj.version>
     <junit-jupiter-version>5.9.1</junit-jupiter-version>
     <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.7</vertx.version>
-    <micrometer.version>1.9.5</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <vertx.version>4.3.8</vertx.version>
+    <micrometer.version>1.10.3</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->


### PR DESCRIPTION
Upgrade Vertx from 4.3.7 to 4.3.8.

Upgrade Micrometer from 1.9.5 to 1.10.3 to match the version Vert.x 4.3.8 comes with.