### PR TITLE
RMB-975: Define  DB_HOST_ASYNC_READER, DB_PORT_ASYNC_READER 

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ to a running PostgreSQL query. 0 disables this timeout and is the default.
 To take effect an RMB based module must get it via PostgresClient.getConnectionConfig().getInteger("queryTimeout")
 and pass it to the RMB method that starts the connection, transaction or query.
 
-The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the synchronously replicated [Read and write database instances setup](#read-and-write-database-instances-setup).
+The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the synchronously replicated [read and write database instances setup](#read-and-write-database-instances-setup).
 
 The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the asynchronously replicated read and write database instances setup.
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ and pass it to the RMB method that starts the connection, transaction or query.
 
 The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the synchronously replicated [Read and write database instances setup](#read-and-write-database-instances-setup).
 
-The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the [Asynchronously replicated read and write database instances setup](#asynchronously-replicated-read-and-write-database-instances-setup).
+The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the asynchronously replicated read and write database instances setup.
 
 `DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING` is a timestamp in the format `2022-12-31T23:59:59Z`. Setting it disables optimistic locking when sending a record that contains `"_version":-1` before that time, after that time `"_version":-1` is rejected. This applies only to tables with `failOnConflictUnlessSuppressed`, see below. The timestamp ensures that disabling this option cannot be forgotten. Suppressing optimistic locking is known to lead to data loss in some cases, don't use in production, you have been warned!
 

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ to a running PostgreSQL query. 0 disables this timeout and is the default.
 To take effect an RMB based module must get it via PostgresClient.getConnectionConfig().getInteger("queryTimeout")
 and pass it to the RMB method that starts the connection, transaction or query.
 
-The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the [Read and write database instances setup](#read-and-write-database-instances-setup).
+The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the synchronously replicated [Read and write database instances setup](#read-and-write-database-instances-setup).
 
 The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the [Asynchronously replicated read and write database instances setup](#asynchronously-replicated-read-and-write-database-instances-setup).
 
@@ -422,11 +422,13 @@ A PostgreSQL instance (the write instance) can be replicated for horizontal scal
 
 RMB supports separating read and write requests. By default the write instance configured with `DB_HOST` and `DB_PORT` environment variables is used for reading as well, but optionally a read instance (or a load balancer for multiple read instances) can be configured by setting its host and port using the `DB_HOST_READER` and `DB_PORT_READER` environment variables. If either of these reader variables are not set then it will default to use the writer instance.
 
-## Asynchronously replicated read and write database instances setup
-
-RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and asynchronously replicated standby servers (the default)[https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION]. When using synchronous replication, write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
+RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and asynchronously replicated standby servers (the default)[https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION]. When using synchronous replication, write instance must list the `DB_HOST_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
 
 PostgreSQL's default asynchronous replication is supported by RMB by configuring `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER`. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing. To use the async read host in queries, get an instance of `PostgresClient` using `PostgresClientWithAsyncReadConn.getInstance(...)`.
+
+AWS RDS does not support synchronous replication. For AWS it is recommended to only use `DB_HOST` and `DB_HOST_ASYNC_READER` in a given deployment.
+
+APIs using the async client should provide a warning in the API documentation that it uses stale data (for performance reasons).
 
 ## Local development server
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the file ["LICENSE"](LICENSE) for more information.
 * [Command-line options](#command-line-options)
 * [Environment Variables](#environment-variables)
 * [Read and write database instances setup](#read-and-write-database-instances-setup)
+* [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async)
 * [Local development server](#local-development-server)
 * [Creating a new module](#creating-a-new-module)
     * [Step 1: Create new project directory layout](#step-1-create-new-project-directory-layout)
@@ -408,6 +409,8 @@ and pass it to the RMB method that starts the connection, transaction or query.
 
 The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the [Read and write database instances setup](#read-and-write-database-instances-setup).
 
+The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` the [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async).
+
 `DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING` is a timestamp in the format `2022-12-31T23:59:59Z`. Setting it disables optimistic locking when sending a record that contains `"_version":-1` before that time, after that time `"_version":-1` is rejected. This applies only to tables with `failOnConflictUnlessSuppressed`, see below. The timestamp ensures that disabling this option cannot be forgotten. Suppressing optimistic locking is known to lead to data loss in some cases, don't use in production, you have been warned!
 
 `TESTCONTAINERS_POSTGRES_IMAGE` changes the PostgreSQL container image name used at build time for testing; it is not used at runtime.
@@ -419,9 +422,11 @@ A PostgreSQL instance (the write instance) can be replicated for horizontal scal
 
 RMB supports separating read and write requests. By default the write instance configured with `DB_HOST` and `DB_PORT` environment variables is used for reading as well, but optionally a read instance (or a load balancer for multiple read instances) can be configured by setting its host and port using the `DB_HOST_READER` and `DB_PORT_READER` environment variables. If either of these reader variables are not set then it will default to use the writer instance.
 
-RMB only supports [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION). The write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
+## Read and write database instances setup async
 
-PostgreSQL's default asynchronous replication is not supported by RMB and will result in errors caused by outdated data the replica may return. Asynchronous replication is eventual consistency suitable for read-only applications like reporting, analytics, and data warehouse.
+RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and [asynchronously replicated standby servers](TODO). When using synchronous replication, write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
+
+PostgreSQL's default asynchronous replication is now supported by RMB when `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are configured. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehouse.
 
 ## Local development server
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ and pass it to the RMB method that starts the connection, transaction or query.
 
 The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the [Read and write database instances setup](#read-and-write-database-instances-setup).
 
-The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async).
+The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the [Asynchronously replicated read and write database instances setup](#asynchronously-replicated-read-and-write-database-instances-setup).
 
 `DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING` is a timestamp in the format `2022-12-31T23:59:59Z`. Setting it disables optimistic locking when sending a record that contains `"_version":-1` before that time, after that time `"_version":-1` is rejected. This applies only to tables with `failOnConflictUnlessSuppressed`, see below. The timestamp ensures that disabling this option cannot be forgotten. Suppressing optimistic locking is known to lead to data loss in some cases, don't use in production, you have been warned!
 
@@ -422,11 +422,11 @@ A PostgreSQL instance (the write instance) can be replicated for horizontal scal
 
 RMB supports separating read and write requests. By default the write instance configured with `DB_HOST` and `DB_PORT` environment variables is used for reading as well, but optionally a read instance (or a load balancer for multiple read instances) can be configured by setting its host and port using the `DB_HOST_READER` and `DB_PORT_READER` environment variables. If either of these reader variables are not set then it will default to use the writer instance.
 
-## Asynchronously replicated ead and write database instances setup
+## Asynchronously replicated read and write database instances setup
 
 RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and asynchronously replicated standby servers (the default)[https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION]. When using synchronous replication, write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
 
-PostgreSQL's default asynchronous replication is supported by RMB when `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are configured. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing.
+PostgreSQL's default asynchronous replication is supported by RMB by configuring `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER`. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing. To use the async read host in queries, get an instance of `PostgresClient` using `PostgresClientWithAsyncReadConn.getInstance(...)`.
 
 ## Local development server
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ See the file ["LICENSE"](LICENSE) for more information.
 * [Command-line options](#command-line-options)
 * [Environment Variables](#environment-variables)
 * [Read and write database instances setup](#read-and-write-database-instances-setup)
-* [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async)
 * [Local development server](#local-development-server)
 * [Creating a new module](#creating-a-new-module)
     * [Step 1: Create new project directory layout](#step-1-create-new-project-directory-layout)
@@ -418,17 +417,17 @@ The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are 
 See the [Environment Variables](https://github.com/folio-org/okapi/blob/master/doc/guide.md#environment-variables) section of the Okapi Guide for more information on how to deploy environment variables to RMB modules via Okapi.
 
 ## Read and write database instances setup
-A PostgreSQL instance (the write instance) can be replicated for horizontal scaling (scale out), each replica is a read-only standby instance.
+A PostgreSQL instance (the write instance) can be replicated for horizontal scaling (scale out). Each replica is a read-only standby instance.
 
 RMB supports separating read and write requests. By default the write instance configured with `DB_HOST` and `DB_PORT` environment variables is used for reading as well, but optionally a read instance (or a load balancer for multiple read instances) can be configured by setting its host and port using the `DB_HOST_READER` and `DB_PORT_READER` environment variables. If either of these reader variables are not set then it will default to use the writer instance.
 
 RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and asynchronously replicated standby servers (the default)[https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION]. When using synchronous replication, write instance must list the `DB_HOST_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
 
-PostgreSQL's default asynchronous replication is supported by RMB by configuring `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER`. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing. To use the async read host in queries, get an instance of `PostgresClient` using `PostgresClientWithAsyncReadConn.getInstance(...)`.
+PostgreSQL's default asynchronous replication is supported by RMB by configuring `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER`. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing. To use the async read host in queries, get an instance of `PostgresClient` using `PostgresClientWithAsyncReadConn.getInstance(...)`. If no async read host is configured, it falls back to the sync read host if configured, otherwise it uses the write host.
 
 AWS RDS does not support synchronous replication. For AWS it is recommended to only use `DB_HOST` and `DB_HOST_ASYNC_READER` in a given deployment.
 
-APIs using the async client should provide a warning in the API documentation that it uses stale data (for performance reasons).
+APIs using the async client should provide a warning in the API documentation that the API uses stale data (for performance reasons).
 
 ## Local development server
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ and pass it to the RMB method that starts the connection, transaction or query.
 
 The environment variables `DB_HOST_READER` and `DB_PORT_READER` are for the [Read and write database instances setup](#read-and-write-database-instances-setup).
 
-The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` the [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async).
+The environment variables `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are for the [Asynchronously replicated read and write database instances setup](#read-and-write-database-instances-setup-async).
 
 `DB_ALLOW_SUPPRESS_OPTIMISTIC_LOCKING` is a timestamp in the format `2022-12-31T23:59:59Z`. Setting it disables optimistic locking when sending a record that contains `"_version":-1` before that time, after that time `"_version":-1` is rejected. This applies only to tables with `failOnConflictUnlessSuppressed`, see below. The timestamp ensures that disabling this option cannot be forgotten. Suppressing optimistic locking is known to lead to data loss in some cases, don't use in production, you have been warned!
 
@@ -422,11 +422,11 @@ A PostgreSQL instance (the write instance) can be replicated for horizontal scal
 
 RMB supports separating read and write requests. By default the write instance configured with `DB_HOST` and `DB_PORT` environment variables is used for reading as well, but optionally a read instance (or a load balancer for multiple read instances) can be configured by setting its host and port using the `DB_HOST_READER` and `DB_PORT_READER` environment variables. If either of these reader variables are not set then it will default to use the writer instance.
 
-## Read and write database instances setup async
+## Asynchronously replicated ead and write database instances setup
 
-RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and [asynchronously replicated standby servers](TODO). When using synchronous replication, write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
+RMB supports both [synchronous standby servers](https://www.postgresql.org/docs/current/warm-standby.html#SYNCHRONOUS-REPLICATION) and asynchronously replicated standby servers (the default)[https://www.postgresql.org/docs/current/warm-standby.html#STREAMING-REPLICATION]. When using synchronous replication, write instance must list the `DB_*_READER` instance(s) in its `synchronous_standby_names` configuration. This ensures ACID for both write and read instance.
 
-PostgreSQL's default asynchronous replication is now supported by RMB when `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are configured. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehouse.
+PostgreSQL's default asynchronous replication is supported by RMB when `DB_HOST_ASYNC_READER` and `DB_PORT_ASYNC_READER` are configured. Asynchronous replication is eventually consistent and suitable for read-only applications like reporting, analytics, and data warehousing.
 
 ## Local development server
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -529,10 +529,10 @@ public class PostgresClient {
     this.postgresClientInitializer = new PostgresClientInitializer(vertx, postgreSQLClientConfig);
     if (sharedPgPool) {
       client = PG_POOLS.computeIfAbsent(vertx, x -> postgresClientInitializer.getClient());
-      readClient = PG_POOLS_READER.computeIfAbsent(vertx, x -> postgresClientInitializer.getReadClient());
+      readClient = PG_POOLS_READER.computeIfAbsent(vertx, x -> postgresClientInitializer.getSyncReadClient());
     } else {
       client = postgresClientInitializer.getClient();
-      readClient = postgresClientInitializer.getReadClient();
+      readClient = postgresClientInitializer.getSyncReadClient();
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -75,6 +75,7 @@ public class PostgresClient {
   static final String    MAX_SHARED_POOL_SIZE = "maxSharedPoolSize";
 
   static Logger log = LogManager.getLogger(PostgresClient.class);
+
   @SuppressWarnings("java:S2068")  // suppress "Hard-coded credentials are security-sensitive"
   // we use it as a key in the config. We use it as a default password only when testing
   // using embedded postgres, see getPostgreSQLClientConfig
@@ -96,13 +97,6 @@ public class PostgresClient {
    */
   static boolean sharedPgPool = false;
 
-  private static final String    POSTGRES_TESTER = "postgres_tester";
-
-  private static final String    GET_STAT_METHOD = "get";
-  private static final String    EXECUTE_STAT_METHOD = "execute";
-
-  private static final String    PROCESS_RESULTS_STAT_METHOD = "processResults";
-
   private static final String    MODULE_NAME              = getModuleName("org.folio.rest.tools.utils.ModuleName");
   private static final String    ID_FIELD                 = "id";
 
@@ -114,6 +108,12 @@ public class PostgresClient {
   private static final String    SELECT = "SELECT ";
   private static final String    FROM   = " FROM ";
   private static final String    WHERE  = " WHERE ";
+
+  private static final String    POSTGRES_TESTER = "postgres_tester";
+
+  private static final String    GET_STAT_METHOD = "get";
+  private static final String    EXECUTE_STAT_METHOD = "execute";
+  private static final String    PROCESS_RESULTS_STAT_METHOD = "processResults";
 
   private static final String    SPACE = " ";
   private static final String    DOT = ".";
@@ -406,6 +406,10 @@ public class PostgresClient {
     this.client = client;
   }
 
+  /**
+   * Get the {@link PostgresClientInitializer} for this {@link PostgresClient} instance.
+   * @return A reference to the initializer.
+   */
   PostgresClientInitializer getPostgresClientInitializer() {
     return this.postgresClientInitializer;
   }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -85,13 +85,13 @@ public class PostgresClient {
   @SuppressWarnings("java:S2068")  // suppress "Hard-coded credentials are security-sensitive"
   // we use it as a key in the config. We use it as a default password only when testing
   // using embedded postgres, see getPostgreSQLClientConfig
-  static final String    PASSWORD = "password";
-  static final String    USERNAME = "username";
-  static final String    HOST      = "host";
-  static final String    HOST_READER = "host_reader";
-  static final String    PORT      = "port";
-  static final String    PORT_READER = "port_reader";
-  static final String    DATABASE  = "database";
+  static final String PASSWORD = "password";
+  static final String USERNAME = "username";
+  static final String HOST = "host";
+  static final String HOST_READER = "host_reader";
+  static final String PORT = "port";
+  static final String PORT_READER = "port_reader";
+  static final String DATABASE  = "database";
 
   /**
    * True if all tenants of a Vertx share one PgPool, false for having a separate PgPool for

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClient.java
@@ -519,8 +519,6 @@ public class PostgresClient {
       client = initializer.getClient();
       readClient = initializer.getReadClient();
     }
-
-    readClient = readClient != null ? readClient : client;
   }
 
   /**

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -11,20 +11,19 @@ import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.SslMode;
 import io.vertx.sqlclient.PoolOptions;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PostgresClientInitializer {
   static final String HOST_READER_ASYNC = "host_reader_async";
   static final String PORT_READER_ASYNC = "port_reader_async";
 
   private static final Logger LOG = LogManager.getLogger(PostgresClientInitializer.class);
+  private static final int DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
   private static final String CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
   private static final String MAX_POOL_SIZE = "maxPoolSize";
-  private static final int DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
   private static final String RECONNECT_ATTEMPTS = "reconnectAttempts";
   private static final String RECONNECT_INTERVAL = "reconnectInterval";
   private static final String SERVER_PEM = "server_pem";

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -1,0 +1,135 @@
+package org.folio.rest.persist;
+
+import io.netty.handler.ssl.OpenSsl;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.JdkSSLEngineOptions;
+import io.vertx.core.net.OpenSSLEngineOptions;
+import io.vertx.core.net.PemTrustOptions;
+import io.vertx.pgclient.PgConnectOptions;
+import io.vertx.pgclient.PgPool;
+import io.vertx.pgclient.SslMode;
+import io.vertx.sqlclient.PoolOptions;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+public class PostgresClientInitializer {
+  static Logger log = LogManager.getLogger(PostgresClientInitializer.class);
+  private static final String    CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
+  private static final String    MAX_POOL_SIZE = "maxPoolSize";
+  private static final int       DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
+  private static final String    RECONNECT_ATTEMPTS = "reconnectAttempts";
+  private static final String    RECONNECT_INTERVAL = "reconnectInterval";
+  private static final String    SERVER_PEM = "server_pem";
+
+  private Vertx vertx;
+  private JsonObject configuration;
+
+  public PostgresClientInitializer(Vertx vertx, JsonObject configuration) {
+    this.vertx = vertx;
+    this.configuration = configuration;
+  }
+
+  public PgPool getClient() {
+    return createPgPool(vertx, configuration, false);
+  }
+
+  public PgPool getReadClient() {
+    return createPgPool(vertx, configuration, true);
+  }
+
+  public PgPool getReadAsyncClient() {
+    return null;
+  }
+
+  private static PgPool createPgPool(Vertx vertx, JsonObject configuration, Boolean isReader) {
+    var connectOptions = createPgConnectOptions(configuration, isReader);
+
+    if (connectOptions == null) {
+      return null;
+    }
+
+    var poolOptions = new PoolOptions();
+    poolOptions.setMaxSize(
+        configuration.getInteger(PostgresClient.MAX_SHARED_POOL_SIZE, configuration.getInteger(MAX_POOL_SIZE, 4)));
+    Integer connectionReleaseDelay = configuration.getInteger(CONNECTION_RELEASE_DELAY, DEFAULT_CONNECTION_RELEASE_DELAY);
+    poolOptions.setIdleTimeout(connectionReleaseDelay);
+    poolOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
+
+    return PgPool.pool(vertx, connectOptions, poolOptions);
+  }
+
+  static PgConnectOptions createPgConnectOptions(JsonObject sqlConfig, boolean isReader) {
+    PgConnectOptions pgConnectOptions = new PgConnectOptions();
+    String hostToResolve = PostgresClient.HOST;
+    String portToResolve = PostgresClient.PORT;
+
+    if (isReader) {
+      hostToResolve = PostgresClient.HOST_READER;
+      portToResolve = PostgresClient.PORT_READER;
+    }
+
+    String host = sqlConfig.getString(hostToResolve);
+    if (host != null) {
+      pgConnectOptions.setHost(host);
+    }
+
+    Integer port;
+    port = sqlConfig.getInteger(portToResolve);
+
+    if (port != null) {
+      pgConnectOptions.setPort(port);
+    }
+
+    if (isReader && (host == null || port == null)) {
+      return null;
+    }
+
+    String username = sqlConfig.getString(PostgresClient.USERNAME);
+    if (username != null) {
+      pgConnectOptions.setUser(username);
+    }
+    String password = sqlConfig.getString(PostgresClient.PASSWORD);
+    if (password != null) {
+      pgConnectOptions.setPassword(password);
+    }
+    String database = sqlConfig.getString(PostgresClient.DATABASE);
+    if (database != null) {
+      pgConnectOptions.setDatabase(database);
+    }
+    Integer reconnectAttempts = sqlConfig.getInteger(RECONNECT_ATTEMPTS);
+    if (reconnectAttempts != null) {
+      pgConnectOptions.setReconnectAttempts(reconnectAttempts);
+    }
+    Long reconnectInterval = sqlConfig.getLong(RECONNECT_INTERVAL);
+    if (reconnectInterval != null) {
+      pgConnectOptions.setReconnectInterval(reconnectInterval);
+    }
+    String serverPem = sqlConfig.getString(SERVER_PEM);
+    if (serverPem != null) {
+      pgConnectOptions.setSslMode(SslMode.VERIFY_FULL);
+      pgConnectOptions.setHostnameVerificationAlgorithm("HTTPS");
+      pgConnectOptions.setPemTrustOptions(
+          new PemTrustOptions().addCertValue(Buffer.buffer(serverPem)));
+      pgConnectOptions.setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.3"));
+      if (OpenSSLEngineOptions.isAvailable()) {
+        pgConnectOptions.setOpenSslEngineOptions(new OpenSSLEngineOptions());
+      } else {
+        pgConnectOptions.setJdkSslEngineOptions(new JdkSSLEngineOptions());
+        log.error("Cannot run OpenSSL, using slow JDKSSL. Is netty-tcnative-boringssl-static for windows-x86_64, "
+            + "osx-x86_64 or linux-x86_64 installed? https://netty.io/wiki/forked-tomcat-native.html "
+            + "Is libc6-compat installed (if required)? https://github.com/pires/netty-tcnative-alpine");
+      }
+      log.debug("Enforcing SSL encryption for PostgreSQL connections, "
+          + "requiring TLSv1.3 with server name certificate, "
+          + "using " + (OpenSSLEngineOptions.isAvailable() ? "OpenSSL " + OpenSsl.versionString() : "JDKSSL"));
+    }
+    return pgConnectOptions;
+  }
+
+}
+

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -18,36 +18,64 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 public class PostgresClientInitializer {
-  static Logger log = LogManager.getLogger(PostgresClientInitializer.class);
-  private static final String    CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
-  private static final String    MAX_POOL_SIZE = "maxPoolSize";
-  private static final int       DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
-  private static final String    RECONNECT_ATTEMPTS = "reconnectAttempts";
-  private static final String    RECONNECT_INTERVAL = "reconnectInterval";
-  private static final String    SERVER_PEM = "server_pem";
+  static final String HOST_READER_ASYNC = "host_reader_async";
+  static final String PORT_READER_ASYNC = "port_reader_async";
 
-  private Vertx vertx;
-  private JsonObject configuration;
+  private static final Logger LOG = LogManager.getLogger(PostgresClientInitializer.class);
+  private static final String CONNECTION_RELEASE_DELAY = "connectionReleaseDelay";
+  private static final String MAX_POOL_SIZE = "maxPoolSize";
+  private static final int DEFAULT_CONNECTION_RELEASE_DELAY = 60000;
+  private static final String RECONNECT_ATTEMPTS = "reconnectAttempts";
+  private static final String RECONNECT_INTERVAL = "reconnectInterval";
+  private static final String SERVER_PEM = "server_pem";
 
+  private final PgPool client;
+  private PgPool readClient;
+  private PgPool readClientAsync;
+
+  /**
+   * Defines the various clients (PgPool instances) based on their configured hosts in any supported combination.
+   * @param vertx A reference to the current vertex instance.
+   * @param configuration A reference to the current database configuration.
+   */
   public PostgresClientInitializer(Vertx vertx, JsonObject configuration) {
-    this.vertx = vertx;
-    this.configuration = configuration;
+    client = createPgPool(vertx, configuration, PostgresClient.HOST, PostgresClient.PORT);
+    readClient = createPgPool(vertx, configuration, PostgresClient.HOST_READER, PostgresClient.PORT_READER);
+    readClientAsync = createPgPool(vertx, configuration, HOST_READER_ASYNC, PORT_READER_ASYNC);
+
+    // If neither read clients are defined, they must both use the r/w client.
+    if (readClient == null && readClientAsync == null) {
+      readClient = client;
+      readClientAsync = client;
+    }
+    // If there is only the synchronous read client, then it is fine that the async read client code can use it.
+    if (readClient != null && readClientAsync == null) {
+      readClientAsync = readClient;
+    }
+    // If only the async read client is defined (as will be the desired state for AWS RDS), then any code
+    // which uses the sync read client must use the w/r client.
+    if (readClient == null && readClientAsync != null) {
+      readClient = client;
+    }
   }
 
   public PgPool getClient() {
-    return createPgPool(vertx, configuration, false);
+    return client;
   }
 
   public PgPool getReadClient() {
-    return createPgPool(vertx, configuration, true);
+    return readClient;
   }
 
-  public PgPool getReadAsyncClient() {
-    return null;
+  public PgPool getReadClientAsync() {
+    return readClientAsync;
   }
 
-  private static PgPool createPgPool(Vertx vertx, JsonObject configuration, Boolean isReader) {
-    var connectOptions = createPgConnectOptions(configuration, isReader);
+  private static PgPool createPgPool(Vertx vertx,
+                                     JsonObject configuration,
+                                     String hostToResolve,
+                                     String portToResolve) {
+    var connectOptions = createPgConnectOptions(configuration, hostToResolve, portToResolve);
 
     if (connectOptions == null) {
       return null;
@@ -56,24 +84,52 @@ public class PostgresClientInitializer {
     var poolOptions = new PoolOptions();
     poolOptions.setMaxSize(
         configuration.getInteger(PostgresClient.MAX_SHARED_POOL_SIZE, configuration.getInteger(MAX_POOL_SIZE, 4)));
-    Integer connectionReleaseDelay = configuration.getInteger(CONNECTION_RELEASE_DELAY, DEFAULT_CONNECTION_RELEASE_DELAY);
+    var connectionReleaseDelay = configuration.getInteger(CONNECTION_RELEASE_DELAY, DEFAULT_CONNECTION_RELEASE_DELAY);
     poolOptions.setIdleTimeout(connectionReleaseDelay);
     poolOptions.setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
     return PgPool.pool(vertx, connectOptions, poolOptions);
   }
 
-  static PgConnectOptions createPgConnectOptions(JsonObject sqlConfig, boolean isReader) {
-    PgConnectOptions pgConnectOptions = new PgConnectOptions();
-    String hostToResolve = PostgresClient.HOST;
-    String portToResolve = PostgresClient.PORT;
+  static PgConnectOptions createPgConnectOptions(JsonObject sqlConfig, String hostToResolve, String portToResolve) {
+    var pgConnectOptions = new PgConnectOptions();
 
-    if (isReader) {
-      hostToResolve = PostgresClient.HOST_READER;
-      portToResolve = PostgresClient.PORT_READER;
+    if (!trySetHostAndPort(pgConnectOptions, sqlConfig, hostToResolve, portToResolve)) {
+      return null;
     }
 
-    String host = sqlConfig.getString(hostToResolve);
+    var username = sqlConfig.getString(PostgresClient.USERNAME);
+    if (username != null) {
+      pgConnectOptions.setUser(username);
+    }
+    var password = sqlConfig.getString(PostgresClient.PASSWORD);
+    if (password != null) {
+      pgConnectOptions.setPassword(password);
+    }
+    var database = sqlConfig.getString(PostgresClient.DATABASE);
+    if (database != null) {
+      pgConnectOptions.setDatabase(database);
+    }
+    var reconnectAttempts = sqlConfig.getInteger(RECONNECT_ATTEMPTS);
+    if (reconnectAttempts != null) {
+      pgConnectOptions.setReconnectAttempts(reconnectAttempts);
+    }
+    var reconnectInterval = sqlConfig.getLong(RECONNECT_INTERVAL);
+    if (reconnectInterval != null) {
+      pgConnectOptions.setReconnectInterval(reconnectInterval);
+    }
+    var serverPem = sqlConfig.getString(SERVER_PEM);
+    if (serverPem != null) {
+      setUpSsl(pgConnectOptions, serverPem);
+    }
+    return pgConnectOptions;
+  }
+
+  private static boolean trySetHostAndPort(PgConnectOptions pgConnectOptions,
+                                           JsonObject sqlConfig,
+                                           String hostToResolve,
+                                           String portToResolve) {
+    var host = sqlConfig.getString(hostToResolve);
     if (host != null) {
       pgConnectOptions.setHost(host);
     }
@@ -85,51 +141,30 @@ public class PostgresClientInitializer {
       pgConnectOptions.setPort(port);
     }
 
-    if (isReader && (host == null || port == null)) {
-      return null;
-    }
-
-    String username = sqlConfig.getString(PostgresClient.USERNAME);
-    if (username != null) {
-      pgConnectOptions.setUser(username);
-    }
-    String password = sqlConfig.getString(PostgresClient.PASSWORD);
-    if (password != null) {
-      pgConnectOptions.setPassword(password);
-    }
-    String database = sqlConfig.getString(PostgresClient.DATABASE);
-    if (database != null) {
-      pgConnectOptions.setDatabase(database);
-    }
-    Integer reconnectAttempts = sqlConfig.getInteger(RECONNECT_ATTEMPTS);
-    if (reconnectAttempts != null) {
-      pgConnectOptions.setReconnectAttempts(reconnectAttempts);
-    }
-    Long reconnectInterval = sqlConfig.getLong(RECONNECT_INTERVAL);
-    if (reconnectInterval != null) {
-      pgConnectOptions.setReconnectInterval(reconnectInterval);
-    }
-    String serverPem = sqlConfig.getString(SERVER_PEM);
-    if (serverPem != null) {
-      pgConnectOptions.setSslMode(SslMode.VERIFY_FULL);
-      pgConnectOptions.setHostnameVerificationAlgorithm("HTTPS");
-      pgConnectOptions.setPemTrustOptions(
-          new PemTrustOptions().addCertValue(Buffer.buffer(serverPem)));
-      pgConnectOptions.setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.3"));
-      if (OpenSSLEngineOptions.isAvailable()) {
-        pgConnectOptions.setOpenSslEngineOptions(new OpenSSLEngineOptions());
-      } else {
-        pgConnectOptions.setJdkSslEngineOptions(new JdkSSLEngineOptions());
-        log.error("Cannot run OpenSSL, using slow JDKSSL. Is netty-tcnative-boringssl-static for windows-x86_64, "
-            + "osx-x86_64 or linux-x86_64 installed? https://netty.io/wiki/forked-tomcat-native.html "
-            + "Is libc6-compat installed (if required)? https://github.com/pires/netty-tcnative-alpine");
-      }
-      log.debug("Enforcing SSL encryption for PostgreSQL connections, "
-          + "requiring TLSv1.3 with server name certificate, "
-          + "using " + (OpenSSLEngineOptions.isAvailable() ? "OpenSSL " + OpenSsl.versionString() : "JDKSSL"));
-    }
-    return pgConnectOptions;
+    return !isReaderHost(hostToResolve) || (host != null && port != null);
   }
 
+  private static void setUpSsl(PgConnectOptions pgConnectOptions, String serverPem) {
+    pgConnectOptions.setSslMode(SslMode.VERIFY_FULL);
+    pgConnectOptions.setHostnameVerificationAlgorithm("HTTPS");
+    pgConnectOptions.setPemTrustOptions(
+        new PemTrustOptions().addCertValue(Buffer.buffer(serverPem)));
+    pgConnectOptions.setEnabledSecureTransportProtocols(Collections.singleton("TLSv1.3"));
+    if (OpenSSLEngineOptions.isAvailable()) {
+      pgConnectOptions.setOpenSslEngineOptions(new OpenSSLEngineOptions());
+    } else {
+      pgConnectOptions.setJdkSslEngineOptions(new JdkSSLEngineOptions());
+      LOG.error("Cannot run OpenSSL, using slow JDKSSL. Is netty-tcnative-boringssl-static for windows-x86_64, "
+          + "osx-x86_64 or linux-x86_64 installed? https://netty.io/wiki/forked-tomcat-native.html "
+          + "Is libc6-compat installed (if required)? https://github.com/pires/netty-tcnative-alpine");
+    }
+    LOG.debug("Enforcing SSL encryption for PostgreSQL connections, "
+        + "requiring TLSv1.3 with server name certificate, "
+        + "using {}", (OpenSSLEngineOptions.isAvailable() ? ("OpenSSL " + OpenSsl.versionString()) : "JDKSSL"));
+  }
+
+  private static boolean isReaderHost(String hostToResolve) {
+    return hostToResolve.equals(PostgresClient.HOST_READER) || hostToResolve.equals(HOST_READER_ASYNC);
+  }
 }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -30,8 +30,8 @@ public class PostgresClientInitializer {
   private static final String SERVER_PEM = "server_pem";
 
   private final PgPool client;
-  private PgPool readClient;
-  private PgPool readClientAsync;
+  private PgPool syncReadClient;
+  private PgPool asyncReadClient;
 
   /**
    * Defines the various clients (PgPool instances) based on their configured hosts in any supported combination.
@@ -40,17 +40,17 @@ public class PostgresClientInitializer {
    */
   protected PostgresClientInitializer(Vertx vertx, JsonObject configuration) {
     client = createPgPool(vertx, configuration, PostgresClient.HOST, PostgresClient.PORT);
-    readClient = createPgPool(vertx, configuration, PostgresClient.HOST_READER, PostgresClient.PORT_READER);
-    readClientAsync = createPgPool(vertx, configuration, HOST_READER_ASYNC, PORT_READER_ASYNC);
+    syncReadClient = createPgPool(vertx, configuration, PostgresClient.HOST_READER, PostgresClient.PORT_READER);
+    asyncReadClient = createPgPool(vertx, configuration, HOST_READER_ASYNC, PORT_READER_ASYNC);
 
     // If there is no read client defined, then use the r/w client for it.
     // If there is no async read client defined, then use the sync read client for it if it exists,
     // otherwise all 3 clients are the r/w client.
-    if (readClient == null) {
-      readClient = client;
+    if (syncReadClient == null) {
+      syncReadClient = client;
     }
-    if (readClientAsync == null) {
-      readClientAsync = readClient;
+    if (asyncReadClient == null) {
+      asyncReadClient = syncReadClient;
     }
   }
 
@@ -58,12 +58,12 @@ public class PostgresClientInitializer {
     return client;
   }
 
-  public PgPool getReadClient() {
-    return  readClient;
+  public PgPool getSyncReadClient() {
+    return syncReadClient;
   }
 
-  public PgPool getReadClientAsync() {
-    return readClientAsync;
+  public PgPool getAsyncReadClient() {
+    return asyncReadClient;
   }
 
   private static PgPool createPgPool(Vertx vertx,

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -43,19 +43,14 @@ public class PostgresClientInitializer {
     readClient = createPgPool(vertx, configuration, PostgresClient.HOST_READER, PostgresClient.PORT_READER);
     readClientAsync = createPgPool(vertx, configuration, HOST_READER_ASYNC, PORT_READER_ASYNC);
 
-    // If neither read clients are defined, they must both use the r/w client.
-    if (readClient == null && readClientAsync == null) {
+    // If there is no read client defined, then use the r/w client for it.
+    // If there is no async read client defined, then use the sync read client for it if it exists,
+    // otherwise all 3 clients are the r/w client.
+    if (readClient == null) {
       readClient = client;
-      readClientAsync = client;
     }
-    // If there is only the synchronous read client, then it is fine that the async read client code can use it.
-    if (readClient != null && readClientAsync == null) {
+    if (readClientAsync == null) {
       readClientAsync = readClient;
-    }
-    // If only the async read client is defined (as will be the desired state for AWS RDS), then any code
-    // which uses the sync read client must use the w/r client.
-    if (readClient == null && readClientAsync != null) {
-      readClient = client;
     }
   }
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientInitializer.java
@@ -38,7 +38,7 @@ public class PostgresClientInitializer {
    * @param vertx A reference to the current vertex instance.
    * @param configuration A reference to the current database configuration.
    */
-  public PostgresClientInitializer(Vertx vertx, JsonObject configuration) {
+  protected PostgresClientInitializer(Vertx vertx, JsonObject configuration) {
     client = createPgPool(vertx, configuration, PostgresClient.HOST, PostgresClient.PORT);
     readClient = createPgPool(vertx, configuration, PostgresClient.HOST_READER, PostgresClient.PORT_READER);
     readClientAsync = createPgPool(vertx, configuration, HOST_READER_ASYNC, PORT_READER_ASYNC);
@@ -64,7 +64,7 @@ public class PostgresClientInitializer {
   }
 
   public PgPool getReadClient() {
-    return readClient;
+    return  readClient;
   }
 
   public PgPool getReadClientAsync() {

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
@@ -8,9 +8,9 @@ public class PostgresClientWithAsyncReadConn extends PostgresClient {
   }
 
   public static PostgresClient getInstance(Vertx vertx, String tenantId) {
-    var client = getInstanceInternal(vertx, tenantId);
-    var initializer = client.getPostgresClientInitializer();
-    client.setReaderClient(initializer.getReadClientAsync());
-    return client;
+    var postgresClient = getInstanceInternal(vertx, tenantId);
+    var initializer = postgresClient.getPostgresClientInitializer();
+    postgresClient.setReaderClient(initializer.getReadClientAsync());
+    return postgresClient;
   }
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
@@ -1,0 +1,41 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.pgclient.PgPool;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PostgresClientWithAsyncReadConn {
+  /**
+   * Allows for pools to be reused when in shared pool mode.
+   */
+  private static final Map<Vertx,PgPool> PG_POOLS_ASYNC_READER = new HashMap<>();
+  private static final String    HOST_READER = "host_async_reader";
+  private static final String    PORT_READER = "port_async_reader";
+  private final PostgresClient postgresClient;
+  private PgPool readAsyncClient;
+
+  public PostgresClientWithAsyncReadConn(PostgresClient postgresClient) {
+    this.postgresClient = postgresClient;
+    init();
+  }
+
+  private void init() {
+    // TODO
+  }
+
+  public Future<PgConnection> getAsyncReadConnection() {
+    return postgresClient.getConnection(readAsyncClient)
+        .recover(e -> {
+          if (! "Timeout".equals(e.getMessage())) {
+            return Future.failedFuture(e);
+          }
+          return Future.failedFuture("Timeout for DB_HOST_ASYNC_READER:DB_PORT_ASYNC_READER="
+              + " TODO -- get from this config :"
+              + " TODO -- get from this config");
+        });
+  }
+}

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
@@ -1,7 +1,19 @@
 package org.folio.rest.persist;
 
 import io.vertx.core.Vertx;
+import org.folio.rest.persist.cache.ConnectionCache;
 
+/**
+ * Clients which, for performance reasons, would like to take advantage of asynchronous read replication can use
+ * this class to create their instance of the {@link PostgresClient} using the {@link PostgresClient#getInstance(Vertx)}
+ * or the {@link PostgresClient#getInstance(Vertx, String)} method.
+ * Note that the data on the read-only host is asynchronously replicated. This means that it is eventually consistent
+ * and not ACID. In other words, it is not guaranteed to be up-to-date or synchronized with the read/write host.
+ * The async read host used by this class is therefore intended to be used in cases where eventually consistent data
+ * is acceptable, such as reporting.
+ * APIs using the async client should have a warning in the API documentation that it uses stale data (for performance
+ * reasons).
+ */
 public class PostgresClientWithAsyncReadConn extends PostgresClient {
   protected PostgresClientWithAsyncReadConn(Vertx vertx, String tenantId) throws Exception {
     super(vertx, tenantId);

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
@@ -1,7 +1,6 @@
 package org.folio.rest.persist;
 
 import io.vertx.core.Vertx;
-import org.folio.rest.persist.cache.ConnectionCache;
 
 /**
  * Clients which, for performance reasons, would like to take advantage of asynchronous read replication can use
@@ -22,7 +21,7 @@ public class PostgresClientWithAsyncReadConn extends PostgresClient {
   public static PostgresClient getInstance(Vertx vertx, String tenantId) {
     var postgresClient = getInstanceInternal(vertx, tenantId);
     var initializer = postgresClient.getPostgresClientInitializer();
-    postgresClient.setReaderClient(initializer.getReadClientAsync());
+    postgresClient.setReaderClient(initializer.getAsyncReadClient());
     return postgresClient;
   }
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/PostgresClientWithAsyncReadConn.java
@@ -1,41 +1,16 @@
 package org.folio.rest.persist;
 
-import io.vertx.core.Future;
 import io.vertx.core.Vertx;
-import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgPool;
 
-import java.util.HashMap;
-import java.util.Map;
-
-public class PostgresClientWithAsyncReadConn {
-  /**
-   * Allows for pools to be reused when in shared pool mode.
-   */
-  private static final Map<Vertx,PgPool> PG_POOLS_ASYNC_READER = new HashMap<>();
-  private static final String    HOST_READER = "host_async_reader";
-  private static final String    PORT_READER = "port_async_reader";
-  private final PostgresClient postgresClient;
-  private PgPool readAsyncClient;
-
-  public PostgresClientWithAsyncReadConn(PostgresClient postgresClient) {
-    this.postgresClient = postgresClient;
-    init();
+public class PostgresClientWithAsyncReadConn extends PostgresClient {
+  protected PostgresClientWithAsyncReadConn(Vertx vertx, String tenantId) throws Exception {
+    super(vertx, tenantId);
   }
 
-  private void init() {
-    // TODO
-  }
-
-  public Future<PgConnection> getAsyncReadConnection() {
-    return postgresClient.getConnection(readAsyncClient)
-        .recover(e -> {
-          if (! "Timeout".equals(e.getMessage())) {
-            return Future.failedFuture(e);
-          }
-          return Future.failedFuture("Timeout for DB_HOST_ASYNC_READER:DB_PORT_ASYNC_READER="
-              + " TODO -- get from this config :"
-              + " TODO -- get from this config");
-        });
+  public static PostgresClient getInstance(Vertx vertx, String tenantId) {
+    var client = getInstanceInternal(vertx, tenantId);
+    var initializer = client.getPostgresClientInitializer();
+    client.setReaderClient(initializer.getReadClientAsync());
+    return client;
   }
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/cache/CachedConnectionManager.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/cache/CachedConnectionManager.java
@@ -3,6 +3,7 @@ package org.folio.rest.persist.cache;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
 import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.PostgresClientInitializer;
 import org.folio.rest.tools.utils.Envs;
 import io.vertx.core.Vertx;
 import io.vertx.core.Future;
@@ -24,8 +25,8 @@ public class CachedConnectionManager {
   private static final Logger LOG = LogManager.getLogger(CachedConnectionManager.class);
   private static final int MAX_POOL_SIZE =
       getIntFromEnvOrDefault(Envs.DB_MAXSHAREDPOOLSIZE, PostgresClient.DEFAULT_MAX_POOL_SIZE);
-  private static final int CONNECTION_RELEASE_DELAY_SECONDS =
-      getIntFromEnvOrDefault(Envs.DB_CONNECTIONRELEASEDELAY, PostgresClient.DEFAULT_CONNECTION_RELEASE_DELAY);
+  private static final int CONNECTION_RELEASE_DELAY_SECONDS = getIntFromEnvOrDefault(Envs.DB_CONNECTIONRELEASEDELAY,
+      PostgresClientInitializer.DEFAULT_CONNECTION_RELEASE_DELAY);
 
   private final ConnectionCache connectionCache = new ConnectionCache();
 

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -8,10 +8,10 @@ import java.util.Map;
 public enum Envs {
   DB_HOST,
   DB_HOST_READER,
-  DB_HOST_ASYNC_READER,
+  DB_HOST_READER_ASYNC,
   DB_PORT,
   DB_PORT_READER,
-  DB_PORT_ASYNC_READER,
+  DB_PORT_READER_ASYNC,
   DB_USERNAME,
   DB_PASSWORD,
   DB_DATABASE,
@@ -68,6 +68,7 @@ public enum Envs {
       switch (envs) {
       case DB_PORT:
       case DB_PORT_READER:
+      case DB_PORT_READER_ASYNC:
       case DB_QUERYTIMEOUT:
       case DB_MAXPOOLSIZE:
       case DB_MAXSHAREDPOOLSIZE:

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/utils/Envs.java
@@ -8,8 +8,10 @@ import java.util.Map;
 public enum Envs {
   DB_HOST,
   DB_HOST_READER,
+  DB_HOST_ASYNC_READER,
   DB_PORT,
   DB_PORT_READER,
+  DB_PORT_ASYNC_READER,
   DB_USERNAME,
   DB_PASSWORD,
   DB_DATABASE,

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -458,7 +458,7 @@ public class PostgresClientIT {
     postgresClient = createA(context, TENANT);
     JsonObject configuration = postgresClient.getConnectionConfig().copy()
         .put("maxPoolSize", maxPoolSize);
-    var initializer = new PostgresClientInitializer(vertx, configuration);
+    var initializer = new PostgresClientInitializer(Vertx.vertx(), configuration);
     postgresClient.setClient(initializer.getClient());
     List<Future> futures = new ArrayList<>();
     for (int i=0; i<maxPoolSize; i++) {

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientIT.java
@@ -458,7 +458,8 @@ public class PostgresClientIT {
     postgresClient = createA(context, TENANT);
     JsonObject configuration = postgresClient.getConnectionConfig().copy()
         .put("maxPoolSize", maxPoolSize);
-    postgresClient.setClient(PostgresClient.createPgPool(vertx, configuration, false));
+    var initializer = new PostgresClientInitializer(vertx, configuration);
+    postgresClient.setClient(initializer.getClient());
     List<Future> futures = new ArrayList<>();
     for (int i=0; i<maxPoolSize; i++) {
       futures.add(Future.<RowSet<Row>>future(promise ->

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -28,7 +28,6 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.pgclient.PgConnection;
-import io.vertx.pgclient.PgPool;
 import io.vertx.pgclient.impl.RowImpl;
 import io.vertx.sqlclient.Query;
 import io.vertx.sqlclient.Row;

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -51,7 +51,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class PostgresClientTest {
   // See PostgresClientIT.java for the tests that require a postgres database!
 

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -275,8 +275,37 @@ public class PostgresClientTest {
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
       assertNotNull(initializer.getReadClient());
+      assertNotNull(initializer.getReadClientAsync());
       assertEquals(initializer.getClient(), initializer.getReadClient());
+      assertEquals(initializer.getClient(), initializer.getReadClientAsync());
+    } finally {
+      // restore defaults
+      Envs.setEnv(System.getenv());
+    }
+  }
+
+  @Test
+  public void testGettingPgPoolWithNoReader() throws Exception {
+    try {
+      Envs.setEnv(Map.of(
+          "DB_HOST", "myhost",
+          "DB_PORT", "5433",
+          "DB_USERNAME", "myuser",
+          "DB_PASSWORD", "mypassword",
+          "DB_DATABASE", "mydatabase",
+          "DB_CONNECTIONRELEASEDELAY", "1000",
+          "DB_RECONNECTATTEMPTS", "3",
+          "DB_RECONNECTINTERVAL", "2000"
+      ));
+      JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
+      var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
+      assertNotNull(initializer.getReadClient());
+      assertNotNull(initializer.getReadClientAsync());
+      assertEquals(initializer.getClient(), initializer.getReadClient());
+      assertEquals(initializer.getClient(), initializer.getReadClientAsync());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -300,8 +329,8 @@ public class PostgresClientTest {
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
-      assertNotNull(initializer.getReadClient());
       assertNotEquals(initializer.getClient(), initializer.getReadClient());
+      assertEquals(initializer.getReadClient(), initializer.getReadClientAsync());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -325,6 +354,7 @@ public class PostgresClientTest {
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
       assertNotNull(initializer.getReadClient());
       assertNotNull(initializer.getReadClientAsync());
       assertEquals(initializer.getClient(), initializer.getReadClient());
@@ -335,6 +365,53 @@ public class PostgresClientTest {
     }
   }
 
+  @Test
+  public void testGettingPgPoolWithAllThreeHostTypes() throws Exception {
+    try {
+      Envs.setEnv(Map.of(
+          "DB_PORT_READER_ASYNC", "12345",
+          "DB_HOST_READER_ASYNC", "myhost_reader_async",
+          "DB_PORT_READER", "54321",
+          "DB_HOST_READER", "myhost_reader",
+          "DB_HOST", "myhost",
+          "DB_PORT", "5433"
+      ));
+      JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
+      var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
+      assertNotNull(initializer.getReadClient());
+      assertNotNull(initializer.getReadClientAsync());
+      assertNotEquals(initializer.getClient(), initializer.getReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
+      assertNotEquals(initializer.getReadClient(), initializer.getReadClientAsync());
+    } finally {
+      // restore defaults
+      Envs.setEnv(System.getenv());
+    }
+  }
+
+  @Test
+  public void testGettingPgPoolWithSharedReader() throws Exception {
+    try {
+      Envs.setEnv(Map.of(
+          "DB_PORT_READER", "54321",
+          "DB_HOST_READER", "myhost_reader",
+          "DB_HOST", "myhost",
+          "DB_PORT", "5433"
+      ));
+      JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
+      var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
+      assertNotNull(initializer.getReadClient());
+      assertNotNull(initializer.getReadClientAsync());
+      assertNotEquals(initializer.getClient(), initializer.getReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
+      assertEquals(initializer.getReadClient(), initializer.getReadClientAsync());
+    } finally {
+      // restore defaults
+      Envs.setEnv(System.getenv());
+    }
+  }
 
   @Test
   public void closePostgresTester() {

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -276,10 +276,10 @@ public class PostgresClientTest {
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
       assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertEquals(initializer.getClient(), initializer.getReadClient());
-      assertEquals(initializer.getClient(), initializer.getReadClientAsync());
+      assertNotNull(initializer.getSyncReadClient());
+      assertNotNull(initializer.getAsyncReadClient());
+      assertEquals(initializer.getClient(), initializer.getSyncReadClient());
+      assertEquals(initializer.getClient(), initializer.getAsyncReadClient());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -302,10 +302,10 @@ public class PostgresClientTest {
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
       assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertEquals(initializer.getClient(), initializer.getReadClient());
-      assertEquals(initializer.getClient(), initializer.getReadClientAsync());
+      assertNotNull(initializer.getSyncReadClient());
+      assertNotNull(initializer.getAsyncReadClient());
+      assertEquals(initializer.getClient(), initializer.getSyncReadClient());
+      assertEquals(initializer.getClient(), initializer.getAsyncReadClient());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -330,11 +330,11 @@ public class PostgresClientTest {
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
       assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertNotEquals(initializer.getClient(), initializer.getReadClient());
-      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
-      assertEquals(initializer.getReadClient(), initializer.getReadClientAsync());
+      assertNotNull(initializer.getSyncReadClient());
+      assertNotNull(initializer.getAsyncReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getSyncReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getAsyncReadClient());
+      assertEquals(initializer.getSyncReadClient(), initializer.getAsyncReadClient());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -359,10 +359,10 @@ public class PostgresClientTest {
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
       assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertEquals(initializer.getClient(), initializer.getReadClient());
-      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
+      assertNotNull(initializer.getSyncReadClient());
+      assertNotNull(initializer.getAsyncReadClient());
+      assertEquals(initializer.getClient(), initializer.getSyncReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getAsyncReadClient());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());
@@ -383,11 +383,11 @@ public class PostgresClientTest {
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
       assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertNotEquals(initializer.getClient(), initializer.getReadClient());
-      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
-      assertNotEquals(initializer.getReadClient(), initializer.getReadClientAsync());
+      assertNotNull(initializer.getSyncReadClient());
+      assertNotNull(initializer.getAsyncReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getSyncReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getAsyncReadClient());
+      assertNotEquals(initializer.getSyncReadClient(), initializer.getAsyncReadClient());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -329,7 +329,11 @@ public class PostgresClientTest {
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
       var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
+      assertNotNull(initializer.getClient());
+      assertNotNull(initializer.getReadClient());
+      assertNotNull(initializer.getReadClientAsync());
       assertNotEquals(initializer.getClient(), initializer.getReadClient());
+      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
       assertEquals(initializer.getReadClient(), initializer.getReadClientAsync());
     } finally {
       // restore defaults
@@ -384,29 +388,6 @@ public class PostgresClientTest {
       assertNotEquals(initializer.getClient(), initializer.getReadClient());
       assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
       assertNotEquals(initializer.getReadClient(), initializer.getReadClientAsync());
-    } finally {
-      // restore defaults
-      Envs.setEnv(System.getenv());
-    }
-  }
-
-  @Test
-  public void testGettingPgPoolWithSharedReader() throws Exception {
-    try {
-      Envs.setEnv(Map.of(
-          "DB_PORT_READER", "54321",
-          "DB_HOST_READER", "myhost_reader",
-          "DB_HOST", "myhost",
-          "DB_PORT", "5433"
-      ));
-      JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
-      var initializer = new PostgresClientInitializer(Vertx.vertx(), conf);
-      assertNotNull(initializer.getClient());
-      assertNotNull(initializer.getReadClient());
-      assertNotNull(initializer.getReadClientAsync());
-      assertNotEquals(initializer.getClient(), initializer.getReadClient());
-      assertNotEquals(initializer.getClient(), initializer.getReadClientAsync());
-      assertEquals(initializer.getReadClient(), initializer.getReadClientAsync());
     } finally {
       // restore defaults
       Envs.setEnv(System.getenv());

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientTest.java
@@ -168,7 +168,7 @@ public class PostgresClientTest {
   @Test
   public void testPgConnectOptionsEmpty() {
     JsonObject conf = new JsonObject();
-    PgConnectOptions options = PostgresClient.createPgConnectOptions(conf, false);
+    PgConnectOptions options = PostgresClientInitializer.createPgConnectOptions(conf, false);
     assertThat("localhost", is(options.getHost()));
     assertThat(5432, is(options.getPort()));
     assertThat("user", is(options.getUser()));
@@ -193,7 +193,7 @@ public class PostgresClientTest {
           "DB_RECONNECTINTERVAL", "2000"
           ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
-      PgConnectOptions options = PostgresClient.createPgConnectOptions(conf, false);
+      PgConnectOptions options = PostgresClientInitializer.createPgConnectOptions(conf, false);
       assertThat(options.getHost(), is("myhost"));
       assertThat(options.getPort(), is(5433));
       assertThat(options.getUser(), is("myuser"));
@@ -226,7 +226,7 @@ public class PostgresClientTest {
           "DB_RECONNECTINTERVAL", "2000"
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
-      PgConnectOptions options = PostgresClient.createPgConnectOptions(conf, true);
+      PgConnectOptions options = PostgresClientInitializer.createPgConnectOptions(conf, true);
       assertThat(options.getHost(), is("myhost_reader"));
       assertThat(options.getPort(), is(12345));
       assertThat(options.getUser(), is("myuser"));
@@ -255,7 +255,7 @@ public class PostgresClientTest {
           "DB_RECONNECTINTERVAL", "2000"
       ));
       JsonObject conf = new PostgresClient(Vertx.vertx(), "public").getConnectionConfig();
-      PgConnectOptions options = PostgresClient.createPgConnectOptions(conf, true);
+      PgConnectOptions options = PostgresClientInitializer.createPgConnectOptions(conf, true);
       assertNull(options);
     } finally {
       // restore defaults
@@ -270,8 +270,8 @@ public class PostgresClientTest {
       config.put("DB_PORT_READER", "5433")
             .put("DB_USERNAME", "myuser")
             .put("DB_PASSWORD", "mypassword");
-
-      PgPool pgPool = PostgresClient.createPgPool(Vertx.vertx(), config, true);
+      var initializer = new PostgresClientInitializer(Vertx.vertx(), config);
+      PgPool pgPool = initializer.getReadClient();
       assertNull(pgPool);
     } finally {
       // restore defaults

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientWithAsyncReadConnTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientWithAsyncReadConnTest.java
@@ -31,6 +31,6 @@ public class PostgresClientWithAsyncReadConnTest {
     assertNotNull(client);
     assertNotNull(client.getReaderClient());
     assertNotEquals(client.getClient(), client.getReaderClient());
-    assertEquals(client.getReaderClient(), initializer.getReadClientAsync());
+    assertEquals(client.getReaderClient(), initializer.getAsyncReadClient());
   }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientWithAsyncReadConnTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/PostgresClientWithAsyncReadConnTest.java
@@ -1,0 +1,36 @@
+package org.folio.rest.persist;
+
+import io.vertx.core.Vertx;
+import org.folio.rest.tools.utils.Envs;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class PostgresClientWithAsyncReadConnTest {
+
+  @Test
+  public void getInstanceTest() {
+    Envs.setEnv(Map.of(
+        "DB_HOST_READER_ASYNC", "myhost_reader_async",
+        "DB_PORT_READER_ASYNC", "54321",
+        "DB_HOST_READER", "myhost_reader",
+        "DB_PORT_READER", "12345",
+        "DB_HOST", "myhost",
+        "DB_PORT", "5433",
+        "DB_USERNAME", "myuser",
+        "DB_PASSWORD", "mypassword",
+        "DB_DATABASE", "mydatabase",
+        "DB_CONNECTIONRELEASEDELAY", "1000"
+    ));
+    var vertx = Vertx.vertx();
+    var tenant = "testTenant";
+    var client = PostgresClientWithAsyncReadConn.getInstance(vertx, tenant);
+    var initializer = client.getPostgresClientInitializer();
+    assertNotNull(client);
+    assertNotNull(client.getReaderClient());
+    assertNotEquals(client.getClient(), client.getReaderClient());
+    assertEquals(client.getReaderClient(), initializer.getReadClientAsync());
+  }
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-975

Breaks logic for constructing the three types of hosts out into its own class since it is now used by `PostgresClient` and `PostgresClientWithAsyncReadConn`. `PostgresClientWithAsyncReadConn` is responsible for setting the read host to be the async reader. Users can use the `PostgresClient` returned from PostgresClientWithAsyncReadConn.getInstance` as a drop in replacement of `PostgresClient`.

I opted to use inheritance rather than composition to make `PostgresClientWithAsyncReadConn` since extending it didn't require wrapping of all of the `SELECT` type of methods. If there are certain methods we don't want to support, it is easy enough to add overrides and throw an unsupported operation exception if needed.