### PR TITLE
RMB-1057: Bump deps fixing vulns (Vertx 5.1.6, Netty 4.2.17, …)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,11 @@
 
     <aspectj.version>1.9.22.1</aspectj.version>
     <maven.version>3.9.14</maven.version>
-    <vertx.version>5.1.5</vertx.version>
-    <micrometer.version>1.17.0</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L41 -->
+    <vertx.version>5.1.6</vertx.version>
+    <micrometer.version>1.17.0</micrometer.version> <!-- https://github.com/vert-x3/vertx-micrometer-metrics/blob/master/pom.xml#L39 -->
     <awaitility.version>4.3.0</awaitility.version>
     <hamcrest.version>3.0</hamcrest.version>
-    <okapi.version>7.0.3</okapi.version>
+    <okapi.version>7.0.6</okapi.version>
 
     <!-- ramlfiles_path needed to generate interfaces, pojos and api mapping
     path to func, ui of raml -->


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-1057

Bump Vert.x from 5.1.5 to 5.1.6 with several fixes: https://github.com/vert-x3/wiki/wiki/5.1.6-Release-Notes

The Vert.x bump transitively bumps Netty from 4.2.16.Final to 4.2.17.Final fixing multiple security vulnerabilities: https://netty.io/news/2026/08/04/4-2-17-Final.html
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-fccg-mwvh-qqg4) : algorithm inefficiency in io.netty:netty-handler
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-cc6x-ffm5-83wf) : improper NUL byte neutrolization in io.netty:netty-codec-socks
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-c4c3-7fpv-j4q5) : SNI bypass in io.netty:netty-handler
* [CVE-2026-59902](https://github.com/netty/netty/security/advisories/GHSA-2qj4-mmr9-4v2f) : memory exhaustion in io.netty:netty-transport-sctp
* [CVE-2026-59903](https://github.com/netty/netty/security/advisories/GHSA-8c42-7qj2-3j46) : cache poisoning & info disclosure in io.netty:netty-codec-http
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-43fm-7cxg-hf3j) : validation bypass in io.netty:netty-codec-mqtt
* [CVE-2026-XXXXX](https://github.com/netty/netty/security/advisories/GHSA-p85m-gvr3-788c) : improper hostname verification in io.netty:netty-handler

Bump okapi-common from 7.0.3 to 7.0.6 fixing [OKAPI-1247](https://folio-org.atlassian.net/browse/OKAPI-1247): OkapiClient should log errorsClosed