### PR TITLE
RMB-971: Java 17 javadoc

### DIFF
--- a/cql2pgjson/src/main/java/org/folio/cql2pgjson/model/CqlModifiers.java
+++ b/cql2pgjson/src/main/java/org/folio/cql2pgjson/model/CqlModifiers.java
@@ -4,7 +4,6 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.folio.cql2pgjson.exception.CQLFeatureUnsupportedException;
-import org.folio.cql2pgjson.exception.QueryValidationException;
 import org.z3950.zing.cql.CQLTermNode;
 import org.z3950.zing.cql.Modifier;
 import org.z3950.zing.cql.ModifierSet;
@@ -30,7 +29,7 @@ public class CqlModifiers {
    * Default is ascending, ignoreCase, ignoreAccents and masked.
    *
    * @param modifiers where to read from
-   * @throws QueryValidationException
+   * @throws CQLFeatureUnsupportedException
    */
   @SuppressWarnings("squid:MethodCyclomaticComplexity")
   public final void readModifiers(List<Modifier> modifiers) throws CQLFeatureUnsupportedException {

--- a/dbschema/src/main/java/org/folio/dbschema/ForeignKeys.java
+++ b/dbschema/src/main/java/org/folio/dbschema/ForeignKeys.java
@@ -87,7 +87,6 @@ public class ForeignKeys extends Field {
    * the tableAlias can differ from the database child table name, for example
    * tableName="holdings_records", tableAlias="holdingsRecords".
    * Null indicates that using this parent->child foreign key relation is disabled for CQL queries.
-   * @return the alias name, or null if disabled.
    */
   public void setTableAlias(String tableAlias) {
     this.tableAlias = tableAlias;
@@ -103,7 +102,6 @@ public class ForeignKeys extends Field {
 
   /**
    * Set the list of fieldNames for a join of more than two tables.
-   * @return list of fieldNames, or null if this is a two table join using fieldName.
    */
   public void setTargetPath(List<String> targetPath) {
     this.targetPath = targetPath;

--- a/dbschema/src/main/java/org/folio/dbschema/util/SqlUtil.java
+++ b/dbschema/src/main/java/org/folio/dbschema/util/SqlUtil.java
@@ -256,7 +256,7 @@ public final class SqlUtil {
      *
      * <p><code>appendQuoted("4 Rock'n'roll!", 2, 13, result)</code> appends <code>'Rock''n''roll'</code>
      *
-     * @param s the source text to take the subsequence from, must not be null if start < end
+     * @param s the source text to take the subsequence from, must not be null if start &lt; end
      * @param start the start of the substring within s
      * @param end the end of the substring within s
      * @param result where to append

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -137,8 +137,23 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
+          <execution>
+            <id>fix-javadoc-in-generated-code</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <replace token= "@param java_package" value="@param javaPackage" failOnNoReplacements="true"
+                         file="${project.build.directory}/generated-sources/raml-jaxrs/org/folio/rest/jaxrs/resource/Admin.java" />
+                <replace token= "@param access_token" value="@param accessToken" failOnNoReplacements="true"
+                         file="${project.build.directory}/generated-sources/raml-jaxrs/org/folio/rest/jaxrs/resource/Rmbtests.java" />
+              </target>
+            </configuration>
+          </execution>
           <execution>
             <id>delete-modulename-class</id>
             <phase>process-sources</phase>

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/DomainModelsMojo.java
@@ -20,9 +20,6 @@ import org.apache.maven.project.MavenProject;
 import org.folio.rest.tools.plugins.CustomTypeAnnotator;
 import org.folio.rest.tools.utils.RamlDirCopier;
 
-/**
- * @requiresDependencyResolution runtime
- */
 @Mojo(name = "java", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class DomainModelsMojo extends AbstractMojo {
 

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
@@ -148,7 +148,7 @@ public class GenerateRunner {
   /**
    * Generate the .java files from the .raml files.
    * @param inputDirectory  where to search for .raml files
-   * @throws Exception  on read, write or validate error
+   * @throws IOException  on read, write or validate error
    */
   public void generate(String inputDirectory) throws IOException {
     System.out.println("GenerateRunner.generate Input directory " + inputDirectory);

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/plugins/CustomTypeAnnotator.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/plugins/CustomTypeAnnotator.java
@@ -28,9 +28,11 @@ import io.vertx.core.json.JsonObject;
  * see https://github.com/folio-org/raml-module-builder#json-schema-fields
  *
  * this is called since we set the generator configuration with the following (in GenerateRunner.java):
+ * <pre>{@code
  *     Map<String, String> config = new HashMap<>();
  *     config.put("customAnnotator", "ramltojaxrs.resources.CustomTypeAnnotator");
  *     configuration.setJsonMapperConfiguration(config);
+ *  }</pre>
  */
 public class CustomTypeAnnotator extends Jackson2Annotator {
 

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/plugins/ResourceMethodExtensionPlugin.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/plugins/ResourceMethodExtensionPlugin.java
@@ -12,7 +12,6 @@ import javax.lang.model.element.Modifier;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.io.IOUtils;
-import org.folio.rest.tools.AnnotationGrabber;
 import org.folio.rest.tools.PomReader;
 import org.folio.rest.tools.utils.Enum2Annotation;
 import org.folio.rest.annotations.Validate;
@@ -21,7 +20,6 @@ import org.raml.jaxrs.generator.extension.resources.api.ResourceMethodExtension;
 import org.raml.jaxrs.generator.ramltypes.GMethod;
 import org.raml.jaxrs.generator.ramltypes.GParameter;
 import org.raml.jaxrs.generator.ramltypes.GRequest;
-import org.raml.jaxrs.generator.ramltypes.GType;
 import org.raml.v2.api.model.v10.datamodel.ExampleSpec;
 import org.raml.v2.api.model.v10.datamodel.TypeDeclaration;
 import org.raml.v2.api.model.v10.system.types.MarkdownString;
@@ -230,10 +228,6 @@ public class ResourceMethodExtensionPlugin implements ResourceMethodExtension<GM
 
     List<GRequest> bodyContent = method.body();
     for(int i=0; i< bodyContent.size(); i++){
-      GType entity = bodyContent.get(i).type();
-      if(entity != null){
-        methodSpec.addJavadoc("@param entity <code>"+entity.defaultJavaTypeName("")+"</code>\n");
-      }
       ExampleSpec example = ((TypeDeclaration)method.body().get(i).implementation()).example();
       if(example != null){
         methodSpec.addJavadoc(example.value());
@@ -241,7 +235,7 @@ public class ResourceMethodExtensionPlugin implements ResourceMethodExtension<GM
       }
     }
 
-    methodSpec.addJavadoc("@param asyncResultHandler An AsyncResult<Response> Handler ");
+    methodSpec.addJavadoc("@param asyncResultHandler An AsyncResult&lt;Response&gt; Handler ");
     methodSpec.addJavadoc(" {@link $T} " , Handler.class);
     methodSpec.addJavadoc("which must be called as follows - Note the 'GetPatronsResponse' should be replaced with '[nameOfYourFunction]Response': (example only) <code>asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetPatronsResponse.withJsonOK( new ObjectMapper().readValue(reply.result().body().toString(), Patron.class))));</code> in the final callback (most internal callback) of the function.\n");
 
@@ -249,7 +243,7 @@ public class ResourceMethodExtensionPlugin implements ResourceMethodExtension<GM
     methodSpec.addJavadoc(" The Vertx Context Object <code>io.vertx.core.Context</code> \n");
 
     methodSpec.addJavadoc("@param okapiHeaders\n");
-    methodSpec.addJavadoc(" Case insensitive map of x-okapi-* headers passed in as part of the request <code>java.util.Map<String, String></code> ");
+    methodSpec.addJavadoc(" Case insensitive map of x-okapi-* headers passed in as part of the request <code>java.util.Map&lt;String, String&gt;</code> ");
   }
 
   private static void handleOverrides() throws IOException {

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -264,7 +264,7 @@
             <goals>
               <goal>add-source</goal>
             </goals>
-            <phase>process-sources</phase>
+            <phase>generate-sources</phase>
             <configuration>
               <sources>
                 <source>${project.build.directory}/generated-sources/rmbversion</source>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Conn.java
@@ -25,6 +25,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.dbschema.util.SqlUtil;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.UpdateSection;
+import org.folio.rest.jaxrs.model.ResultInfo;
 import org.folio.rest.persist.PostgresClient.FunctionWithException;
 import org.folio.rest.persist.PostgresClient.QueryHelper;
 import org.folio.rest.persist.PostgresClient.TotaledResults;
@@ -610,7 +611,7 @@ public class Conn {
    * <br>
    * 1. can be mapped from a string in the following format [{"field":"''","value":"","op":""}]
    * <pre>
-   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"<\"}]"); //denotes funds_distribution is an array of objects
+   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"&lt;\"}]"); //denotes funds_distribution is an array of objects
    *    Criterion a = json2Criterion("[{"field":"'po_line_status'->>'value'","value":"SENT","op":"like"},{"field":"'owner'->>'value'","value":"MITLIBMATH","op":"="}, {"op":"AND"}]");
    *    (see postgres query syntax for more examples in the read.me
    * </pre>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/Criteria/Criterion.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/Criteria/Criterion.java
@@ -5,10 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-
 import org.folio.rest.persist.Criteria.GroupedCriterias.Pairs;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -180,7 +176,7 @@ public class Criterion {
 
   /**
    * example of json that can be passed in and converted into a postgres jsonb query
-   * "[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"<\"}]"
+   * "[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"&lt;\"}]"
    * with the use of cql this function should be depreicated
    * @param query
    * @return

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgExceptionUtil.java
@@ -128,15 +128,8 @@ public final class PgExceptionUtil {
    * (Message, duplicate key value violates unique constraint "t_text_key"),
    * (Detail, Key (text)=(a) already exists.)]}
    *
-   * <p>This is similar to {@link com.github.jasync.sql.db.postgresql.exceptions.GenericDatabaseException#getMessage()
-   * GenericDatabaseException#getMessage()} that returns
-   *
-   * <p>{@code ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 23505),
-   * (Message, duplicate key value violates unique constraint "t_text_key"),
-   * (Detail, Key (text)=(a) already exists.), (s, public), (t, t), (n, t_text_key),
-   * (File, nbtinsert.c), (Line, 427), (Routine, _bt_check_unique)])}
-   *
-   * <p>Use this method where PgException.getMessage() returning the message field only is not sufficient.
+   * <p>This is more than {@link PgException#getMessage()} that returns
+   * {@code ERROR: duplicate key value violates unique constraint "t_text_key" (23505)}.
    *
    * @return all PgException fields if throwable is a PgException, throwable.getMessage() otherwise
    */

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java
@@ -573,13 +573,13 @@ public final class PgUtil {
    *   "instances",
    *   "totalRecords"
    * ]
-   *</pre>
+   *}</pre>
    * @param <T> Class for each item returned
    * @param table SQL table
    * @param clazz The item class
    * @param cql CQL query
-   * @param offset offset >= 0; < 0 for no offset
-   * @param limit  limit >= 0 ; <0 for no limit
+   * @param offset offset &gt;= 0; &lt; 0 for no offset
+   * @param limit  limit &gt;= 0 ; &lt; 0 for no limit
    * @param facets facets (empty or null for  no facets)
    * @param element wrapper JSON element for list of items (eg books / users)
    * @param routingContext routing context from which a HTTP response is made
@@ -624,14 +624,14 @@ public final class PgUtil {
    * "required": [
    *   "instances"
    * ]
-   *</pre>
+   *}</pre>
    * @param <T> Class for each item returned
    * @param table SQL table
    * @param clazz The item class
    * @param cql CQL query
    * @param hasTotalRecords "auto" for estimating totalRecords, "none" to suppress totalRecords estimation
-   * @param offset offset >= 0; < 0 for no offset
-   * @param limit  limit >= 0 ; <0 for no limit
+   * @param offset offset &gt;= 0; &lt; 0 for no offset
+   * @param limit  limit &gt;= 0 ; &lt; 0 for no limit
    * @param facets facets (null or empty for no facets)
    * @param element wrapper JSON element for list of items (eg books / users)
    * @param routingContext routing context from which a HTTP response is made
@@ -1158,7 +1158,6 @@ public final class PgUtil {
 *                  headersFor201(), respond201WithApplicationJson(T, HeadersFor201),
 *                  respond400WithTextPlain(Object), respond500WithTextPlain(Object).
    * @param asyncResultHandler  where to return the result created by clazz
-   * @return
    */
   @SuppressWarnings("squid:S1523")  // suppress "Dynamically executing code is security-sensitive"
                                     // we use only hard-coded names
@@ -1182,7 +1181,7 @@ public final class PgUtil {
    * @param clazz  the ResponseDelegate class generated as defined by the RAML file, must have these methods:
 *               headersFor201(), respond201WithApplicationJson(T, HeadersFor201),
 *               respond400WithTextPlain(Object), respond500WithTextPlain(Object).
-   * @return Future<Response>  where to return the result created by clazz
+   * @return Future&lt;Response&gt;  where to return the result created by clazz
    */
   @SuppressWarnings("squid:S1523")  // suppress "Dynamically executing code is security-sensitive"
                                     // we use only hard-coded names

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -247,7 +247,7 @@ public class PostgresClient {
    * <p>Setting the same or a different PostgresTester instance invokes the close method of the
    * old PostgresTester instance.
    *
-   * <p>See {@link org.folio.postgres.testing.PostgresTesterContainer#PostgresTesterContainer()}
+   * <p>See {@code org.folio.postgres.testing.PostgresTesterContainer}.
    *
    * @param tester instance to use for testing.
    */
@@ -704,7 +704,7 @@ public class PostgresClient {
   /**
    * Start an SQL transaction.
    *
-   * <p>Use the AsyncResult<SQLConnection> result to invoke any of the
+   * <p>Use the AsyncResult&lt;SQLConnection&gt; result to invoke any of the
    * functions that take that result as first parameter for the commands
    * within the transaction.
    *
@@ -892,7 +892,6 @@ public class PostgresClient {
    * @param table database table (without schema)
    * @param id primary key for the record
    * @param entity a POJO (plain old java object)
-   * @param replyHandler returns any errors and the entity after applying any database INSERT triggers
    * @return the entity after applying any database INSERT triggers
    */
   public <T> Future<T> saveAndReturnUpdatedEntity(String table, String id, T entity) {
@@ -1379,7 +1378,7 @@ public class PostgresClient {
    * <br>
    * 1. can be mapped from a string in the following format [{"field":"''","value":"","op":""}]
    * <pre>
-   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"<\"}]"); //denotes funds_distribution is an array of objects
+   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"&lt;\"}]"); //denotes funds_distribution is an array of objects
    *    Criterion a = json2Criterion("[{"field":"'po_line_status'->>'value'","value":"SENT","op":"like"},{"field":"'owner'->>'value'","value":"MITLIBMATH","op":"="}, {"op":"AND"}]");
    *    (see postgres query syntax for more examples in the read.me
    * </pre>
@@ -1435,7 +1434,7 @@ public class PostgresClient {
    * <br>
    * 1. can be mapped from a string in the following format [{"field":"''","value":"","op":""}]
    * <pre>
-   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"<\"}]"); //denotes funds_distribution is an array of objects
+   *    Criterion a = json2Criterion("[{\"field\":\"'fund_distributions'->[]->'amount'->>'sum'\",\"value\":120,\"op\":\"&lt;\"}]"); //denotes funds_distribution is an array of objects
    *    Criterion a = json2Criterion("[{"field":"'po_line_status'->>'value'","value":"SENT","op":"like"},{"field":"'owner'->>'value'","value":"MITLIBMATH","op":"="}, {"op":"AND"}]");
    *    (see postgres query syntax for more examples in the read.me
    * </pre>
@@ -2552,7 +2551,7 @@ public class PostgresClient {
     /**
      * @param t  some input
      * @return some output
-     * @throws Exception of type E
+     * @throws E Exception of type E
      */
     R apply(T t) throws E;
   }
@@ -4226,7 +4225,7 @@ public class PostgresClient {
 
   /**
    * Will connect to a specific database and execute the commands in the .sql file
-   * against that database.<p />
+   * against that database.<p>
    * NOTE: NOT tested on all types of statements - but on a lot
    *
    * @param sqlFile - string of sqls with executable statements
@@ -4245,7 +4244,7 @@ public class PostgresClient {
 
   /**
    * Will connect to a specific database and execute the commands in the .sql file
-   * against that database.<p />
+   * against that database.<p>
    * NOTE: NOT tested on all types of statements - but on a lot
    *
    * @param sqlFile - string of sqls with executable statements
@@ -4380,7 +4379,7 @@ public class PostgresClient {
 
   /**
    * Name of the back-end module, usually determined and stored in
-   * {@link org.folio.rest.tools.utils.ModuleName} by domain-models-maven-plugin at build time.
+   * {@code org.folio.rest.tools.utils.ModuleName} by domain-models-maven-plugin at build time.
    */
   public static String getModuleName() {
     return MODULE_NAME;

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PreparedRowStream.java
@@ -10,7 +10,7 @@ import io.vertx.sqlclient.RowStream;
 import io.vertx.sqlclient.Tuple;
 
 /**
- * Extend a RowStream<Row> with a result {@link Future} that completes after
+ * Extend a RowStream&lt;Row&gt; with a result {@link Future} that completes after
  * endHandler or exceptionHandler has been called.
  */
 public class PreparedRowStream implements RowStream<Row> {
@@ -25,7 +25,7 @@ public class PreparedRowStream implements RowStream<Row> {
   }
 
   /**
-   * Constructor with PreparedStatement and RowStream<Row>.
+   * Constructor with PreparedStatement and RowStream&lt;Row&gt;.
    *
    * @param preparedStatement the query to execute, it is closed when this PreparedRowStream is closed
    */
@@ -47,7 +47,7 @@ public class PreparedRowStream implements RowStream<Row> {
   }
 
   /**
-   * Create a RowStream<Row> using the preparedStatement, fetch and tuple.
+   * Create a RowStream&lt;Row&gt; using the preparedStatement, fetch and tuple.
    *
    * @param preparedStatement the query to execute, it is closed when this PreparedRowStream is closed
    * @param fetch the cursor fetch size

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/cql/CQLWrapper.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/cql/CQLWrapper.java
@@ -129,7 +129,7 @@ public class CQLWrapper {
   /**
    * Sets CQL query (should be used with {@link CQLWrapper#setField(org.folio.cql2pgjson.CQL2PgJSON)}
    * Or this constructor can be used to specify both:
-   * {@link CQLWrapper#CQLWrapper(org.folio.cql2pgjson.CQL2PgJSON, java.lang.String)
+   * {@link CQLWrapper#CQLWrapper(org.folio.cql2pgjson.CQL2PgJSON, java.lang.String)}
    * @param query CQL query
    * @return wrapper itself
    */

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/facets/FacetManager.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/facets/FacetManager.java
@@ -98,9 +98,9 @@ public class FacetManager {
 
   /**
    * pass in a list of facets, where each facet is in the form of:
-   * a.b.c <- path to the facet
-   * a.b.c:10 <- path to the facet with count of values to return
-   * a < - path to facet - top level field in the json
+   * a.b.c t &lt;- path to the facet
+   * a.b.c:10 &lt;- path to the facet with count of values to return
+   * a &lt;- path to facet - top level field in the json
    *
    * @param facets
    * @param columnName - the column where the json is stored - for example jsonb.

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpClientFactory.java
@@ -12,8 +12,8 @@ import org.folio.rest.tools.client.test.HttpClientMock2;
  * an {@link HttpModuleClient2} instance if mocking is disabled.
  *
  * <p>Mocking is disabled by default. It can be enabled by setting the system property
- * {@link HttpClientMock2.MOCK_MODE} to any value (for example in pom.xml),
- * or by setting the {@link DeploymentOptions} property {@link HttpClientMock2.MOCK_MODE}
+ * {@link HttpClientMock2#MOCK_MODE} to any value (for example in pom.xml),
+ * or by setting the {@link DeploymentOptions} property {@link HttpClientMock2#MOCK_MODE}
  * to any value when deploying {@link RestVerticle}. It can programmatically been enabled
  * or disabled by calling {@link #setMockEnabled(boolean)}.
  *

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/Response.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/Response.java
@@ -89,7 +89,6 @@ public class Response {
    * Replace the withField in the current response
    * with the value found in the insertField (from the Response parameter)
    * @param withField
-   * @param response
    * @param onField
    * @param extractField - the field to extract from the response to join on. Two options:
    * 1. an absolute path - such as a.b.c or a.b.c.d[0] - should be used when one field needs to be

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/JsonUtils.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/JsonUtils.java
@@ -48,7 +48,7 @@ public class JsonUtils {
    * for example a list of parameters with a key in the list called 'key' will be transformed into
    * parameters.key
    * @param entity pojo to transform into a query
-   * @param removeFields fields starting with this prefix will not be included in the returned json object
+   * @param removeFieldsPrefixes fields starting with this prefix will not be included in the returned json object
    * @return
    */
   public static JsonObject entity2Json(Object entity, String[] removeFieldsPrefixes){
@@ -115,7 +115,6 @@ public class JsonUtils {
    * for example a list of parameters with a key in the list called 'key' will be transformed into
    * parameters.key
    * @param entity
-   * @param removeFields fields starting with this prefix will not be included in the returned json object
    * @return
    */
   public static JsonObject entity2Json(Object entity){

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/MetadataUtil.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/MetadataUtil.java
@@ -33,8 +33,8 @@ public final class MetadataUtil {
   /**
    * @return Metadata where createdDate and updatedDate are set to current time and
    * createdByUserId and updatedByUserId are set to the
-   * {@link RestVerticle.OKAPI_USERID_HEADER} header, using {@code user_id} from the
-   * {@link RestVerticle.OKAPI_HEADER_TOKEN} as a fall-back. The token is used without
+   * {@link RestVerticle#OKAPI_USERID_HEADER} header, using {@code user_id} from the
+   * {@link RestVerticle#OKAPI_HEADER_TOKEN} as a fall-back. The token is used without
    * validation.
    */
   public static Metadata createMetadata(Map<String, String> okapiHeaders) {

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/TenantLoading.java
@@ -60,21 +60,17 @@ import org.folio.util.PercentCodec;
  * </ul>
  *
  * <pre>
- * <code>
- *
- * @Override
- * Future<Void> loadData(TenantAttributes attributes, String tenantId,
- *                       Map<String, String> headers, Context vertxContext) {
+ * &#64;Override
+ * Future&lt;Void&gt; loadData(TenantAttributes attributes, String tenantId,
+ *                       Map&lt;String, String&gt; headers, Context vertxContext) {
  *   return super.loadData(attributes, tenantId, headers, vertxContext)
- *       .compose(res -> new TenantLoading()
+ *       .compose(res -&gt; new TenantLoading()
  *           .withKey("loadReference").withLead("ref-data")
  *           .add("groups")
  *           .withKey("loadSample").withLead("sample-data")
  *           .add("users")
  *           .perform(attributes, headers, vertxContext));
  * }
- *
- * </code>
  * </pre>
  */
 public class TenantLoading {
@@ -438,8 +434,8 @@ public class TenantLoading {
    * Specify for TenantLoading object the key that triggers loading of the subsequent files to be
    * added (see add method)
    *
-   * For sample data, the convention is <literal>loadSample</literal>. For reference data, the
-   * convention is <literal>loadReference</literal>.
+   * For sample data, the convention is <code>loadSample</code>. For reference data, the
+   * convention is <code>loadReference</code>.
    *
    * @param key the parameter key
    * @return TenandLoading new state
@@ -467,7 +463,7 @@ public class TenantLoading {
   /**
    * Specify loading with unique key in JSON field "id"
    *
-   * In most cases, data has a unique key in JSON field <literal>"id"</literal>. The content of the
+   * In most cases, data has a unique key in JSON field <code>"id"</code>. The content of the
    * that field is used to check the existence of the object or update thereof.
    *
    * @return TenandLoading new state
@@ -482,7 +478,7 @@ public class TenantLoading {
    * Specify loading with unique key in custom JSON field
    *
    * Should be used if unique key is in other field than
-   * <literal>"id"</literal>. The content of the that field is used to check the
+   * <code>"id"</code>. The content of the that field is used to check the
    * existence of the object or update thereof.
    *
    * @return TenandLoading new state

--- a/util/src/main/java/org/folio/HttpStatus.java
+++ b/util/src/main/java/org/folio/HttpStatus.java
@@ -63,7 +63,7 @@ public enum HttpStatus {
    * <a href="https://github.com/folio-org/raml/blob/raml1.0/rtypes/item-collection.raml">item-collection</a>
    * resource types.
    * <p>
-   * For an application/json response body see {@link #HTTP_VALIDATION_ERROR} (422).
+   * For an application/json response body see {@link #HTTP_UNPROCESSABLE_ENTITY} (422).
    */
   HTTP_BAD_REQUEST(400),
 

--- a/util/src/main/java/org/folio/util/StringUtil.java
+++ b/util/src/main/java/org/folio/util/StringUtil.java
@@ -81,7 +81,7 @@ public final class StringUtil {
    * <p>query is {@code username=="\\\*\?\^\""} if s is {@code \*?^"}
    *
    * @return appendable
-   * @see {@link #appendCqlEncoded(Appendable, CharSequence)} for appending to a StringBuilder
+   * @see #appendCqlEncoded(Appendable, CharSequence) appendCqlEncoded for appending to a StringBuilder
    */
   public static String cqlEncode(CharSequence s) {
     if (s == null) {


### PR DESCRIPTION
JDK 17 is more picky about invalid javadoc and fails the deploy phase:

https://jenkins-aws.indexdata.com/job/folio-org/job/raml-module-builder/job/master/921/execution/node/61/log/

So we need to fix several syntax and link bugs in the javadoc.