### PR TITLE
RMB-1056: Bump deps fixing vulns: Vertx 5.1.5, Jackson 2.21.5, Netty …

### DIFF
--- a/domain-models-runtime/pom.xml
+++ b/domain-models-runtime/pom.xml
@@ -160,6 +160,12 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-pg-client</artifactId>
     </dependency>
+    <!-- remove this scram dependency when vertx ships with scram-client >= 3.3, see CVE-2026-53712 https://github.com/advisories/GHSA-p9jg-fcr6-3mhf -->
+    <dependency>
+      <groupId>com.ongres.scram</groupId>
+      <artifactId>scram-client</artifactId> <!-- https://github.com/eclipse-vertx/vertx-sql-client/blob/5.1/vertx-pg-client/pom.xml#L54 -->
+      <version>3.4</version>
+    </dependency>
 
     <dependency>
       <groupId>javax.ws.rs</groupId>

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
@@ -55,7 +55,7 @@ public class LocalRowDesc implements RowDescriptor {
   @Override
   public int columnIndex(String columnName) {
     if (columnName == null) {
-      throw new NullPointerException("columnName must not be null");
+      throw new IllegalArgumentException("columnName must not be null");
     }
     return columnNames().indexOf(columnName);
   }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowDesc.java
@@ -1,13 +1,13 @@
 package org.folio.rest.persist.helpers;
 
 import io.vertx.sqlclient.desc.ColumnDescriptor;
-
+import io.vertx.sqlclient.desc.RowDescriptor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-public class LocalRowDesc {
+public class LocalRowDesc implements RowDescriptor {
   private final ColumnDescriptor[] columnDescriptors;
   private List<String> columnNames;
   private List<ColumnDescriptor> columnDescriptorsList;
@@ -28,6 +28,7 @@ public class LocalRowDesc {
     return columnDescriptors;
   }
 
+  @Override
   public List<String> columnNames() {
     if (columnNames == null) {
       columnNames = new ArrayList<>(columnDescriptors.length);
@@ -39,10 +40,24 @@ public class LocalRowDesc {
     return columnNames;
   }
 
-  public List<ColumnDescriptor> columnDescriptor() {
+  @Override
+  public List<ColumnDescriptor> columnDescriptors() {
     if (columnDescriptorsList == null) {
       columnDescriptorsList = Collections.unmodifiableList(Arrays.asList(columnDescriptors));
     }
     return columnDescriptorsList;
   }
+
+  public List<ColumnDescriptor> columnDescriptor() {
+    return columnDescriptors();
+  }
+
+  @Override
+  public int columnIndex(String columnName) {
+    if (columnName == null) {
+      throw new NullPointerException("columnName must not be null");
+    }
+    return columnNames().indexOf(columnName);
+  }
+
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/persist/helpers/LocalRowSet.java
@@ -5,6 +5,7 @@ import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.desc.ColumnDescriptor;
+import io.vertx.sqlclient.desc.RowDescriptor;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -37,6 +38,11 @@ public class LocalRowSet implements RowSet<Row> {
   @Override
   public int rowCount() {
     return rowCount;
+  }
+
+  @Override
+  public RowDescriptor rowDescriptor() {
+    return localRowDesc;
   }
 
   @Override
@@ -86,5 +92,4 @@ public class LocalRowSet implements RowSet<Row> {
       return iterator.next();
     }
   }
-
 }

--- a/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient2.java
+++ b/domain-models-runtime/src/main/java/org/folio/rest/tools/client/HttpModuleClient2.java
@@ -135,7 +135,8 @@ public class HttpModuleClient2 implements HttpClientInterface {
       .onComplete(responseHandler);
     } catch (Exception e) {
       Response r = new Response();
-      r.populateError(endpoint, -1, e.getMessage());
+      var msg = e.getMessage() == null ? e.getClass().getName() : e.getMessage();
+      r.populateError(endpoint, -1, msg);
       r.exception = e;
       cf2.complete(r);
     }

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/helpers/LocalRowDescTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/helpers/LocalRowDescTest.java
@@ -26,7 +26,7 @@ class LocalRowDescTest {
   @Test
   void columnIndexNull() {
     var localRowDesc = new LocalRowDesc(List.of("foo", "bar"));
-    assertThrows(NullPointerException.class, () -> localRowDesc.columnIndex(null));
+    assertThrows(IllegalArgumentException.class, () -> localRowDesc.columnIndex(null));
   }
 
   @ParameterizedTest

--- a/domain-models-runtime/src/test/java/org/folio/rest/persist/helpers/LocalRowDescTest.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/persist/helpers/LocalRowDescTest.java
@@ -4,14 +4,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class LocalRowDescTest {
 
   @Test
-  void test() {
+  void constructor() {
     var localRowDesc = new LocalRowDesc(List.of("foo", "bar"));
     assertThat(localRowDesc.columnNames(), contains("foo", "bar"));
     var descriptor1 = localRowDesc.columnDescriptor();
@@ -21,4 +23,22 @@ class LocalRowDescTest {
     assertThat(descriptor2, is(sameInstance(descriptor1)));
   }
 
+  @Test
+  void columnIndexNull() {
+    var localRowDesc = new LocalRowDesc(List.of("foo", "bar"));
+    assertThrows(NullPointerException.class, () -> localRowDesc.columnIndex(null));
+  }
+
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+      baz, 2
+      foo, 0
+      bar, 1
+      """)
+  void columnIndex(String columnName, int index) {
+    var localRowDesc = new LocalRowDesc(List.of("foo", "bar", "baz"));
+    assertThat(localRowDesc.columnIndex(columnName), is(index));
+    // cached columnNames List
+    assertThat(localRowDesc.columnIndex(columnName), is(index));
+  }
 }

--- a/domain-models-runtime/src/test/java/org/folio/rest/tools/client/HttpModuleClient2Test.java
+++ b/domain-models-runtime/src/test/java/org/folio/rest/tools/client/HttpModuleClient2Test.java
@@ -1,6 +1,7 @@
 package org.folio.rest.tools.client;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.core.Future;
@@ -135,7 +136,7 @@ public class HttpModuleClient2Test {
     cf = httpModuleClient2.request("/test2");
     response = cf.get(5, TimeUnit.SECONDS);
 
-    context.assertTrue(response.error.getString("errorMessage").contains("Client is closed"), response.error.getString("errorMessage"));
+    assertThat(response.error.getString("errorMessage"), is("java.lang.IllegalStateException"));
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 
     <aspectj.version>1.9.22.1</aspectj.version>
     <maven.version>3.9.14</maven.version>
-    <vertx.version>5.0.10</vertx.version>
-    <micrometer.version>1.16.3</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <vertx.version>5.1.5</vertx.version>
+    <micrometer.version>1.17.0</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
     <awaitility.version>4.3.0</awaitility.version>
     <hamcrest.version>3.0</hamcrest.version>
     <okapi.version>7.0.3</okapi.version>
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.25.4</version>
+        <version>2.26.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -191,7 +191,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.7.10</version>
+        <version>42.7.13</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-1056

For Trillium update dependencies to fix security vulnerabilities.

Bump Vert.x from 5.0.10 to 5.1.5. The Vert.x bump transitively bumps
* Netty from 4.2.12.Final to 4.2.16.Final
* Jackson from 2.18.6 to 2.21.5

Bump micrometer from 1.16.3 to 1.17.0 to match the version Vert.x ships with.

Bump scram-client from 3.2 to 3.4.

Bump log4j from 2.25.4 to 2.26.1.

Bump postgresql from 42.7.10 to 42.7.13.

For list of fixed security vulnerabilities see
* https://vertx.io/blog/eclipse-vert-x-5-1-5/
* https://github.com/netty/netty/releases#release-netty-4.2.15.Final
* https://github.com/netty/netty/releases#release-netty-4.2.13.Final
* https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.21.5/release-notes/VERSION-2.x
* https://security.snyk.io/package/maven/io.micrometer%3Amicrometer-core/1.16.3
* https://github.com/ongres/scram/releases/tag/3.3
* https://logging.apache.org/security.html#CVE-2026-49844
* https://jdbc.postgresql.org/security/