### PR TITLE
RMB-1058 Fix generated resource interfaces using wrong import package when schema defines javaType

### DIFF
--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
@@ -240,7 +240,7 @@ public class GenerateRunner {
       var fixed = DEFAULT_IMPORT_PATTERN.matcher(content).replaceAll(mr -> {
         var simpleName = mr.group(1);
         var actualPkg = classPackageMap.get(simpleName);
-        return (actualPkg != null && !actualPkg.equals(MODEL_PACKAGE_DEFAULT))
+        return (actualPkg != null)
             ? "import " + actualPkg + "." + simpleName + ";"
             : mr.group(0);
       });

--- a/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
+++ b/domain-models-maven-plugin/src/main/java/org/folio/rest/tools/GenerateRunner.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -47,7 +48,10 @@ public class GenerateRunner {
   static final Logger log = Logger.getLogger(GenerateRunner.class.getName());
 
   private static final String MODEL_PACKAGE_DEFAULT = "org.folio.rest.jaxrs.model";
+  private static final Pattern DEFAULT_IMPORT_PATTERN = Pattern.compile(
+      "^import " + Pattern.quote(MODEL_PACKAGE_DEFAULT) + "\\.(\\w+);", Pattern.MULTILINE);
   private static final String SCHEMA_CONFIG_PROPERTY_PREFIX = "jsonschema2pojo.config.";
+  private static final String JAVA_FILE_EXTENSION = ".java";
 
   private String outputDirectory = null;
   private String outputDirectoryWithPackage = null;
@@ -185,7 +189,67 @@ public class GenerateRunner {
       }
     }
     migrateToJakarta();
+    fixModelPackageImports();
     log.info("processed: " + numMatches + " raml files");
+  }
+
+  /**
+   * Fix imports in generated resource interfaces where a JSON schema's "javaType" field
+   * redirected POJO generation to a package other than MODEL_PACKAGE_DEFAULT.
+   * <p>
+   * The jaxrs-code-generator library computes the interface parameter type from the schema
+   * path alone (always resolving to MODEL_PACKAGE_DEFAULT), while jsonschema2pojo internally
+   * respects "javaType" and generates the POJO in the declared package. This leaves the
+   * interfaces with stale imports. We fix them here by scanning all generated model classes
+   * and rewriting any mismatched import in the resource interfaces.
+   */
+  private void fixModelPackageImports() {
+    try {
+      var genDir = Paths.get(outputDirectory);
+      var resourceDir = genDir.resolve(Path.of("org", "folio", "rest", "jaxrs", "resource"));
+      if (!Files.exists(resourceDir)) {
+        return;
+      }
+      var classPackageMap = buildClassPackageMap(genDir, resourceDir);
+      try (Stream<Path> paths = Files.walk(resourceDir)) {
+        paths.filter(p -> p.toString().endsWith(JAVA_FILE_EXTENSION))
+             .forEach(p -> fixImports(p, classPackageMap));
+      }
+    } catch (IOException e) {
+      throw new UncheckedException(e);
+    }
+  }
+
+  private Map<String, String> buildClassPackageMap(Path genDir, Path resourceDir) throws IOException {
+    Map<String, String> map = new HashMap<>();
+    try (Stream<Path> paths = Files.walk(genDir)) {
+      paths.filter(p -> p.toString().endsWith(JAVA_FILE_EXTENSION))
+           .filter(p -> !p.startsWith(resourceDir))
+           .forEach(p -> {
+             String simpleName = p.getFileName().toString().replace(JAVA_FILE_EXTENSION, "");
+             String pkg = genDir.relativize(p.getParent()).toString().replace(File.separatorChar, '.');
+             map.put(simpleName, pkg);
+           });
+    }
+    return map;
+  }
+
+  private void fixImports(Path file, Map<String, String> classPackageMap) {
+    try {
+      var content = Files.readString(file, StandardCharsets.UTF_8);
+      var fixed = DEFAULT_IMPORT_PATTERN.matcher(content).replaceAll(mr -> {
+        var simpleName = mr.group(1);
+        var actualPkg = classPackageMap.get(simpleName);
+        return (actualPkg != null && !actualPkg.equals(MODEL_PACKAGE_DEFAULT))
+            ? "import " + actualPkg + "." + simpleName + ";"
+            : mr.group(0);
+      });
+      if (!fixed.equals(content)) {
+        Files.writeString(file, fixed, StandardCharsets.UTF_8);
+      }
+    } catch (IOException e) {
+      throw new UncheckedException(e);
+    }
   }
 
   private void migrateToJakarta() {

--- a/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/GenerateRunnerTest.java
+++ b/domain-models-maven-plugin/src/test/java/org/folio/rest/tools/GenerateRunnerTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.tools;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -115,6 +116,27 @@ public class GenerateRunnerTest {
     GenerateRunner.main(null);
     assertJobMsgs();
     assertElementAnnotations();
+  }
+
+  /**
+   * A schema with "javaType" pointing to a non-default package must cause the generated
+   * resource interface to import that package, not org.folio.rest.jaxrs.model.
+   *
+   * Regression test for the mismatch between jaxrs-code-generator (which derives the
+   * import from the schema path) and jsonschema2pojo (which respects "javaType" when
+   * writing the POJO), fixed in GenerateRunner.fixModelPackageImports().
+   */
+  @Test
+  public void fixModelPackageImports_usesJavaTypePackageInResourceInterface() throws Exception {
+    String javaTypeResourcesDir = userDir + "/src/test/resources/javatype";
+    System.setProperty("raml_files", javaTypeResourcesDir);
+    System.setProperty("project.basedir", baseDir);
+    FileUtils.copyDirectory(new File(javaTypeResourcesDir), new File(baseDir + "/ramls/"));
+    GenerateRunner.main(null);
+
+    String widgetsResource = IoUtil.toStringUtf8(baseDir + jaxrsDir + "/resource/Widgets.java");
+    assertThat(widgetsResource, containsString("import org.folio.acme.Widget;"));
+    assertThat(widgetsResource, not(containsString("import org.folio.rest.jaxrs.model.Widget;")));
   }
 
   @Test(expected=IOException.class)

--- a/domain-models-maven-plugin/src/test/resources/javatype/widget.json
+++ b/domain-models-maven-plugin/src/test/resources/javatype/widget.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A widget",
+  "javaType": "org.folio.acme.Widget",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/domain-models-maven-plugin/src/test/resources/javatype/widgets.raml
+++ b/domain-models-maven-plugin/src/test/resources/javatype/widgets.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0
+
+title: Widgets API
+baseUri: http://localhost:8081/v1
+version: v1
+
+types:
+  widget: !include widget.json
+
+/widgets:
+  displayName: Widgets
+  post:
+    body:
+      application/json:
+        schema: widget
+    responses:
+      201:
+        description: Created


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RMB-1058

## Purpose
Fix generated resource interfaces using wrong import package when schema defines javaType

## Approach
- Added GenerateRunner.fixModelPackageImports(), called after code generation. It scans all generated POJO files to build a simpleClassName → actualPackage map, then rewrites any stale import org.folio.rest.jaxrs.model.X; in the generated resource interfaces to use the correct package. The approach mirrors the existing migrateToJakarta() post-processing pattern. 
- Added test fixture (widget.json schema with "javaType": "org.folio.acme.Widget" + widgets.raml) and a regression test fixModelPackageImports_usesJavaTypePackageInResourceInterface that verifies the generated Widgets resource interface imports org.folio.acme.Widget and does not import org.folio.rest.jaxrs.model.Widget.