### PR TITLE
RMB-979: Poppy dependencies: Vert.x 4.4.5, log4j 2.20.0, ...

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -45,6 +45,11 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
 

--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -23,6 +23,16 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 * [Version 25](#version-25)
 * [Version 20](#version-20)
 
+## Version 36.1
+
+RMB requires Vert.x 4.4.\*.
+
+RMB uses log4j 2.20.0. Ensure that log4j-bom is listed before vertx-stack-depchain in
+<dependencyManagement>.
+
+postgres-testing requires testcontainers >= 1.19.0. If log4j-slf4j-impl has been used
+for testcontainers logging you need to switch to log4j-slf4j2-impl.
+
 ## Version 35.0
 
 ### [RMB-932](https://issues.folio.org/browse/RMB-932) Broken empty string matching: uuidfield == ""

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -77,6 +77,10 @@
       <artifactId>domain-models-api-aspects</artifactId>
       <version>${project.parent.version}</version>
     </dependency>
+	<dependency>
+      <groupId>org.apache.commons</groupId>
+	  <artifactId>commons-lang3</artifactId>
+	</dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PgConnectionMock.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PgConnectionMock.java
@@ -35,6 +35,11 @@ public class PgConnectionMock implements PgConnection {
   }
 
   @Override
+  public Future<Void> cancelRequest() {
+    return Future.succeededFuture();
+  }
+
+  @Override
   public int processId() {
     return 0;
   }
@@ -89,6 +94,11 @@ public class PgConnectionMock implements PgConnection {
   @Override
   public Future<Transaction> begin() {
     throw new PgConnectionMockException();
+  }
+
+  @Override
+  public Transaction transaction() {
+    return null;
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,14 @@
   </licenses>
 
   <properties>
-    <aspectj.version>1.9.19</aspectj.version>
-    <junit-jupiter-version>5.9.1</junit-jupiter-version>
-    <maven.version>3.8.4</maven.version>
-    <vertx.version>4.3.8</vertx.version>
-    <micrometer.version>1.10.3</micrometer.version>  <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+
+    <project.build.outputTimestamp>2023-09-23T00:00:00Z</project.build.outputTimestamp>
+
+    <aspectj.version>1.9.20.1</aspectj.version>
+    <junit-jupiter-version>5.10.0</junit-jupiter-version>
+    <maven.version>3.9.4</maven.version>
+    <vertx.version>4.4.5</vertx.version>
+    <micrometer.version>1.11.4</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -54,7 +57,14 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>31.1-jre</version>
+        <version>32.1.2-jre</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.20.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
@@ -73,7 +83,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.2.0</version>
+        <version>5.3.2</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -83,7 +93,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
+        <version>2.13.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -98,14 +108,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.19.0</version>
-        <scope>import</scope>
-        <type>pom</type>
+        <version>3.13.0</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
@@ -160,14 +163,14 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>5.1.1</version>
+        <version>5.5.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.38</version>
+        <version>2.40</version>
       </dependency>
       <dependency>
         <groupId>javax.validation</groupId>
@@ -193,12 +196,12 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>4.14.10</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-testing</artifactId>
-        <version>4.14.10</version>
+        <version>5.0.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -208,7 +211,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.6</version>
+        <version>1.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -222,7 +225,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.11.0</version>
           <configuration>
             <release>17</release>
             <compilerArgument>-Xlint:unchecked</compilerArgument>
@@ -239,24 +242,29 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.1.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M3</version>
+          <version>3.4.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.1.2</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
+          <!-- Versions [3.3.0 ... 3.5.0] create a published domain-models-runtime pom.xml
+               where the domain-models-api-interfaces dependency is missing.
+               Compiling mod-inventory-storage fails with
+               "Compilation failure: class file for org.folio.rest.jaxrs.resource.Tenant not found"
+          -->
           <version>3.2.4</version>
           <configuration>
             <filters>
@@ -273,7 +281,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.1.2</version>
           <configuration>
             <useSystemClassLoader>false</useSystemClassLoader>
             <classesDirectory>${project.build.outputDirectory}</classesDirectory>
@@ -292,13 +300,13 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.4.0</version>
           <executions>
             <execution>
               <id>add-raml-jaxrs-source</id>
@@ -327,7 +335,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.16.1</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -336,7 +344,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.2.0</version>
         <executions>
           <execution>
             <goals>
@@ -357,12 +365,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.3.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.3</version>
+            <version>10.12.3</version>
           </dependency>
         </dependencies>
         <executions>
@@ -421,8 +429,14 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+      </plugin>
+
+      <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.3.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -436,7 +450,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -450,7 +464,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.1.1</version>
         <executions>
           <execution>
             <id>deploy</id>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -23,7 +23,7 @@
     <!-- for Testcontainers -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
For the RMB Poppy release upgrade all dependencies to current stable versions.

Add `<project.build.outputTimestamp>` towards reproducible-builds:
https://maven.apache.org/guides/mini/guide-reproducible-builds.html