### PR TITLE
RMB-1055: Sunflower: Vertx 4.5.31, Netty 4.1.136.Final, etc.

### DIFF
--- a/domain-models-api-aspects/src/main/resources/log4j2.properties
+++ b/domain-models-api-aspects/src/main/resources/log4j2.properties
@@ -1,8 +1,19 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
+status = error
+name = PropertiesConfig
+packages = org.folio.okapi.common.logging
 
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss:SSS} %-5p %C{1} %X{reqId} %m%n
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/domain-models-api-interfaces/src/main/resources/log4j2.properties
+++ b/domain-models-api-interfaces/src/main/resources/log4j2.properties
@@ -1,8 +1,19 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
+status = error
+name = PropertiesConfig
+packages = org.folio.okapi.common.logging
 
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{dd MMM yyyy HH:mm:ss:SSS} %-5p %C{1} %X{reqId} %m%n
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -85,7 +85,7 @@
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
 
     <aspectj.version>1.9.22.1</aspectj.version>
     <maven.version>3.9.9</maven.version>
-    <vertx.version>4.5.23</vertx.version>
-    <micrometer.version>1.12.13</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <vertx.version>4.5.31</vertx.version>
+    <micrometer.version>1.15.12</micrometer.version> <!-- security fix https://spring.io/security/cve-2026-40984 -->
     <awaitility.version>4.3.0</awaitility.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <okapi.version>6.2.0</okapi.version>
+    <okapi.version>6.2.9</okapi.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->
@@ -65,7 +65,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.24.1</version>
+        <version>2.25.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Vertx 4.5.31, Netty 4.1.136.Final, micrometer 1.15.12, okapi 6.2.9, log4j 2.25.5

https://folio-org.atlassian.net/browse/RMB-1055

Bump Vert.x from 4.5.23 to 4.5.31 to fix multiple security vulnerabilities.

Vert.x 4.5.31 bumps Netty from 4.1.130.Final to 4.1.136.Final: https://github.com/vert-x3/vertx-dependencies/blob/4.5.31/pom.xml#L56 The Netty bump fixes multiple security vulnerabilities.

Bump micrometer from 1.12.13 to 1.15.12 to fix multiple security vulnerabilities.

Bump okapi-common from 6.2.0 to 6.2.9 to be in sync with the Vert.x version.

Bump log4j from 2.24.1 to 2.25.5 to fix multiple security vulnerabilities.

We need to fix invalid log4j2.properties because log4j >= 2.25.0 fails on them:
* https://github.com/apache/logging-log4j2/issues/3836
* https://github.com/apache/logging-log4j2/issues/3088

