### PR TITLE
RMB-1007: Upgrade dependencies for Ramsons; add license

### DIFF
--- a/cql2pgjson/pom.xml
+++ b/cql2pgjson/pom.xml
@@ -10,6 +10,14 @@
     <version>35.3.0-SNAPSHOT</version>
   </parent>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -136,27 +144,6 @@
 
   <build>
     <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
-        <executions>
-          <execution>
-            <id>enforce-maven</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>3.1.1</version>
-                </requireMavenVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/dbschema/pom.xml
+++ b/dbschema/pom.xml
@@ -10,6 +10,14 @@
     <version>35.3.0-SNAPSHOT</version>
   </parent>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/domain-models-api-aspects/pom.xml
+++ b/domain-models-api-aspects/pom.xml
@@ -7,6 +7,13 @@
   </parent>
   <artifactId>domain-models-api-aspects</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <dependencies>
 
@@ -57,7 +64,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.29.2-GA</version>
+      <version>3.30.2-GA</version>
     </dependency>
 
     <!-- test dependencies -->
@@ -100,7 +107,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>1.8</complianceLevel>
+          <complianceLevel>17</complianceLevel>
 
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>

--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -6,6 +6,15 @@
     <version>35.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>domain-models-api-interfaces</artifactId>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <properties>
     <jaxrsVersion>2.0</jaxrsVersion>
     <generate_routing_context>/rmbtests/test,/rmbtests/testForm</generate_routing_context>

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -9,6 +9,14 @@
   <description>Domain Model Generator that reads RAML files and writes Java files</description>
   <packaging>maven-plugin</packaging>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -31,7 +39,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.6.4</version>
+      <version>3.15.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -86,7 +94,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.3.9</version>
+      <version>3.9.9</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -135,7 +143,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>1.8</complianceLevel>
+          <complianceLevel>17</complianceLevel>
           <includes>
             <include>**/*.java</include>
             <include>**/*.aj</include>
@@ -169,7 +177,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.15.0</version>
         <configuration>
           <!-- <goalPrefix>maven-archetype-plugin</goalPrefix> -->
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/domain-models-runtime-it/pom.xml
+++ b/domain-models-runtime-it/pom.xml
@@ -9,6 +9,14 @@
     <version>35.3.0-SNAPSHOT</version>
   </parent>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <repositories>
     <repository>
       <id>folio-nexus</id>
@@ -20,7 +28,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
-    <aspectj.version>1.9.19</aspectj.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
   </properties>
 
   <dependencies>
@@ -103,7 +111,7 @@
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>1.8</complianceLevel>
+          <complianceLevel>17</complianceLevel>
           <includes>
             <include>**/impl/*.java</include>
             <include>**/*.aj</include>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -9,6 +9,14 @@
     <version>35.3.0-SNAPSHOT</version>
   </parent>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <repositories>
     <repository>
       <id>folio-nexus</id>
@@ -188,7 +196,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.32</version>
+      <version>2.3.33</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
@@ -414,7 +422,7 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0</version>
         <executions>
           <!-- Replace the baseUri in the RAMLs that have been copied to
           apidocs directory so that they can be used via the local html api console. -->
@@ -485,7 +493,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>5.0.0</version>
+        <version>9.0.1</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,9 @@
 
   <licenses>
     <license>
-      <name>Apache License 2.0</name>
-      <url>http://spdx.org/licenses/Apache-2.0</url>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
     </license>
   </licenses>
 
@@ -30,11 +31,13 @@
 
     <project.build.outputTimestamp>2024-04-12T11:06:20Z</project.build.outputTimestamp>
 
-    <aspectj.version>1.9.21.1</aspectj.version>
-    <maven.version>3.9.6</maven.version>
-    <vertx.version>4.5.7</vertx.version>
-    <micrometer.version>1.12.3</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
-    <awaitility.version>4.2.0</awaitility.version>
+    <aspectj.version>1.9.22.1</aspectj.version>
+    <maven.version>3.9.9</maven.version>
+    <vertx.version>4.5.10</vertx.version>
+    <micrometer.version>1.12.4</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <awaitility.version>4.2.2</awaitility.version>
+    <hamcrest.version>3.0</hamcrest.version>
+    <okapi.version>6.0.3</okapi.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -57,12 +60,12 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.0.0-jre</version>
+        <version>33.3.1-jre</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.23.0</version>
+        <version>2.24.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -83,7 +86,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.4.0</version>
+        <version>5.5.0</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -93,7 +96,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.15.1</version>
+        <version>2.17.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -108,7 +111,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.14.0</version>
+        <version>3.17.0</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
@@ -123,36 +126,36 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
-        <version>2.2</version>
+        <version>${hamcrest.version}</version>
       </dependency>
       <dependency>  <!-- http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x -->
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
-        <version>2.2</version>
+        <version>${hamcrest.version}</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.25.3</version>
+        <version>3.26.3</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.10.2</version>
+        <version>5.11.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>5.10.0</version>
+        <version>5.14.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.41</version>
+        <version>2.45</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.validator</groupId>
@@ -167,12 +170,12 @@
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-common</artifactId>
-        <version>5.3.0</version>
+        <version>${okapi.version}</version>
       </dependency>
       <dependency>
         <groupId>org.folio.okapi</groupId>
         <artifactId>okapi-testing</artifactId>
-        <version>5.3.0</version>
+        <version>${okapi.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -182,7 +185,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>1.19.6</version>
+        <version>1.20.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -196,7 +199,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.26.0</version>
+        <version>1.27.1</version>
       </dependency>
       <!-- remove org.postgresql:postgresql dependency when testcontainers
            comes with postgresql:postgresql >= 42.7.2 fixing
@@ -205,7 +208,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.2</version>
+        <version>42.7.4</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -217,7 +220,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.12.1</version>
+          <version>3.13.0</version>
           <configuration>
             <release>17</release>
             <compilerArgument>-Xlint:unchecked</compilerArgument>
@@ -234,25 +237,25 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.2.0</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.4.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>3.5.0</version>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.2</version>
+          <version>3.6.0</version>
           <configuration>
             <filters>
               <filter>
@@ -268,7 +271,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.1</version>
           <configuration>
             <useSystemClassLoader>false</useSystemClassLoader>
             <classesDirectory>${project.build.outputDirectory}</classesDirectory>
@@ -293,7 +296,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <id>add-raml-jaxrs-source</id>
@@ -322,7 +325,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.16.2</version>
+        <version>2.17.1</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -352,12 +355,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.5.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.13.0</version>
+            <version>10.18.2</version>
           </dependency>
         </dependencies>
         <executions>
@@ -383,7 +386,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -418,12 +421,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.4.2</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -437,7 +440,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.6.3</version>
+        <version>3.10.1</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>
@@ -451,7 +454,7 @@
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.3</version>
         <executions>
           <execution>
             <id>deploy</id>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -10,6 +10,14 @@
 
   <artifactId>postgres-testing</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -70,7 +78,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>

--- a/raml-module-builder-bom/pom.xml
+++ b/raml-module-builder-bom/pom.xml
@@ -13,6 +13,14 @@
   <packaging>pom</packaging>
   <name>raml-module-builder-bom</name>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -107,12 +115,5 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <licenses>
-    <license>
-      <name>Apache License 2.0</name>
-      <url>http://spdx.org/licenses/Apache-2.0</url>
-    </license>
-  </licenses>
 
 </project>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -10,6 +10,14 @@
 
   <artifactId>testing</artifactId>
 
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>
@@ -24,7 +32,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -10,7 +10,15 @@
 
   <artifactId>util</artifactId>
 
-   <repositories>
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <repositories>
     <repository>
       <id>folio-nexus</id>
       <name>FOLIO Maven repository</name>
@@ -57,7 +65,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>


### PR DESCRIPTION
Upgrade all dependencies to latest (compatible) production version.

Add Apache license header to each sub-module using the content suggested by Apache foundation: https://maven.apache.org/pom.html#Licenses