### PR TITLE
RMB-1051: Trillium: Bump dependencies (Vertx 5.0.10, log4j 2.25.4, …)

### DIFF
--- a/domain-models-api-interfaces/pom.xml
+++ b/domain-models-api-interfaces/pom.xml
@@ -150,7 +150,7 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <executions>
           <execution>
             <id>fix-javadoc-in-generated-code</id>

--- a/domain-models-maven-plugin/pom.xml
+++ b/domain-models-maven-plugin/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.15.0</version>
+      <version>3.15.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.9.11</version>
+      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -177,7 +177,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.15.0</version>
+        <version>3.15.2</version>
         <configuration>
           <!-- <goalPrefix>maven-archetype-plugin</goalPrefix> -->
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -421,7 +421,7 @@
 
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.2.0</version>
         <executions>
           <!-- Replace the baseUri in the RAMLs that have been copied to
           apidocs directory so that they can be used via the local html api console. -->
@@ -492,7 +492,7 @@
       <plugin>
         <groupId>io.github.git-commit-id</groupId>
         <artifactId>git-commit-id-maven-plugin</artifactId>
-        <version>9.0.1</version>
+        <version>9.1.0</version>
         <executions>
           <execution>
             <id>get-the-git-infos</id>

--- a/pom.xml
+++ b/pom.xml
@@ -32,12 +32,12 @@
     <project.build.outputTimestamp>2025-10-02T08:45:44Z</project.build.outputTimestamp>
 
     <aspectj.version>1.9.22.1</aspectj.version>
-    <maven.version>3.9.11</maven.version>
-    <vertx.version>5.0.6</vertx.version>
-    <micrometer.version>1.15.5</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <maven.version>3.9.14</maven.version>
+    <vertx.version>5.0.10</vertx.version>
+    <micrometer.version>1.16.3</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
     <awaitility.version>4.3.0</awaitility.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <okapi.version>7.0.1</okapi.version>
+    <okapi.version>7.0.3</okapi.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.25.2</version>
+        <version>2.25.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>5.5.6</version>
+        <version>5.5.7</version>
       </dependency>
       <dependency>
         <groupId>javax.ws.rs</groupId>
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.18.0</version>
+        <version>2.21.0</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -111,7 +111,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.17.0</version>
+        <version>3.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.aspectj</groupId>
@@ -136,31 +136,31 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.27.3</version>
+        <version>3.27.7</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
-        <version>5.20.0</version>
+        <version>5.23.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>
         <artifactId>jersey-media-json-jackson</artifactId>
-        <version>2.46</version>
+        <version>2.48</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator</artifactId>
-        <version>8.0.2.Final</version>
+        <version>9.1.0.Final</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish</groupId>
@@ -180,23 +180,19 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.4</version>
+        <version>4.5.0</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- remove org.postgresql:postgresql dependency when testcontainers
-           comes with postgresql:postgresql >= 42.7.2 fixing
-              https://nvd.nist.gov/vuln/detail/CVE-2024-1597
-      -->
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.5</version>
+        <version>42.7.10</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -208,7 +204,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.14.0</version>
+          <version>3.15.0</version>
           <configuration>
             <release>21</release>
             <compilerArgument>-Xlint:unchecked</compilerArgument>
@@ -219,31 +215,31 @@
         <plugin>
           <groupId>dev.aspectj</groupId>
           <artifactId>aspectj-maven-plugin</artifactId>
-          <version>1.14</version>
+          <version>1.14.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.3</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.2</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.5.2</version>
+          <version>3.5.5</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.6.0</version>
+          <version>3.6.2</version>
           <configuration>
             <filters>
               <filter>
@@ -259,7 +255,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.5.2</version>
+          <version>3.5.5</version>
           <configuration>
             <useSystemClassLoader>false</useSystemClassLoader>
             <classesDirectory>${project.build.outputDirectory}</classesDirectory>
@@ -278,7 +274,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
@@ -313,7 +309,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.18.0</version>
+        <version>2.21.0</version>
         <configuration>
           <generateBackupPoms>false</generateBackupPoms>
         </configuration>
@@ -322,7 +318,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.3.0</version>
         <executions>
           <execution>
             <goals>
@@ -343,12 +339,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.0</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.21.3</version>
+            <version>13.4.0</version>
           </dependency>
         </dependencies>
         <executions>
@@ -374,7 +370,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.3.1</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
@@ -409,12 +405,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.4.2</version>
+        <version>3.5.0</version>
       </plugin>
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -428,7 +424,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/postgres-testing/pom.xml
+++ b/postgres-testing/pom.xml
@@ -59,7 +59,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -32,7 +32,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -65,7 +65,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.5.0</version>
         <executions>
           <execution>
             <id>verify-style</id>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-1051

For Trillium bump all dependencies.

Runtime dependency bumps:

* Vert.x 5.0.6 → 5.0.10
* log4j 2.25.2 → 2.25.4
* micrometer 1.15.5 → 1.16.3
* okapi-common 7.0.1 → 7.0.3
* commons-io 2.18.0 → 2.21.0
* commons-lang 3.17.0 → 3.20.0
* jersey-media-json-jackson 2.46 → 2.48
* hibernate-validator 8.0.2.Final → 9.1.0.Final
* commons-collections4 4.4 → 4.5.0

Also several test and build dependency bumps.