### PR TITLE
Set correct db search_path for tenant_module user

### DIFF
--- a/domain-models-runtime/src/main/resources/templates/db_scripts/create.ftl
+++ b/domain-models-runtime/src/main/resources/templates/db_scripts/create.ftl
@@ -7,7 +7,7 @@ CREATE SCHEMA ${myuniversity}_${mymodule} AUTHORIZATION ${myuniversity}_${mymodu
 
 </#if>
 
-ALTER ROLE ${myuniversity}_${mymodule} SET search_path = "$user";
+ALTER ROLE ${myuniversity}_${mymodule} SET search_path = "${myuniversity}_${mymodule}";
 
 <#include "extensions.ftl">
 


### PR DESCRIPTION
While looking at https://issues.folio.org/browse/CIRCSTORE-377, noticed that db `search_path` for `tenant_module` user is not set up correctly. This PR fixes that.