### PR TITLE
RMB-1012: Don't store JSON properties with empty list or object

### DIFF
--- a/doc/upgrading.md
+++ b/doc/upgrading.md
@@ -26,6 +26,10 @@ See the [NEWS](../NEWS.md) summary of changes for each version.
 * [Version 25](#version-25)
 * [Version 20](#version-20)
 
+## Version 35.4
+
+Serialization no longer produces a property if its value is an empty list `[]` or an empty object `{}`: `{ "mylist": [] }` has become `{}` and `{ "myObj": {} }` has become `{}`. This affects `ObjectMapper` and the JSON written into the database. Deserialization to POJO generates an empty list or an empty object, but rest-assured tests need to switch from `is(empty())` and from `hasSize(0)` to `anyOf(nullValue(), empty())` (or `anyOf(nullValue(), hasSize(0))`).
+
 ## Version 35.3
 
 35.3.\* is the Ramsons (R2 2024) version.

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
@@ -184,25 +184,31 @@ public class GenerateRunner {
         log.info(ramls[j] + " has a .raml suffix but does not start with #%RAML");
       }
     }
-    migrateToJakarta();
+    runPostProcessor();
     log.info("processed: " + numMatches + " raml files");
   }
 
-  private void migrateToJakarta() {
+  private void runPostProcessor() {
     try {
-      Files.walkFileTree(Path.of(outputDirectory), new JakartaMigrator());
+      Files.walkFileTree(Path.of(outputDirectory), new PostProcessor());
     } catch (IOException e) {
       throw new UncheckedException(e);
     }
   }
 
-  private static class JakartaMigrator extends SimpleFileVisitor<Path> {
+  /**
+   * Fix generated files by replacing "import javax.validation." with "import jakarta.validation."
+   * and by replacing "@JsonInclude(JsonInclude.Include.NON_NULL)" with
+   * "@JsonInclude(JsonInclude.Include.NON_EMPTY)".
+   */
+  private static class PostProcessor extends SimpleFileVisitor<Path> {
     @SuppressWarnings("java:S6212")  // suppress 'Declare this local variable with "var" instead.'
                                      // because aspectj AJC doesn't support "var"
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
       String java = new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
-      java = java.replace("import javax.validation.", "import jakarta.validation.");
+      java = java.replace("import javax.validation.", "import jakarta.validation.")
+          .replace("@JsonInclude(JsonInclude.Include.NON_NULL)", "@JsonInclude(JsonInclude.Include.NON_EMPTY)");
       Files.write(file, java.getBytes(StandardCharsets.UTF_8));
       return FileVisitResult.CONTINUE;
     }

--- a/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/GenerateRunnerTest.java
+++ b/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/GenerateRunnerTest.java
@@ -1,11 +1,11 @@
 package org.folio.rest.tools;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -19,7 +19,6 @@ import org.apache.commons.io.FileUtils;
 import org.folio.util.IoUtil;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -81,6 +80,7 @@ public class GenerateRunnerTest {
   private void assertTest() throws IOException {
     assertThat(testSchema(), containsString("\"name\""));
     assertThat(testJava(), allOf(
+        containsString("@JsonInclude(JsonInclude.Include.NON_EMPTY)"),
         containsString("String getName("),
         containsString("setName(String"),
         containsString("withName(String")));
@@ -146,34 +146,34 @@ public class GenerateRunnerTest {
   @Test
   public void testCreateRamlsLookupList() throws Exception {
     List<String> actualRamls = testCreateLookupList(GenerateRunner.RAML_LIST, Collections.singletonList(".raml"));
-    Assert.assertThat(actualRamls, containsInAnyOrder("test.raml"));
+    assertThat(actualRamls, containsInAnyOrder("test.raml"));
   }
 
   @Test
   public void testCreateJsonSchemasLookupList() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"));
-    Assert.assertThat(actualJsonSchemas, containsInAnyOrder("test.schema", "object.json"));
+    assertThat(actualJsonSchemas, containsInAnyOrder("test.schema", "object.json"));
   }
 
   @Test
   public void testCreateJsonSchemasLookupListFromSubfolderNotRecursively() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"),
       Collections.singletonList("test/test2"));
-    Assert.assertThat(actualJsonSchemas, containsInAnyOrder("test/test2/test.schema"));
+    assertThat(actualJsonSchemas, containsInAnyOrder("test/test2/test.schema"));
   }
 
   @Test
   public void testCreateJsonSchemasLookupListFromSubfolderRecursively() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"),
       Collections.singletonList("test/test2/**"));
-    Assert.assertThat(actualJsonSchemas, containsInAnyOrder("test/test2/test.schema", "test/test2/sub/test.schema"));
+    assertThat(actualJsonSchemas, containsInAnyOrder("test/test2/test.schema", "test/test2/sub/test.schema"));
   }
 
   @Test
   public void testCreateJsonSchemasLookupListFromMultipleSubfolders() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"),
       Arrays.asList("test/test1", "test/test2/**"));
-    Assert.assertThat(actualJsonSchemas,
+    assertThat(actualJsonSchemas,
       containsInAnyOrder("test/test2/test.schema", "test/test2/sub/test.schema",
         "test/test1/test1.schema", "test/test1/test2.schema"));
   }
@@ -182,7 +182,7 @@ public class GenerateRunnerTest {
   public void testCreateJsonSchemasLookupListFromCommonSubfolderRecursively() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"),
       Collections.singletonList("test/**"));
-    Assert.assertThat(actualJsonSchemas,
+    assertThat(actualJsonSchemas,
       containsInAnyOrder("test/test2/test.schema", "test/test2/sub/test.schema",
         "test/test1/test1.schema", "test/test1/test2.schema"));
   }
@@ -191,7 +191,7 @@ public class GenerateRunnerTest {
   public void testCreateJsonSchemasLookupListFromSubfolderNonRecursively() throws Exception {
     List<String> actualJsonSchemas = testCreateLookupList(GenerateRunner.JSON_SCHEMA_LIST, Arrays.asList(".json", ".schema"),
       Collections.singletonList("test"));
-    Assert.assertThat(actualJsonSchemas, is(empty()));
+    assertThat(actualJsonSchemas, is(empty()));
   }
 
   private List<String> testCreateLookupList(String filename, List<String> exts) throws IOException {

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/ApiTestBase.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/ApiTestBase.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -110,6 +111,8 @@ public class ApiTestBase {
       statusCode(200).
       body("total_records", lessThan(100)).
     extract().path(arrayName);
+
+    array = Objects.requireNonNullElse(array, List.of());
 
     for (Map<String,String> item : array) {
       given(r).

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/ObjectMapperTest.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/ObjectMapperTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 class ObjectMapperTest {
 
   @Test
+  @SuppressWarnings("java:S125")  // suppress false positive "block of commented-out lines of code should be removed."
   void skipEmptyArrayOnWrite() {
     var bees = new Bees();
     var s = ObjectMapperTool.valueAsString(bees);
@@ -26,6 +27,7 @@ class ObjectMapperTest {
   }
 
   @Test
+  @SuppressWarnings("java:S125")  // suppress false positive "block of commented-out lines of code should be removed."
   void skipEmptyHashOnWrite() {
     var bee = new Bee();
     var s = ObjectMapperTool.valueAsString(bee);

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/ObjectMapperTest.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/ObjectMapperTest.java
@@ -1,0 +1,41 @@
+package org.folio.rest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.folio.dbschema.ObjectMapperTool;
+import org.folio.rest.jaxrs.model.Bee;
+import org.folio.rest.jaxrs.model.Bees;
+import org.junit.jupiter.api.Test;
+
+class ObjectMapperTest {
+
+  @Test
+  void skipEmptyArrayOnWrite() {
+    var bees = new Bees();
+    var s = ObjectMapperTool.valueAsString(bees);
+    assertThat(s, is("{}"));  // no empty array { "bees": [] }
+  }
+
+  @Test
+  void readMissingArray() {
+    var bees = ObjectMapperTool.readValue("{}",  Bees.class);
+    assertThat(bees.getBees(), is(notNullValue()));
+    assertThat(bees.getBees().size(), is(0));
+  }
+
+  @Test
+  void skipEmptyHashOnWrite() {
+    var bee = new Bee();
+    var s = ObjectMapperTool.valueAsString(bee);
+    assertThat(s, is("{}"));  // no empty object { "additionalProperties": {} }
+  }
+
+  @Test
+  void readMissingObject() {
+    var bees = ObjectMapperTool.readValue("{}",  Bee.class);
+    assertThat(bees.getAdditionalProperties(), is(notNullValue()));
+    assertThat(bees.getAdditionalProperties().size(), is(0));
+  }
+}

--- a/domain-models-runtime-it/src/test/java/org/folio/rest/TenantApiTest.java
+++ b/domain-models-runtime-it/src/test/java/org/folio/rest/TenantApiTest.java
@@ -1,8 +1,11 @@
 package org.folio.rest;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.Matchers.hasSize;
 
 import java.util.Random;
 
@@ -38,7 +41,7 @@ public class TenantApiTest extends ApiTestBase {
         get(location + "?wait=5000").
         then().
         statusCode(200).
-        body("messages", hasSize(0));  // JSON list of commands that have failed
+        body("messages", is(anyOf(nullValue(), empty())));  // JSON list of commands that have failed
   }
 
   // https://issues.folio.org/browse/RMB-508 https://issues.folio.org/browse/RMB-511 https://issues.folio.org/browse/MODEVENTC-14
@@ -62,6 +65,6 @@ public class TenantApiTest extends ApiTestBase {
         get(location + "?wait=5000").
         then().
         statusCode(200).
-        body("messages", hasSize(0));  // JSON list of commands that have failed
+        body("messages", is(anyOf(nullValue(), empty())));  // JSON list of commands that have failed
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-1012

When serializing a POJO to JSON skip (suppress) any property that contains an empty list `[]` or an empty object `{}`.

When deserializing JSON to POJO create an empty List or an empty Map if the property is missing in the JSON.

Replaces #1178 